### PR TITLE
Make token validation / processing optional

### DIFF
--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -153,6 +153,13 @@ static jlong netty_quic_quiche_accept(JNIEnv* env, jclass clazz, jlong scid, jin
                                  (quiche_config *) config);
 }
 
+static jlong netty_quic_quiche_accept_no_token(JNIEnv* env, jclass clazz, jlong scid, jint scid_len, jlong config) {
+    return (jlong) quiche_accept((const uint8_t *) scid, (size_t) scid_len,
+                                 // No token validation was done before
+                                 NULL, 0,
+                                 (quiche_config *) config);
+}
+
 static jint netty_quic_quiche_conn_recv(JNIEnv* env, jclass clazz, jlong conn, jlong buf, jint buf_len) {
     return (jint) quiche_conn_recv((quiche_conn *) conn, (uint8_t *) buf, (size_t) buf_len);
 }
@@ -463,6 +470,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_negotiate_version", "(JIJIJI)I", (void *) netty_quic_quiche_negotiate_version },
   { "quiche_retry", "(JIJIJIJIIJI)I", (void *) netty_quic_quiche_retry },
   { "quiche_accept", "(JIJIJ)J", (void *) netty_quic_quiche_accept },
+  { "quiche_accept_no_token", "(JIJ)J", (void *) netty_quic_quiche_accept_no_token },
   { "quiche_conn_recv", "(JJI)I", (void *) netty_quic_quiche_conn_recv },
   { "quiche_conn_send", "(JJI)I", (void *) netty_quic_quiche_conn_send },
   { "quiche_conn_free", "(J)V", (void *) netty_quic_quiche_conn_free },

--- a/src/main/java/io/netty/incubator/codec/quic/InsecureQuicTokenHandler.java
+++ b/src/main/java/io/netty/incubator/codec/quic/InsecureQuicTokenHandler.java
@@ -45,11 +45,12 @@ public final class InsecureQuicTokenHandler implements QuicTokenHandler {
     public static final InsecureQuicTokenHandler INSTANCE = new InsecureQuicTokenHandler();
 
     @Override
-    public void writeToken(ByteBuf out, ByteBuf dcid, InetSocketAddress address) {
+    public boolean writeToken(ByteBuf out, ByteBuf dcid, InetSocketAddress address) {
         byte[] addr = address.getAddress().getAddress();
         out.writeBytes(SERVER_NAME_BYTES)
                 .writeBytes(addr)
                 .writeBytes(dcid, dcid.readerIndex(), dcid.readableBytes());
+        return true;
     }
 
     @Override

--- a/src/main/java/io/netty/incubator/codec/quic/QuicTokenHandler.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicTokenHandler.java
@@ -26,8 +26,10 @@ public interface QuicTokenHandler {
 
     /**
      * Generate a new token for the given destination connection id and address. This token is written to {@code out}.
+     * If no token should be generated and so no token validation should take place at all this method should return
+     * {@link false}.
      */
-    void writeToken(ByteBuf out, ByteBuf dcid, InetSocketAddress address);
+    boolean writeToken(ByteBuf out, ByteBuf dcid, InetSocketAddress address);
 
     /**
      * Return the given toke and return the offset, {@code -1} is returned if the token is not valid.

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -214,6 +214,12 @@ final class Quiche {
     static native long quiche_accept(long scidAddr, int scidLen, long odcidAddr, int odcidLen, long configAddr);
 
     /**
+     * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L206">quiche_accept</a> but
+     * used for accepting QUIC connections without token validation.
+     */
+    static native long quiche_accept_no_token(long scidAddr, int scidLen, long configAddr);
+
+    /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L249">quiche_conn_recv</a>.
      */
     static native int quiche_conn_recv(long connAddr, long bufAddr, int bufLen);

--- a/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
@@ -72,7 +72,8 @@ final class QuicTestUtils {
                 .enableEarlyData().buildBootstrap(channel);
     }
 
-    static Bootstrap newServerBootstrap(QuicChannelInitializer channelInitializer) throws Exception {
+    private static Bootstrap newServerBootstrap(
+            QuicTokenHandler tokenHandler, QuicChannelInitializer channelInitializer) {
         ChannelHandler codec = new QuicServerBuilder()
                 .certificateChain("./src/test/resources/cert.crt")
                 .privateKey("./src/test/resources/cert.key")
@@ -86,7 +87,7 @@ final class QuicTestUtils {
                 .initialMaxStreamsBidirectional(100)
                 .initialMaxStreamsUnidirectional(100)
                 .disableActiveMigration(true)
-                .enableEarlyData().buildCodec(InsecureQuicTokenHandler.INSTANCE, channelInitializer);
+                .enableEarlyData().buildCodec(tokenHandler, channelInitializer);
         Bootstrap bs = new Bootstrap();
         return bs.group(GROUP)
                 .channel(NioDatagramChannel.class)
@@ -95,8 +96,13 @@ final class QuicTestUtils {
                 .localAddress(new InetSocketAddress(NetUtil.LOCALHOST4, 0));
     }
 
+    static Channel newServer(QuicTokenHandler tokenHandler, QuicChannelInitializer channelInitializer)
+            throws Exception {
+        return newServerBootstrap(tokenHandler, channelInitializer).bind().sync().channel();
+    }
+
     static Channel newServer(QuicChannelInitializer channelInitializer) throws Exception {
-        return newServerBootstrap(channelInitializer).bind().sync().channel();
+        return newServer(InsecureQuicTokenHandler.INSTANCE, channelInitializer);
     }
 
     static void closeParent(ChannelFuture future) throws Exception {


### PR DESCRIPTION
Motivation:

While it is highly recommended to use tokens during QUIC connection establishment it is not really required by the spec and there may be use-cases where token validation is not needed and so the extra roundtrip can be eliminated

Modifications:

- Change QuicTokenHandler.writeToken(...) method to return either true or false. If true is returned a token is used and validation is used. If false is returned it will just accept the connection
- Adjust QuicheQuicServerCodec to account for this
- Add unit test that verifies we can use no tokens

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/1 .