### PR TITLE
Add support for client side

### DIFF
--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -166,12 +166,18 @@ static void netty_quic_quiche_conn_free(JNIEnv* env, jclass clazz, jlong conn) {
 }
 
 static jlong netty_quic_quiche_connect(JNIEnv* env, jclass clazz, jstring server_name, jlong scid, jint scid_len, jlong config) {
-    const char *name = (*env)->GetStringUTFChars(env, server_name, 0);
-    if (name == NULL) {
-        return -1;
+    const char *name = NULL;
+    if (server_name != NULL) {
+        name = (*env)->GetStringUTFChars(env, server_name, 0);
+        if (name == NULL) {
+            return -1;
+        }
     }
+
     quiche_conn *conn = quiche_connect(name, (const uint8_t *) scid, (size_t) scid_len, (quiche_config *) config);
-    (*env)->ReleaseStringUTFChars(env, server_name, name);
+    if (server_name != NULL) {
+        (*env)->ReleaseStringUTFChars(env, server_name, name);
+    }
     if (conn == NULL) {
         return -1;
     }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -16,8 +16,27 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
 
 /**
  * A QUIC channel
  */
-public interface QuicChannel extends Channel { }
+public interface QuicChannel extends Channel {
+
+    /**
+     * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Future} once done.
+     * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
+     * {@link QuicStreamChannel} automatically.
+     */
+    Future<QuicStreamChannel> createStream(QuicStreamAddress address, ChannelHandler handler);
+
+    /**
+     * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Promise} once done.
+     * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
+     * {@link QuicStreamChannel} automatically.
+     */
+    Future<QuicStreamChannel> createStream(QuicStreamAddress address, ChannelHandler handler,
+                                           Promise<QuicStreamChannel> promise);
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelInitializer.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelInitializer.java
@@ -23,21 +23,24 @@ import io.netty.channel.ChannelInitializer;
 
 import java.util.Objects;
 
-public class QuicChannelInitializer extends ChannelInitializer<Channel> {
+/**
+ * {@link ChannelInitializer} for {@link QuicChannel}s.
+ */
+public class QuicChannelInitializer extends ChannelInitializer<QuicChannel> {
 
-    private final ChannelHandler streamHandler;
+    private final ChannelHandler streamChannelHandler;
 
-    public QuicChannelInitializer(ChannelHandler streamHandler) {
-        this.streamHandler = Objects.requireNonNull(streamHandler, "streamHandler");
+    public QuicChannelInitializer(ChannelHandler streamChannelHandler) {
+        this.streamChannelHandler = Objects.requireNonNull(streamChannelHandler, "streamChannelHandler");
     }
 
     @Override
-    protected final void initChannel(Channel channel) {
+    protected final void initChannel(QuicChannel channel) {
         channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) {
                 Channel streamChannel = (Channel) msg;
-                streamChannel.pipeline().addLast(streamHandler);
+                streamChannel.pipeline().addLast(streamChannelHandler);
                 channel.eventLoop().register(streamChannel);
             }
         });

--- a/src/main/java/io/netty/incubator/codec/quic/QuicClientCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicClientCodec.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactory;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.socket.DatagramPacket;
+
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+
+/**
+ * {@link QuicCodec} for QUIC clients.
+ */
+public final class QuicClientCodec extends QuicCodec {
+    private volatile Channel channel;
+
+    QuicClientCodec(long config, int maxTokenLength) {
+        super(config, maxTokenLength);
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) {
+        super.handlerAdded(ctx);
+        channel = ctx.channel();
+    }
+
+    @Override
+    protected boolean quicPacketRead(
+            ChannelHandlerContext ctx, DatagramPacket packet, byte type, int version, ByteBuf scid, ByteBuf dcid,
+            ByteBuf token) {
+        ByteBuffer dcidByteBuffer = dcid.internalNioBuffer(dcid.readerIndex(), dcid.readableBytes());
+        QuicheQuicChannel channel = getChannel(dcidByteBuffer);
+        if (channel != null) {
+            channel.recv(packet.content());
+        }
+        return false;
+    }
+
+    @Override
+    public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress,
+                        SocketAddress localAddress, ChannelPromise promise) {
+        if (remoteAddress instanceof QuicheQuicChannelAddress) {
+            QuicheQuicChannelAddress addr = (QuicheQuicChannelAddress) remoteAddress;
+            QuicheQuicChannel channel = addr.channel;
+            final ByteBuffer key;
+            try {
+                key = channel.connect(config);
+            } catch (Exception e) {
+                promise.setFailure(e);
+                return;
+            }
+            putChannel(key, channel);
+            if (channel.writeEgress()) {
+                ctx.flush();
+            }
+            promise.setSuccess();
+            return;
+        }
+        ctx.connect(remoteAddress, localAddress, promise);
+    }
+
+    ChannelFactory<QuicChannel> newChannelFactory() {
+        return new ChannelFactory<QuicChannel>() {
+            @Override
+            public QuicChannel newChannel() {
+                return QuicheQuicChannel.forClient(channel);
+            }
+        };
+    }
+
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicConnectionIdAddress.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicConnectionIdAddress.java
@@ -15,43 +15,25 @@
  */
 package io.netty.incubator.codec.quic;
 
-import io.netty.channel.ChannelId;
+import java.net.SocketAddress;
+import java.security.SecureRandom;
 
-final class QuicheQuicChannelId implements ChannelId {
+public final class QuicConnectionIdAddress extends SocketAddress {
+    private static final SecureRandom random = new SecureRandom();
 
-    private final String id;
+    final byte[] connId;
 
-    QuicheQuicChannelId(String id) {
-        this.id = id;
+    private QuicConnectionIdAddress(byte[] connId) {
+        this.connId = connId.clone();
     }
 
-    @Override
-    public String asShortText() {
-        return id;
+    public static QuicConnectionIdAddress random() {
+        byte[] bytes = new byte[Quiche.QUICHE_MAX_CONN_ID_LEN];
+        random.nextBytes(bytes);
+        return new QuicConnectionIdAddress(bytes);
     }
 
-    @Override
-    public String asLongText() {
-        return id;
-    }
-
-    @Override
-    public int compareTo(ChannelId o) {
-        return id.compareTo(o.asLongText());
-    }
-
-    @Override
-    public int hashCode() {
-        return id.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return id.equals(obj);
-    }
-
-    @Override
-    public String toString() {
-        return id;
+    public static QuicConnectionIdAddress fromBytes(byte[] bytes) {
+        return new QuicConnectionIdAddress(bytes.clone());
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicServerCodec.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.util.CharsetUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+
+import java.nio.ByteBuffer;
+
+/**
+ * {@link QuicCodec} for QUIC servers.
+ */
+public final class QuicServerCodec extends QuicCodec {
+    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(QuicServerCodec.class);
+
+    private final ChannelHandler quicChannelHandler;
+    private final QuicConnectionIdSigner connectionSigner;
+    private final QuicTokenHandler tokenHandler;
+    private ByteBuf mintTokenBuffer;
+    private ByteBuf connIdBuffer;
+
+    QuicServerCodec(long config, QuicTokenHandler tokenHandler,
+                    QuicConnectionIdSigner connectionSigner, ChannelHandler quicChannelHandler) {
+        super(config, tokenHandler.maxTokenLength());
+        this.tokenHandler = tokenHandler;
+        this.connectionSigner = connectionSigner;
+        this.quicChannelHandler = quicChannelHandler;
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) {
+        super.handlerAdded(ctx);
+        connIdBuffer = allocateNativeOrder(Quiche.QUICHE_MAX_CONN_ID_LEN);
+        mintTokenBuffer = allocateNativeOrder(tokenHandler.maxTokenLength());
+    }
+
+    @Override
+    protected boolean quicPacketRead(ChannelHandlerContext ctx, DatagramPacket packet, byte type, int version,
+                                     ByteBuf scid, ByteBuf dcid, ByteBuf token) throws Exception {
+        ByteBuffer dcidByteBuffer = dcid.internalNioBuffer(dcid.readerIndex(), dcid.readableBytes());
+
+        QuicheQuicChannel channel = getChannel(dcidByteBuffer);
+        if (channel == null) {
+            final ByteBuffer connId = ByteBuffer.wrap(connectionSigner.sign(dcid));
+
+            channel = getChannel(connId);
+            if (channel == null) {
+                return handleServer(ctx, packet, connId, type, version, scid, dcid, token);
+            }
+        }
+
+        channel.recv(packet.content());
+        return false;
+    }
+
+    private boolean handleServer(ChannelHandlerContext ctx, DatagramPacket packet, ByteBuffer connId,
+                                           byte type, int version, ByteBuf scid, ByteBuf dcid, ByteBuf token)
+            throws Exception {
+        if (!Quiche.quiche_version_is_supported(version)) {
+            // Version is not supported, try to negotiate it.
+            ByteBuf out = ctx.alloc().directBuffer(Quic.MAX_DATAGRAM_SIZE);
+            int outWriterIndex = out.writerIndex();
+
+            int res = Quiche.quiche_negotiate_version(
+                    scid.memoryAddress() + scid.readerIndex(), scid.readableBytes(),
+                    dcid.memoryAddress() + dcid.readerIndex(), dcid.readableBytes(),
+                    out.memoryAddress() + outWriterIndex, out.writableBytes());
+            if (res < 0) {
+                out.release();
+                Quiche.throwIfError(res);
+                return false;
+            }
+
+            ctx.write(new DatagramPacket(out.writerIndex(outWriterIndex + res), packet.sender()));
+            return true;
+        }
+
+        if (!token.isReadable()) {
+            // Clear buffers so we can reuse these.
+            mintTokenBuffer.clear();
+            connIdBuffer.clear();
+
+            // The remote peer did not send a token.
+            tokenHandler.writeToken(mintTokenBuffer, dcid, packet.sender());
+
+            connIdBuffer.writeBytes(connId);
+
+            ByteBuf out = ctx.alloc().directBuffer(Quic.MAX_DATAGRAM_SIZE);
+            int outWriterIndex = out.writerIndex();
+            int written = Quiche.quiche_retry(scid.memoryAddress() + scid.readerIndex(), scid.readableBytes(),
+                    dcid.memoryAddress() + dcid.readerIndex(), dcid.readableBytes(),
+                    connIdBuffer.memoryAddress() + connIdBuffer.readerIndex(), connIdBuffer.readableBytes(),
+                    mintTokenBuffer.memoryAddress() + mintTokenBuffer.readerIndex(),
+                    mintTokenBuffer.readableBytes(),
+                    version, out.memoryAddress() + outWriterIndex, out.writableBytes());
+
+            if (written < 0) {
+                out.release();
+                Quiche.throwIfError(written);
+            } else {
+                ctx.write(new DatagramPacket(out.writerIndex(outWriterIndex + written),
+                        packet.sender()));
+                return true;
+            }
+            return false;
+        }
+        int offset = tokenHandler.validateToken(token, packet.sender());
+        if (offset == -1) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("invalid token: {}", token.toString(CharsetUtil.US_ASCII));
+            }
+            return false;
+        }
+
+        if (connId.limit() != dcid.readableBytes()) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("invalid destination connection id: {}",
+                        dcid.toString(CharsetUtil.US_ASCII));
+            }
+            return false;
+        }
+
+        long conn = Quiche.quiche_accept(dcid.memoryAddress() + dcid.readerIndex(), dcid.readableBytes(),
+                token.memoryAddress() + offset, token.readableBytes() - offset, config);
+        if (conn < 0) {
+            LOGGER.debug("quiche_accept failed");
+            return false;
+        }
+
+        QuicheQuicChannel channel = QuicheQuicChannel.forServer(
+                ctx.channel(), conn, Quiche.traceId(conn, dcid), packet.sender());
+        channel.pipeline().addLast(quicChannelHandler);
+
+        putChannel(connId, channel);
+        ctx.channel().eventLoop().register(channel);
+        channel.recv(packet.content());
+        return false;
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
@@ -15,6 +15,7 @@
  */
 package io.netty.incubator.codec.quic;
 
+import io.netty.channel.Channel;
 import io.netty.channel.socket.DuplexChannel;
 
 /**
@@ -37,4 +38,7 @@ public interface QuicStreamChannel extends DuplexChannel {
      * The id of the stream.
      */
     long streamId();
+
+    @Override
+    QuicChannel parent();
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannelAddress.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannelAddress.java
@@ -17,7 +17,14 @@ package io.netty.incubator.codec.quic;
 
 import java.net.SocketAddress;
 
-// TODO: Implement me
-public final class QuicAddress extends SocketAddress {
+/**
+ * Just a container to pass the {@link QuicheQuicChannel} to {@link QuicServerCodec}.
+ */
+final class QuicheQuicChannelAddress extends SocketAddress {
 
+    final QuicheQuicChannel channel;
+
+    QuicheQuicChannelAddress(QuicheQuicChannel channel) {
+        this.channel = channel;
+    }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -94,7 +94,12 @@ final class QuicheQuicStreamChannel extends AbstractChannel implements QuicStrea
         return (QuicheQuicChannel) parent();
     }
 
-    public void shutdownInput0(ChannelPromise channelPromise) {
+    @Override
+    public QuicChannel parent() {
+        return (QuicChannel) super.parent();
+    }
+
+    private void shutdownInput0(ChannelPromise channelPromise) {
         inputShutdown = true;
         parentQuicChannel().shutdownRead(streamId, channelPromise);
     }
@@ -256,9 +261,7 @@ final class QuicheQuicStreamChannel extends AbstractChannel implements QuicStrea
     private final class QuicStreamChannelUnsafe extends AbstractUnsafe {
         @Override
         public void connect(SocketAddress socketAddress, SocketAddress socketAddress1, ChannelPromise channelPromise) {
-            // TODO: Should we delegate this to the parent and so allow easier creation of streams from within
-            //       streams ?
-            channelPromise.setFailure(new UnsupportedOperationException("Not supported by streams"));
+            channelPromise.setFailure(new UnsupportedOperationException());
         }
 
         @Override


### PR DESCRIPTION
Motivation:

We need to support client and server side QUIC.

Modifications:

- Split QuicCodec to QuicServerCodec and QuicClientCodec
- Remove QuicChannelId
- Make QuicheQuicChannel usable for client side as well
- Add example for client side
- Add createStream(...) methods to QuicChannel

Result:

After your change, what will change.