### PR TITLE
API for collecting and showing the statistics on the connection

### DIFF
--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -238,8 +238,7 @@ static jboolean netty_quic_quiche_conn_is_closed(JNIEnv* env, jclass clazz, jlon
 }
 
 static jlongArray netty_quic_quiche_conn_stats(JNIEnv* env, jclass clazz, jlong conn) {
-    quiche_stats stats;
-    memset(&stats, 0, sizeof(stats));
+    quiche_stats stats = {0,0,0,0,0,0};
     quiche_conn_stats((quiche_conn *) conn, &stats);
 
     jlongArray statsArray = (*env)->NewLongArray(env, 6);

--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -237,6 +237,26 @@ static jboolean netty_quic_quiche_conn_is_closed(JNIEnv* env, jclass clazz, jlon
     return quiche_conn_is_closed((quiche_conn *) conn) == true ? JNI_TRUE : JNI_FALSE;
 }
 
+static jlongArray netty_quic_quiche_conn_stats(JNIEnv* env, jclass clazz, jlong conn) {
+    quiche_stats stats;
+    quiche_conn_stats((quiche_conn *) conn, &stats);
+    jlongArray statsArray = (*env)->NewLongArray(env, 6);
+    if (statsArray == NULL) {
+        // This will put an OOME on the stack
+        return NULL;
+    }
+    jlong statsArrayElements[] = {
+        (jlong)stats.recv,
+        (jlong)stats.sent,
+        (jlong)stats.lost,
+        (jlong)stats.rtt,
+        (jlong)stats.cwnd,
+        (jlong)stats.delivery_rate,
+    };
+    (*env)->SetLongArrayRegion(env, statsArray, 0, 6, statsArrayElements);
+    return statsArray;
+}
+
 static jlong netty_quic_quiche_conn_timeout_as_nanos(JNIEnv* env, jclass clazz, jlong conn) {
     return quiche_conn_timeout_as_nanos((quiche_conn *) conn);
 }
@@ -451,6 +471,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_is_established", "(J)Z", (void *) netty_quic_quiche_conn_is_established },
   { "quiche_conn_is_in_early_data", "(J)Z", (void *) netty_quic_quiche_conn_is_in_early_data },
   { "quiche_conn_is_closed", "(J)Z", (void *) netty_quic_quiche_conn_is_closed },
+  { "quiche_conn_stats", "(J)[J", (void *) netty_quic_quiche_conn_stats },
   { "quiche_conn_timeout_as_nanos", "(J)J", (void *) netty_quic_quiche_conn_timeout_as_nanos },
   { "quiche_conn_timeout_as_millis", "(J)J", (void *) netty_quic_quiche_conn_timeout_as_millis },
   { "quiche_conn_on_timeout", "(J)V", (void *) netty_quic_quiche_conn_on_timeout },

--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -239,7 +239,9 @@ static jboolean netty_quic_quiche_conn_is_closed(JNIEnv* env, jclass clazz, jlon
 
 static jlongArray netty_quic_quiche_conn_stats(JNIEnv* env, jclass clazz, jlong conn) {
     quiche_stats stats;
+    memset(&stats, 0, sizeof(stats));
     quiche_conn_stats((quiche_conn *) conn, &stats);
+
     jlongArray statsArray = (*env)->NewLongArray(env, 6);
     if (statsArray == NULL) {
         // This will put an OOME on the stack

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -29,45 +29,57 @@ import io.netty.util.concurrent.Promise;
 public interface QuicChannel extends Channel {
 
     /**
-     * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Future} once done.
-     * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
+     * Creates a stream that is using this {@link QuicChannel} and notifies the
+     * {@link Future} once done. The {@link ChannelHandler} (if not {@code null}) is
+     * added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} automatically.
      */
     Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler);
 
     /**
-     * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Promise} once done.
-     * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
+     * Creates a stream that is using this {@link QuicChannel} and notifies the
+     * {@link Promise} once done. The {@link ChannelHandler} (if not {@code null})
+     * is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} automatically.
      */
     Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler,
-                                           Promise<QuicStreamChannel> promise);
+            Promise<QuicStreamChannel> promise);
 
     /**
-     * Returns the negotiated ALPN protocol or {@code null} if non has been negotiated.
+     * Returns the negotiated ALPN protocol or {@code null} if non has been
+     * negotiated.
      */
     byte[] applicationProtocol();
 
     /**
      * Close the {@link QuicChannel}
      *
-     * @param applicationClose  {@code true} if an application close should be used,
-     *                          {@code false} if a normal close should be used.
-     * @param error             the application error number, or {@code 0} if no special error should be signaled.
-     * @param reason            the reason for the closure (which may be an empty {@link ByteBuf}.
-     * @return                  the future that is notified.
+     * @param applicationClose {@code true} if an application close should be used,
+     *                         {@code false} if a normal close should be used.
+     * @param error            the application error number, or {@code 0} if no
+     *                         special error should be signaled.
+     * @param reason           the reason for the closure (which may be an empty
+     *                         {@link ByteBuf}.
+     * @return the future that is notified.
      */
     ChannelFuture close(boolean applicationClose, int error, ByteBuf reason);
 
     /**
      * Close the {@link QuicChannel}
      *
-     * @param applicationClose  {@code true} if an application close should be used,
-     *                          {@code false} if a normal close should be used.
-     * @param error             the application error number, or {@code 0} if no special error should be signaled.
-     * @param reason            the reason for the closure (which may be an empty {@link ByteBuf}.
-     * @param promise           the {@link ChannelPromise} that will be notified.
-     * @return                  the future that is notified.
+     * @param applicationClose {@code true} if an application close should be used,
+     *                         {@code false} if a normal close should be used.
+     * @param error            the application error number, or {@code 0} if no
+     *                         special error should be signaled.
+     * @param reason           the reason for the closure (which may be an empty
+     *                         {@link ByteBuf}.
+     * @param promise          the {@link ChannelPromise} that will be notified.
+     * @return the future that is notified.
      */
     ChannelFuture close(boolean applicationClose, int error, ByteBuf reason, ChannelPromise promise);
+
+    /**
+     * Collects and returns statistics about the connection.
+     */
+    QuicConnectionStats stats();
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -72,7 +72,12 @@ public interface QuicChannel extends Channel {
     ChannelFuture close(boolean applicationClose, int error, ByteBuf reason, ChannelPromise promise);
 
     /**
-     * Collects and returns statistics about the connection.
+     * Collects statistics about the connection and notifies the {@link Future} once done.
      */
-    QuicConnectionStats stats();
+    Future<QuicConnectionStats> collectStats();
+
+    /**
+     * Collects statistics about the connection and notifies the {@link Promise} once done.
+     */
+    Future<QuicConnectionStats> collectStats(Promise<QuicConnectionStats> promise);
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -15,8 +15,11 @@
  */
 package io.netty.incubator.codec.quic;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
@@ -44,6 +47,29 @@ public interface QuicChannel extends Channel {
      * Returns the negotiated ALPN protocol or {@code null} if non has been negotiated.
      */
     byte[] applicationProtocol();
+
+    /**
+     * Close the {@link QuicChannel}
+     *
+     * @param applicationClose  {@code true} if an application close should be used,
+     *                          {@code false} if a normal close should be used.
+     * @param error             the application error number, or {@code 0} if no special error should be signaled.
+     * @param reason            the reason for the closure (which may be an empty {@link ByteBuf}.
+     * @return                  the future that is notified.
+     */
+    ChannelFuture close(boolean applicationClose, int error, ByteBuf reason);
+
+    /**
+     * Close the {@link QuicChannel}
+     *
+     * @param applicationClose  {@code true} if an application close should be used,
+     *                          {@code false} if a normal close should be used.
+     * @param error             the application error number, or {@code 0} if no special error should be signaled.
+     * @param reason            the reason for the closure (which may be an empty {@link ByteBuf}.
+     * @param promise           the {@link ChannelPromise} that will be notified.
+     * @return                  the future that is notified.
+     */
+    ChannelFuture close(boolean applicationClose, int error, ByteBuf reason, ChannelPromise promise);
 
     /**
      * Collects and returns statistics about the connection.

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -15,11 +15,8 @@
  */
 package io.netty.incubator.codec.quic;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
@@ -29,54 +26,24 @@ import io.netty.util.concurrent.Promise;
 public interface QuicChannel extends Channel {
 
     /**
-     * Creates a stream that is using this {@link QuicChannel} and notifies the
-     * {@link Future} once done. The {@link ChannelHandler} (if not {@code null}) is
-     * added to the {@link io.netty.channel.ChannelPipeline} of the
+     * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Future} once done.
+     * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} automatically.
      */
     Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler);
 
     /**
-     * Creates a stream that is using this {@link QuicChannel} and notifies the
-     * {@link Promise} once done. The {@link ChannelHandler} (if not {@code null})
-     * is added to the {@link io.netty.channel.ChannelPipeline} of the
+     * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Promise} once done.
+     * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} automatically.
      */
     Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler,
-            Promise<QuicStreamChannel> promise);
+                                           Promise<QuicStreamChannel> promise);
 
     /**
-     * Returns the negotiated ALPN protocol or {@code null} if non has been
-     * negotiated.
+     * Returns the negotiated ALPN protocol or {@code null} if non has been negotiated.
      */
     byte[] applicationProtocol();
-
-    /**
-     * Close the {@link QuicChannel}
-     *
-     * @param applicationClose {@code true} if an application close should be used,
-     *                         {@code false} if a normal close should be used.
-     * @param error            the application error number, or {@code 0} if no
-     *                         special error should be signaled.
-     * @param reason           the reason for the closure (which may be an empty
-     *                         {@link ByteBuf}.
-     * @return the future that is notified.
-     */
-    ChannelFuture close(boolean applicationClose, int error, ByteBuf reason);
-
-    /**
-     * Close the {@link QuicChannel}
-     *
-     * @param applicationClose {@code true} if an application close should be used,
-     *                         {@code false} if a normal close should be used.
-     * @param error            the application error number, or {@code 0} if no
-     *                         special error should be signaled.
-     * @param reason           the reason for the closure (which may be an empty
-     *                         {@link ByteBuf}.
-     * @param promise          the {@link ChannelPromise} that will be notified.
-     * @return the future that is notified.
-     */
-    ChannelFuture close(boolean applicationClose, int error, ByteBuf reason, ChannelPromise promise);
 
     /**
      * Collects and returns statistics about the connection.

--- a/src/main/java/io/netty/incubator/codec/quic/QuicConnectionStats.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicConnectionStats.java
@@ -35,9 +35,9 @@ public interface QuicConnectionStats {
     long lost();
 
     /**
-     * @return The estimated round-trip time of the connection in milliseconds.
+     * @return The estimated round-trip time of the connection in nanoseconds.
      */
-    long rttMillis();
+    long rttNanos();
 
     /**
      * @return The size of the connection's congestion window in bytes.

--- a/src/main/java/io/netty/incubator/codec/quic/QuicConnectionStats.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicConnectionStats.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+/**
+ * Statistics about the connection.
+ */
+public interface QuicConnectionStats {
+    /**
+     * @return The number of QUIC packets received on the connection.
+     */
+    long recv();
+
+    /**
+     * @return The number of QUIC packets sent on this connection.
+     */
+    long sent();
+
+    /**
+     * @return The number of QUIC packets that were lost.
+     */
+    long lost();
+
+    /**
+     * @return The estimated round-trip time of the connection in milliseconds.
+     */
+    long rttMillis();
+
+    /**
+     * @return The size of the connection's congestion window in bytes.
+     */
+    long congestionWindow();
+
+    /**
+     * @return The estimated data delivery rate in bytes/s.
+     */
+    long deliveryRate();
+}

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -293,6 +293,15 @@ final class Quiche {
 
     /**
      * See
+     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L361">quiche_conn_stats</a>.
+     * The implementation relies on all fields of
+     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L340">quiche_stats</a> being numerical.
+     * The assumption made allows passing primitive array rather than dealing with objects.
+     */
+    static native long[] quiche_conn_stats(long connAddr);
+
+    /**
+     * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L288">quiche_conn_timeout_as_nanos</a>.
      */
     static native long quiche_conn_timeout_as_nanos(long connAddr);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -63,6 +63,23 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         OK
     }
 
+    private static final class CloseData implements ChannelFutureListener {
+        final boolean applicationClose;
+        final int err;
+        final ByteBuf reason;
+
+        CloseData(boolean applicationClose, int err, ByteBuf reason) {
+            this.applicationClose = applicationClose;
+            this.err = err;
+            this.reason = reason;
+        }
+
+        @Override
+        public void operationComplete(ChannelFuture future) {
+            reason.release();
+        }
+    }
+
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
     private final long[] readableStreams = new long[1024];
     private final long[] writableStreams = new long[1024];
@@ -71,7 +88,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private final ChannelConfig config;
     private final boolean server;
     private final QuicStreamIdGenerator idGenerator;
-    private final InetSocketAddress remote;
 
     private final ChannelFutureListener timeoutScheduleListener = new ChannelFutureListener() {
         @Override
@@ -121,15 +137,16 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private boolean connectionSendNeeded;
     private ByteBuf finBuffer;
     private ChannelPromise connectPromise;
-    private byte[] connectId;
+    private ByteBuffer connectId;
     private ByteBuffer key;
+    private CloseData closeData;
 
     private static final int CLOSED = 0;
     private static final int OPEN = 1;
     private static final int ACTIVE = 2;
     private volatile int state;
     private volatile String traceId;
-
+    private volatile InetSocketAddress remote;
     private QuicheQuicChannel(Channel parent, boolean server, ByteBuffer key, long connAddr, String traceId,
                       InetSocketAddress remote) {
         super(parent);
@@ -161,7 +178,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         assert this.connAddr == -1;
         assert this.traceId == null;
         assert this.key == null;
-        ByteBuf idBuffer = alloc().directBuffer(connectId.length).writeBytes(connectId);
+        ByteBuf idBuffer = alloc().directBuffer(connectId.remaining()).writeBytes(connectId.duplicate());
         try {
             long connection = Quiche.quiche_connect(null, idBuffer.memoryAddress() + idBuffer.readerIndex(),
                     idBuffer.readableBytes(), configAddr);
@@ -178,7 +195,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             this.connAddr = connection;
 
             connectionSendNeeded = true;
-            key = ByteBuffer.wrap(connectId);
+            key = connectId;
         } finally {
             idBuffer.release();
         }
@@ -260,6 +277,43 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     @Override
+    public ChannelFuture close(boolean applicationClose, int error, ByteBuf reason) {
+        return close(applicationClose, error, reason, newPromise());
+    }
+
+    @Override
+    public ChannelFuture close(boolean applicationClose, int error, ByteBuf reason, ChannelPromise promise) {
+        if (eventLoop().inEventLoop()) {
+            close0(applicationClose, error, reason, promise);
+        } else {
+            eventLoop().execute(new Runnable() {
+                @Override
+                public void run() {
+                    close0(applicationClose, error, reason, promise);
+                }
+            });
+        }
+        return promise;
+    }
+
+    private void close0(boolean applicationClose, int error, ByteBuf reason, ChannelPromise promise) {
+        if (closeData == null) {
+            if (!reason.hasMemoryAddress()) {
+                // Copy to direct buffer as that's what we need.
+                ByteBuf copy = alloc().directBuffer(reason.readableBytes()).writeBytes(reason);
+                reason.release();
+                reason = copy;
+            }
+            closeData = new CloseData(applicationClose, error, reason);
+            promise.addListener(closeData);
+        } else {
+            // We already have a close scheduled that uses a close data. Lets release the buffer early.
+            reason.release();
+        }
+        close(promise);
+    }
+
+    @Override
     public String toString() {
         String traceId = this.traceId;
         if (traceId == null) {
@@ -302,8 +356,22 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     @Override
     protected void doClose() throws Exception {
         state = CLOSED;
-        Quiche.throwIfError(Quiche.quiche_conn_close(connectionAddressChecked(), false, 0,
-                Unpooled.EMPTY_BUFFER.memoryAddress(), 0));
+
+        final boolean app;
+        final int err;
+        final ByteBuf reason;
+        if (closeData == null) {
+            app = false;
+            err = 0;
+            reason = Unpooled.EMPTY_BUFFER;
+        } else {
+            app = closeData.applicationClose;
+            err = closeData.err;
+            reason = closeData.reason;
+            closeData = null;
+        }
+        Quiche.throwIfError(Quiche.quiche_conn_close(connectionAddressChecked(), app, err,
+                reason.memoryAddress() + reason.readerIndex(), reason.readableBytes()));
     }
 
     @Override
@@ -671,16 +739,19 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 return;
             }
 
-            if (remote instanceof QuicConnectionIdAddress) {
+            if (remote instanceof QuicConnectionAddress) {
                 if (key != null) {
                     // If a key is assigned we know this channel was already connected.
                     channelPromise.setFailure(new AlreadyConnectedException());
                     return;
                 }
 
+                QuicConnectionAddress address = (QuicConnectionAddress) remote;
                 connectPromise = channelPromise;
-                connectId = ((QuicConnectionIdAddress) remote).connId;
-
+                connectId = address.connId.duplicate();
+                if (address.remote != null) {
+                    QuicheQuicChannel.this.remote = address.remote;
+                }
                 parent().connect(new QuicheQuicChannelAddress(QuicheQuicChannel.this));
                 return;
             }
@@ -805,7 +876,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     /**
-     * Just a container to pass the {@link QuicheQuicChannel} to {@link QuicClientCodec}.
+     * Just a container to pass the {@link QuicheQuicChannel} to {@link QuicheQuicClientCodec}.
      */
     private static final class QuicheQuicChannelAddress extends SocketAddress {
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -920,7 +920,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
         final long[] stats = Quiche.quiche_conn_stats(connAddr);
         if (stats == null) {
-            promise.setFailure(new RuntimeException("native quiche_conn_stats(...) failed"));
+            promise.setFailure(new IllegalStateException("native quiche_conn_stats(...) failed"));
             return null;
         }
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -140,6 +140,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private ByteBuffer connectId;
     private ByteBuffer key;
     private CloseData closeData;
+    private QuicConnectionStats statsAtClose;
 
     private static final int CLOSED = 0;
     private static final int OPEN = 1;
@@ -147,6 +148,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private volatile int state;
     private volatile String traceId;
     private volatile InetSocketAddress remote;
+
     private QuicheQuicChannel(Channel parent, boolean server, ByteBuffer key, long connAddr, String traceId,
                       InetSocketAddress remote) {
         super(parent);
@@ -223,6 +225,9 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
     void forceClose() {
         unsafe().close(voidPromise());
+        // making sure that connection statistics is avaliable
+        // even after channel is closed
+        statsAtClose = collectStats0(eventLoop().newPromise());
         Quiche.quiche_conn_free(connAddr);
         connAddr = -1;
         state = CLOSED;
@@ -888,7 +893,40 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     @Override
-    public QuicheQuicConnectionStats stats() {
-        return new QuicheQuicConnectionStats();
+    public Future<QuicConnectionStats> collectStats() {
+        return collectStats(eventLoop().newPromise());
+    }
+
+    @Override
+    public Future<QuicConnectionStats> collectStats(Promise<QuicConnectionStats> promise) {
+        if (eventLoop().inEventLoop()) {
+            collectStats0(promise);
+        } else {
+            eventLoop().execute(new Runnable() {
+                @Override
+                public void run() {
+                    collectStats0(promise);
+                }
+            });
+        }
+        return promise;
+    }
+
+    private QuicConnectionStats collectStats0(Promise<QuicConnectionStats> promise) {
+        if (isConnDestroyed()) {
+            promise.setSuccess(statsAtClose);
+            return statsAtClose;
+        }
+
+        final long[] stats = Quiche.quiche_conn_stats(connAddr);
+        if (stats == null) {
+            promise.setFailure(new RuntimeException("native quiche_conn_stats(...) failed"));
+            return null;
+        }
+
+        final QuicheQuicConnectionStats connStats =
+            new QuicheQuicConnectionStats(stats[0], stats[1], stats[2], stats[3], stats[4], stats[5]);
+        promise.setSuccess(connStats);
+        return connStats;
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnectionStats.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnectionStats.java
@@ -15,36 +15,71 @@
  */
 package io.netty.incubator.codec.quic;
 
+import io.netty.util.internal.StringUtil;
+
 public class QuicheQuicConnectionStats implements QuicConnectionStats {
+
+    private final long recv;
+    private final long sent;
+    private final long lost;
+    private final long rttNanos;
+    private final long congestionWindow;
+    private final long deliveryRate;
+
+    protected QuicheQuicConnectionStats(long recv, long sent, long lost, long rttNanos, long cwnd, long deliveryRate) {
+        this.recv = recv;
+        this.sent = sent;
+        this.lost = lost;
+        this.rttNanos = rttNanos;
+        this.congestionWindow = cwnd;
+        this.deliveryRate = deliveryRate;
+    }
 
     @Override
     public long recv() {
-        return 0;
+        return this.recv;
     }
 
     @Override
     public long sent() {
-        return 0;
+        return this.sent;
     }
 
     @Override
     public long lost() {
-        return 0;
+        return this.lost;
     }
 
     @Override
-    public long rttMillis() {
-        return 0;
+    public long rttNanos() {
+        return this.rttNanos;
     }
 
     @Override
     public long congestionWindow() {
-        return 0;
+        return this.congestionWindow;
     }
 
     @Override
     public long deliveryRate() {
-        return 0;
+        return this.deliveryRate;
+    }
+
+    /**
+     * Returns the {@link String} representation of stats.
+     */
+    @Override
+    public String toString() {
+        return new StringBuilder(StringUtil.simpleClassName(this))
+            .append("[")
+            .append("recv=").append(this.recv)
+            .append(", sent=").append(this.sent)
+            .append(", lost=").append(this.lost)
+            .append(", rttNanos=").append(this.rttNanos)
+            .append(", congestionWindow=").append(this.congestionWindow)
+            .append(", deliveryRate=").append(this.deliveryRate)
+            .append("]")
+            .toString();
     }
 
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnectionStats.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnectionStats.java
@@ -17,7 +17,7 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.util.internal.StringUtil;
 
-public class QuicheQuicConnectionStats implements QuicConnectionStats {
+final class QuicheQuicConnectionStats implements QuicConnectionStats {
 
     private final long recv;
     private final long sent;
@@ -26,7 +26,7 @@ public class QuicheQuicConnectionStats implements QuicConnectionStats {
     private final long congestionWindow;
     private final long deliveryRate;
 
-    protected QuicheQuicConnectionStats(long recv, long sent, long lost, long rttNanos, long cwnd, long deliveryRate) {
+    QuicheQuicConnectionStats(long recv, long sent, long lost, long rttNanos, long cwnd, long deliveryRate) {
         this.recv = recv;
         this.sent = sent;
         this.lost = lost;
@@ -37,32 +37,32 @@ public class QuicheQuicConnectionStats implements QuicConnectionStats {
 
     @Override
     public long recv() {
-        return this.recv;
+        return recv;
     }
 
     @Override
     public long sent() {
-        return this.sent;
+        return sent;
     }
 
     @Override
     public long lost() {
-        return this.lost;
+        return lost;
     }
 
     @Override
     public long rttNanos() {
-        return this.rttNanos;
+        return rttNanos;
     }
 
     @Override
     public long congestionWindow() {
-        return this.congestionWindow;
+        return congestionWindow;
     }
 
     @Override
     public long deliveryRate() {
-        return this.deliveryRate;
+        return deliveryRate;
     }
 
     /**

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnectionStats.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnectionStats.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+public class QuicheQuicConnectionStats implements QuicConnectionStats {
+
+    @Override
+    public long recv() {
+        return 0;
+    }
+
+    @Override
+    public long sent() {
+        return 0;
+    }
+
+    @Override
+    public long lost() {
+        return 0;
+    }
+
+    @Override
+    public long rttMillis() {
+        return 0;
+    }
+
+    @Override
+    public long congestionWindow() {
+        return 0;
+    }
+
+    @Override
+    public long deliveryRate() {
+        return 0;
+    }
+
+}

--- a/src/test/java/io/netty/incubator/codec/quic/QuicExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicExample.java
@@ -25,10 +25,14 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.net.InetSocketAddress;
 
 public final class QuicExample {
+
+    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(QuicExample.class);
 
     private QuicExample() { }
 
@@ -62,6 +66,11 @@ public final class QuicExample {
                                     public void channelActive(ChannelHandlerContext ctx) throws Exception {
                                         QuicChannel channel = (QuicChannel) ctx.channel();
                                         // Create streams etc..
+                                    }
+
+                                    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+                                        LOGGER.info("Connection closed: {}",
+                                            ((QuicheQuicChannel) ctx.channel()).collectStats().getNow());
                                     }
 
                                     @Override


### PR DESCRIPTION
This is just a declaration of the API. While I'm working on the actual implementation just want to bounce back how API looks and feel. Would it be better to have `Stats` immutable and allocate new object on each call or just keep a single mutable Stats object allocated attached to the channel and populate it with the latest data each time `stats` is called?

P.S. Seems like I found answer myself: we need to keep track of stats carefully by using an object attached to the channel + populate it with latest data before freeing the pointer, otherwise channel might outlive the connection making it's impossible to get statistics. 