### PR TITLE
Fix writability handling and add tests

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -267,16 +267,12 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     @Override
     public Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler,
                                                   Promise<QuicStreamChannel> promise) {
-        if (eventLoop().inEventLoop()) {
-            ((QuicChannelUnsafe) unsafe()).connectStream(type, handler, promise);
-        } else {
-            eventLoop().execute(new Runnable() {
-                @Override
-                public void run() {
-                    ((QuicChannelUnsafe) unsafe()).connectStream(type, handler, promise);
-                }
-            });
-        }
+        eventLoop().execute(new Runnable() {
+            @Override
+            public void run() {
+                ((QuicChannelUnsafe) unsafe()).connectStream(type, handler, promise);
+            }
+        });
         return promise;
     }
 
@@ -619,7 +615,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             int writable = Quiche.quiche_conn_writable(connAddr, writableStreams);
 
             for (int i = 0; i < writable; i++) {
-                long stream = writableStreams[writable];
+                long stream = writableStreams[i];
                 QuicheQuicStreamChannel streamChannel = streams.get(stream);
                 if (streamChannel != null) {
                     streamChannel.writable();


### PR DESCRIPTION
Motivation:

We did have an error in handling the writability in QuicChannel which did mean we were not able to flush pending writes correctly.

Modifications:

- Fix writability handling
- Add a test for creating streams from the server side and do echo as well
- Fix writability / readability handling

Result:

Correctly handle writability changes