### PR TITLE
Correctly handle scheduling of timeouts and calling of quiche_conn_se…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicClientCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicClientCodec.java
@@ -69,7 +69,7 @@ public final class QuicClientCodec extends QuicCodec {
                 return;
             }
             putChannel(key, channel);
-            if (channel.writeEgress()) {
+            if (channel.writable()) {
                 ctx.flush();
             }
             promise.setSuccess();

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodec.java
@@ -166,7 +166,7 @@ public abstract class QuicCodec extends ChannelDuplexHandler {
         while (entries.hasNext()) {
             QuicheQuicChannel channel = entries.next().getValue();
             // TODO: Be a bit smarter about this.
-            writeDone |= channel.handleChannelReadComplete();
+            writeDone |= channel.channelReadComplete();
 
             removeIfClosed(entries, channel);
         }
@@ -193,7 +193,7 @@ public abstract class QuicCodec extends ChannelDuplexHandler {
             while (entries.hasNext()) {
                 QuicheQuicChannel channel = entries.next().getValue();
                 // TODO: Be a bit smarter about this.
-                writeDone |= channel.flushStreams();
+                writeDone |= channel.writable();
                 removeIfClosed(entries, channel);
             }
             if (writeDone) {


### PR DESCRIPTION
…nd(...)

Motivation:

We need to carefully handle the scheduling of timeouts and calling of quiche_conn_send to follow the pattern outlined by quiche:

* https://docs.rs/quiche/0.6.0/quiche/struct.Connection.html#method.send
* https://docs.rs/quiche/0.6.0/quiche/#generating-outgoing-packets

Modifications:

- Rename methods to make it easier to understand the code
- Schedule timeouts at the correct time
- Call quiche_conn_send on the correct time
- Add some comments to make it easier to understand the code and the state-machine.

Result:

Correctly use quiche API