### PR TITLE
Allow to enable debug logging in quiche

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -512,5 +512,11 @@
       <version>${netty.build.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.1.7</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodec.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
@@ -221,7 +222,11 @@ public final class QuicCodec extends ChannelDuplexHandler {
                     LOGGER.debug("quiche_accept failed");
                     return;
                 }
-                channel = new QuicheQuicChannel(this, ctx.channel(), conn, true, packet.sender(), quicChannelHandler);
+
+                String traceId = Quiche.traceId(conn, dcid);
+                channel = new QuicheQuicChannel(this, ctx.channel(), conn, traceId,
+                        true, packet.sender(), quicChannelHandler);
+
                 connections.put(connId, channel);
                 ctx.channel().eventLoop().register(channel);
             }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheLogger.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheLogger.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.util.internal.logging.InternalLogger;
+
+/**
+ * Delegates QUICHE logging to {@link InternalLogger}.
+ */
+final class QuicheLogger {
+    private final InternalLogger logger;
+
+    QuicheLogger(InternalLogger logger) {
+        this.logger = logger;
+    }
+
+    // Called from JNI.
+    void log(String msg) {
+        logger.debug(msg);
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -49,6 +49,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private final ChannelConfig config;
     private final boolean server;
     private final QuicCodec codec;
+
     private final ChannelFutureListener flushListener = new ChannelFutureListener() {
         @Override
         public void operationComplete(ChannelFuture channelFuture) {
@@ -85,9 +86,9 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
     private volatile boolean active = true;
 
-    QuicheQuicChannel(QuicCodec codec, Channel parent, long connAddr, boolean server,
+    QuicheQuicChannel(QuicCodec codec, Channel parent, long connAddr, String traceId, boolean server,
                       InetSocketAddress remote, ChannelHandler handler) {
-        super(parent);
+        super(parent, new QuicheQuicChannelId(traceId));
         this.codec = codec;
         config = new DefaultChannelConfig(this);
         this.server = server;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannelId.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannelId.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.channel.ChannelId;
+
+final class QuicheQuicChannelId implements ChannelId {
+
+    private final String id;
+
+    QuicheQuicChannelId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String asShortText() {
+        return id;
+    }
+
+    @Override
+    public String asLongText() {
+        return id;
+    }
+
+    @Override
+    public int compareTo(ChannelId o) {
+        return id.compareTo(o.asLongText());
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return id.equals(obj);
+    }
+
+    @Override
+    public String toString() {
+        return id;
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<configuration debug="false">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="${logLevel:-debug}">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Motivation:

During development it is often useful to have debug logging enabled

Modifications:

Allow to use quiche_enable_debug_logging(...) and have it delegate to our InternalLogger

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/4