### PR TITLE
Correctly fail writes for streams that are unidirectional and not cre…

### DIFF
--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.PromiseNotifier;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class QuicStreamTypeTest {
+
+    @Test
+    public void testUnidirectionalCreatedByClient() throws Exception {
+        Channel server = null;
+        QuicChannel client = null;
+        try {
+            Promise<Throwable> serverWritePromise = ImmediateEventExecutor.INSTANCE.newPromise();
+            server = QuicTestUtils.newServer(new QuicChannelInitializer(new ChannelInboundHandlerAdapter() {
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) {
+                    QuicStreamChannel channel = (QuicStreamChannel) ctx.channel();
+                    assertEquals(QuicStreamType.UNIDIRECTIONAL, channel.type());
+                    assertFalse(channel.isLocalCreated());
+                    ctx.writeAndFlush(Unpooled.buffer().writeZero(8)).addListener(new ChannelFutureListener() {
+                        @Override
+                        public void operationComplete(ChannelFuture future) {
+                            serverWritePromise.setSuccess(future.cause());
+                        }
+                    });
+                }
+
+                @Override
+                public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                    ReferenceCountUtil.release(msg);
+                }
+            }));
+
+            client = (QuicChannel) QuicTestUtils.newClientBootstrap().handler(new ChannelInboundHandlerAdapter())
+                    .connect(QuicConnectionAddress.random((InetSocketAddress) server.localAddress())).sync().channel();
+            QuicStreamChannel streamChannel = client.createStream(
+                    QuicStreamType.UNIDIRECTIONAL, new ChannelInboundHandlerAdapter()).get();
+            // Do the write which should succeed
+            streamChannel.writeAndFlush(Unpooled.buffer().writeZero(8)).sync();
+
+            // Close stream and quic channel
+            streamChannel.close().sync();
+            client.close().sync();
+            assertThat(serverWritePromise.get(), instanceOf(UnsupportedOperationException.class));
+        } finally {
+            QuicTestUtils.closeParent(client);
+            if (server != null) {
+                server.close().sync();
+            }
+        }
+    }
+
+    @Test
+    public void testUnidirectionalCreatedByServer() throws Exception {
+        Channel server = null;
+        QuicChannel client = null;
+        try {
+            Promise<Void> serverWritePromise = ImmediateEventExecutor.INSTANCE.newPromise();
+            Promise<Throwable> clientWritePromise = ImmediateEventExecutor.INSTANCE.newPromise();
+
+            server = QuicTestUtils.newServer(new QuicChannelInitializer(new ChannelInboundHandlerAdapter() {
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                    QuicChannel channel = (QuicChannel) ctx.channel();
+                    channel.createStream(QuicStreamType.UNIDIRECTIONAL, new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                            // Do the write which should succeed
+                            ctx.writeAndFlush(Unpooled.buffer().writeZero(8))
+                                    .addListener(new PromiseNotifier<>(serverWritePromise));
+                        }
+                    });
+                }
+            }, new ChannelInboundHandlerAdapter()));
+
+            client = (QuicChannel) QuicTestUtils.newClientBootstrap().handler(
+                    new QuicChannelInitializer(new ChannelInboundHandlerAdapter() {
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) {
+                    // Do the write should fail
+                    ctx.writeAndFlush(Unpooled.buffer().writeZero(8)).addListener(new ChannelFutureListener() {
+                        @Override
+                        public void operationComplete(ChannelFuture future) {
+                            clientWritePromise.setSuccess(future.cause());
+                        }
+                    });
+                }
+
+                @Override
+                public void channelInactive(ChannelHandlerContext ctx) {
+                    // Close the QUIC channel as well.
+                    ctx.channel().parent().close();
+                }
+
+                @Override
+                public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                    ReferenceCountUtil.release(msg);
+                    // Let's close the stream
+                    ctx.close();
+                }
+            })).connect(QuicConnectionAddress.random((InetSocketAddress) server.localAddress())).sync().channel();
+
+            // Close stream and quic channel
+            client.closeFuture().sync();
+            assertTrue(serverWritePromise.await().isSuccess());
+            assertThat(clientWritePromise.get(), instanceOf(UnsupportedOperationException.class));
+        } finally {
+            QuicTestUtils.closeParent(client);
+            if (server != null) {
+                server.close().sync();
+            }
+        }
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
@@ -67,6 +67,7 @@ final class QuicTestUtils {
                 .initialMaxStreamDataBidirectionalRemote(1000000)
                 .initialMaxStreamsBidirectional(100)
                 .initialMaxStreamsUnidirectional(100)
+                .initialMaxStreamDataUnidirectional(1000000)
                 .disableActiveMigration(true)
                 .enableEarlyData().buildBootstrap(channel);
     }
@@ -81,6 +82,7 @@ final class QuicTestUtils {
                 .initialMaxData(10000000)
                 .initialMaxStreamDataBidirectionalLocal(1000000)
                 .initialMaxStreamDataBidirectionalRemote(1000000)
+                .initialMaxStreamDataUnidirectional(1000000)
                 .initialMaxStreamsBidirectional(100)
                 .initialMaxStreamsUnidirectional(100)
                 .disableActiveMigration(true)


### PR DESCRIPTION
…ated locally

Motivation:

Writes are not allowed on streams that are unidirectiona and are create by the remote peer.

Modifications:

- Correctly fail writes
- Add unit tests

Result:

Correctly handle unidirectional writes