### PR TITLE
Allow to configure the QuicCongestionControlAlgorithm

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicBuilder.java
@@ -40,12 +40,21 @@ public abstract class QuicBuilder<B extends QuicBuilder<B>> {
     private Long maxAckDelay;
     private Boolean disableActiveMigration;
     private Boolean enableHystart;
+    private QuicCongestionControlAlgorithm congestionControlAlgorithm;
 
     QuicBuilder() { }
 
     @SuppressWarnings("unchecked")
     protected final B self() {
         return (B) this;
+    }
+
+    /**
+     * Sets the congestion control algorithm to use.
+     */
+    public final B congestionControlAlgorithm(QuicCongestionControlAlgorithm congestionControlAlgorithm) {
+        this.congestionControlAlgorithm = congestionControlAlgorithm;
+        return self();
     }
 
     /**
@@ -275,6 +284,19 @@ public abstract class QuicBuilder<B extends QuicBuilder<B>> {
             }
             if (enableHystart != null) {
                 Quiche.quiche_config_enable_hystart(config, enableHystart);
+            }
+            if (congestionControlAlgorithm != null) {
+                switch (congestionControlAlgorithm) {
+                    case RENO:
+                        Quiche.quiche_config_set_cc_algorithm(config, Quiche.QUICHE_CC_RENO);
+                        break;
+                    case CUBIC:
+                        Quiche.quiche_config_set_cc_algorithm(config, Quiche.QUICHE_CC_CUBIC);
+                        break;
+                    default:
+                        throw new IllegalArgumentException(
+                                "Unknown congestionControlAlgorithm: " + congestionControlAlgorithm);
+                }
             }
             return config;
         } catch (Throwable cause) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCongestionControlAlgorithm.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCongestionControlAlgorithm.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+/**
+ * Available congestion control algorithms to use.
+ */
+public enum QuicCongestionControlAlgorithm {
+    RENO,
+    CUBIC
+}


### PR DESCRIPTION
Motivation:

We should allow to configure the congestion control algorithm

Modifications:

- Add QuicCongestionControlAlgorithm enum
- Expose an option on the builder to configure it

Result:

Be able to configure the the congestion control algorithm