### PR TITLE
Define -DOPENSSL_C11_ATOMIC and other CFLAGS / CXXFLAGS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,11 +229,15 @@
                       <exec executable="cargo" failonerror="true" dir="${quicheCheckoutDir}" resolveexecutable="true">
                         <arg value="build" />
                         <env key="MACOSX_DEPLOYMENT_TARGET" value="${macosxDeploymentTarget}"/>
+                        <env key="CFLAGS" value="-O3 -fno-omit-frame-pointer -DOPENSSL_C11_ATOMIC"/>
+                        <env key="CXXFLAGS" value="-O3 -fno-omit-frame-pointer"/>
                       </exec>
                     </then>
                     <else>
                       <exec executable="cargo" failonerror="true" dir="${quicheCheckoutDir}" resolveexecutable="true">
                         <arg value="build" />
+                        <env key="CFLAGS" value="-O3 -fno-omit-frame-pointer -DOPENSSL_C11_ATOMIC"/>
+                        <env key="CXXFLAGS" value="-O3 -fno-omit-frame-pointer"/>
                       </exec>
 
                       <!-- delete the shared library as otherwise we may link against it and not against the static


### PR DESCRIPTION
Motivation:

A lot of locking overhead can be reduced in BoringSSL by using -DOPENSSL_C11_ATOMIC. Beside this we should also ensure we use the right optimizer level and also keep frame pointers intact for easier debugging / profiling

Modifications:

Set the right CFLAGS / CXXFLAGS

Result:

Less locking overhead in BoringSSL and intact frame pointers / optimizer level in general