### PR TITLE
Fine-grained Quiche exception

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicError.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicError.java
@@ -22,7 +22,7 @@ import io.netty.util.collection.IntObjectMap;
  * All QUIC error codes identified by Quiche.
  * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/src/lib.rs#L335-L380">Error</a>
  */
-enum QuicError {
+public enum QuicError {
     UNKNOWN_VERSION(Quiche.QUICHE_ERR_UNKNOWN_VERSION, "QUICHE_ERR_UNKNOWN_VERSION"),
     INVALID_FRAME(Quiche.QUICHE_ERR_INVALID_FRAME, "QUICHE_ERR_INVALID_FRAME"),
     INVALID_PACKET(Quiche.QUICHE_ERR_INVALID_PACKET, "QUICHE_ERR_INVALID_PACKET"),

--- a/src/main/java/io/netty/incubator/codec/quic/QuicError.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicError.java
@@ -19,12 +19,10 @@ import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
 
 /**
- * All QUIC error codes identified by Quiche. See <a href=
- * "https://github.com/cloudflare/quiche/blob/0.6.0/src/lib.rs#L335-L380">Error</a>
+ * All QUIC error codes identified by Quiche.
+ * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/src/lib.rs#L335-L380">Error</a>
  */
-public enum QuicheError {
-    DONE(Quiche.QUICHE_ERR_DONE, "QUICHE_ERR_DONE"),
-    BUFFER_TOO_SHORT(Quiche.QUICHE_ERR_BUFFER_TOO_SHORT, "QUICHE_ERR_BUFFER_TOO_SHORT"),
+enum QuicError {
     UNKNOWN_VERSION(Quiche.QUICHE_ERR_UNKNOWN_VERSION, "QUICHE_ERR_UNKNOWN_VERSION"),
     INVALID_FRAME(Quiche.QUICHE_ERR_INVALID_FRAME, "QUICHE_ERR_INVALID_FRAME"),
     INVALID_PACKET(Quiche.QUICHE_ERR_INVALID_PACKET, "QUICHE_ERR_INVALID_PACKET"),
@@ -38,10 +36,10 @@ public enum QuicheError {
     FINAL_SIZE(Quiche.QUICHE_ERR_FINAL_SIZE, "QUICHE_ERR_FINAL_SIZE"),
     CONGESTION_CONTROL(Quiche.QUICHE_ERR_CONGESTION_CONTROL, "QUICHE_ERR_CONGESTION_CONTROL");
 
-    protected static final IntObjectMap<QuicheError> ERROR_MAP = new IntObjectHashMap<>();
+    private static final IntObjectMap<QuicError> ERROR_MAP = new IntObjectHashMap<>();
 
     static {
-        for (QuicheError errorCode : QuicheError.values()) {
+        for (QuicError errorCode : QuicError.values()) {
             ERROR_MAP.put(errorCode.code(), errorCode);
         }
     }
@@ -49,28 +47,28 @@ public enum QuicheError {
     private final int code;
     private final String message;
 
-    QuicheError(int code, String message) {
+    QuicError(int code, String message) {
         this.code = code;
         this.message = message;
     }
 
-    public final int code() {
+    final int code() {
         return code;
     }
 
-    public final String message() {
+    final String message() {
         return message;
     }
 
     @Override
     public final String toString() {
-        return String.format("QuicheError{code=%d, message=%s}", code, message);
+        return String.format("QuicError{code=%d, message=%s}", code, message);
     }
 
-    public static QuicheError valueOf(int code) {
-        final QuicheError errorCode = ERROR_MAP.get(code);
+    static QuicError valueOf(int code) {
+        final QuicError errorCode = ERROR_MAP.get(code);
         if (errorCode == null) {
-            throw new IllegalArgumentException("unknown " + QuicheError.class.getSimpleName() + " code: " + code);
+            throw new IllegalArgumentException("unknown " + QuicError.class.getSimpleName() + " code: " + code);
         }
         return errorCode;
     }

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -28,11 +28,9 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
-import java.io.IOException;
 
 final class Quiche {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Quiche.class);
-    private static final IntObjectMap<String> ERROR_MAP = new IntObjectHashMap<>();
     private static final boolean DEBUG_LOGGING_ENABLED = logger.isDebugEnabled();
 
     static {
@@ -512,36 +510,19 @@ final class Quiche {
      */
     private static native void quiche_enable_debug_logging(QuicheLogger logger);
 
-    static {
-        ERROR_MAP.put(QUICHE_ERR_DONE, "QUICHE_ERR_DONE");
-        ERROR_MAP.put(QUICHE_ERR_BUFFER_TOO_SHORT, "QUICHE_ERR_BUFFER_TOO_SHORT");
-        ERROR_MAP.put(QUICHE_ERR_UNKNOWN_VERSION, "QUICHE_ERR_UNKNOWN_VERSION");
-        ERROR_MAP.put(QUICHE_ERR_INVALID_FRAME, "QUICHE_ERR_INVALID_FRAME");
-        ERROR_MAP.put(QUICHE_ERR_INVALID_PACKET, "QUICHE_ERR_INVALID_PACKET");
-        ERROR_MAP.put(QUICHE_ERR_INVALID_STATE, "QUICHE_ERR_INVALID_STATE");
-        ERROR_MAP.put(QUICHE_ERR_INVALID_STREAM_STATE, "QUICHE_ERR_INVALID_STREAM_STATE");
-        ERROR_MAP.put(QUICHE_ERR_INVALID_TRANSPORT_PARAM, "QUICHE_ERR_INVALID_TRANSPORT_PARAM");
-        ERROR_MAP.put(QUICHE_ERR_CRYPTO_FAIL, "QUICHE_ERR_CRYPTO_FAIL");
-        ERROR_MAP.put(QUICHE_ERR_TLS_FAIL, "QUICHE_ERR_TLS_FAIL");
-        ERROR_MAP.put(QUICHE_ERR_FLOW_CONTROL, "QUICHE_ERR_FLOW_CONTROL");
-        ERROR_MAP.put(QUICHE_ERR_STREAM_LIMIT, "QUICHE_ERR_STREAM_LIMIT");
-        ERROR_MAP.put(QUICHE_ERR_FINAL_SIZE, "QUICHE_ERR_FINAL_SIZE");
-        ERROR_MAP.put(QUICHE_ERR_CONGESTION_CONTROL, "QUICHE_ERR_CONGESTION_CONTROL");
-    }
-
     static String errorAsString(int err) {
-        return ERROR_MAP.get(err);
+        return QuicheError.valueOf(err).message();
     }
 
     static Exception newException(int err) {
-        String errStr = errorAsString(err);
+        final QuicheError error = QuicheError.valueOf(err);
         if (err == QUICHE_ERR_TLS_FAIL) {
-            return new SSLHandshakeException(errStr);
+            return new SSLHandshakeException(error.message());
         }
         if (err == QUICHE_ERR_CRYPTO_FAIL) {
-            return new SSLException(errStr);
+            return new SSLException(error.message());
         }
-        return new IOException(errStr);
+        return new QuicheException(error);
     }
 
     static boolean throwIfError(int res) throws Exception {

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -516,13 +516,16 @@ final class Quiche {
 
     static Exception newException(int err) {
         final QuicError error = QuicError.valueOf(err);
+        final QuicheException reason = new QuicheException(error);
         if (err == QUICHE_ERR_TLS_FAIL) {
-            return new SSLHandshakeException(error.message());
+            final SSLHandshakeException sslExc = new SSLHandshakeException(error.message());
+            sslExc.initCause(reason);
+            return sslExc;
         }
         if (err == QUICHE_ERR_CRYPTO_FAIL) {
-            return new SSLException(error.message());
+            return new SSLException(error.message(), reason);
         }
-        return new QuicheException(error);
+        return reason;
     }
 
     static boolean throwIfError(int res) throws Exception {

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -511,11 +511,11 @@ final class Quiche {
     private static native void quiche_enable_debug_logging(QuicheLogger logger);
 
     static String errorAsString(int err) {
-        return QuicheError.valueOf(err).message();
+        return QuicError.valueOf(err).message();
     }
 
     static Exception newException(int err) {
-        final QuicheError error = QuicheError.valueOf(err);
+        final QuicError error = QuicError.valueOf(err);
         if (err == QUICHE_ERR_TLS_FAIL) {
             return new SSLHandshakeException(error.message());
         }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheError.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheError.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.util.collection.IntObjectHashMap;
+import io.netty.util.collection.IntObjectMap;
+
+/**
+ * All QUIC error codes identified by Quiche. See <a href=
+ * "https://github.com/cloudflare/quiche/blob/0.6.0/src/lib.rs#L335-L380">Error</a>
+ */
+public enum QuicheError {
+    DONE(Quiche.QUICHE_ERR_DONE, "QUICHE_ERR_DONE"),
+    BUFFER_TOO_SHORT(Quiche.QUICHE_ERR_BUFFER_TOO_SHORT, "QUICHE_ERR_BUFFER_TOO_SHORT"),
+    UNKNOWN_VERSION(Quiche.QUICHE_ERR_UNKNOWN_VERSION, "QUICHE_ERR_UNKNOWN_VERSION"),
+    INVALID_FRAME(Quiche.QUICHE_ERR_INVALID_FRAME, "QUICHE_ERR_INVALID_FRAME"),
+    INVALID_PACKET(Quiche.QUICHE_ERR_INVALID_PACKET, "QUICHE_ERR_INVALID_PACKET"),
+    INVALID_STATE(Quiche.QUICHE_ERR_INVALID_STATE, "QUICHE_ERR_INVALID_STATE"),
+    INVALID_STREAM_STATE(Quiche.QUICHE_ERR_INVALID_STREAM_STATE, "QUICHE_ERR_INVALID_STREAM_STATE"),
+    INVALID_TRANSPORT_PARAM(Quiche.QUICHE_ERR_INVALID_TRANSPORT_PARAM, "QUICHE_ERR_INVALID_TRANSPORT_PARAM"),
+    CRYPTO_FAIL(Quiche.QUICHE_ERR_CRYPTO_FAIL, "QUICHE_ERR_CRYPTO_FAIL"),
+    TLS_FAIL(Quiche.QUICHE_ERR_TLS_FAIL, "QUICHE_ERR_TLS_FAIL"),
+    FLOW_CONTROL(Quiche.QUICHE_ERR_FLOW_CONTROL, "QUICHE_ERR_FLOW_CONTROL"),
+    STREAM_LIMIT(Quiche.QUICHE_ERR_STREAM_LIMIT, "QUICHE_ERR_STREAM_LIMIT"),
+    FINAL_SIZE(Quiche.QUICHE_ERR_FINAL_SIZE, "QUICHE_ERR_FINAL_SIZE"),
+    CONGESTION_CONTROL(Quiche.QUICHE_ERR_CONGESTION_CONTROL, "QUICHE_ERR_CONGESTION_CONTROL");
+
+    protected static final IntObjectMap<QuicheError> ERROR_MAP = new IntObjectHashMap<>();
+
+    static {
+        for (QuicheError errorCode : QuicheError.values()) {
+            ERROR_MAP.put(errorCode.code(), errorCode);
+        }
+    }
+
+    private final int code;
+    private final String message;
+
+    QuicheError(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public final int code() {
+        return code;
+    }
+
+    public final String message() {
+        return message;
+    }
+
+    @Override
+    public final String toString() {
+        return String.format("QuicheError{code=%d, message=%s}", code, message);
+    }
+
+    public static QuicheError valueOf(int code) {
+        final QuicheError errorCode = ERROR_MAP.get(code);
+        if (errorCode == null) {
+            throw new IllegalArgumentException("unknown " + QuicheError.class.getSimpleName() + " code: " + code);
+        }
+        return errorCode;
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheException.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheException.java
@@ -19,15 +19,14 @@ import java.io.IOException;
 
 public final class QuicheException extends IOException {
 
-    private final QuicError errorCode;
+    private final QuicError error;
 
-    QuicheException(QuicError errorCode) {
-        super(errorCode.message());
-        this.errorCode = errorCode;
+    QuicheException(QuicError error) {
+        super(error.message());
+        this.error = error;
     }
 
-    public QuicError errorCode() {
-        return errorCode;
+    public QuicError error() {
+        return error;
     }
-
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheException.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import java.io.IOException;
+
+public final class QuicheException extends IOException {
+
+    private final QuicheError errorCode;
+
+    QuicheException(QuicheError errorCode) {
+        super(errorCode.message());
+        this.errorCode = errorCode;
+    }
+
+    public QuicheError errorCode() {
+        return errorCode;
+    }
+
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheException.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheException.java
@@ -19,14 +19,14 @@ import java.io.IOException;
 
 public final class QuicheException extends IOException {
 
-    private final QuicheError errorCode;
+    private final QuicError errorCode;
 
-    QuicheException(QuicheError errorCode) {
+    QuicheException(QuicError errorCode) {
         super(errorCode.message());
         this.errorCode = errorCode;
     }
 
-    public QuicheError errorCode() {
+    public QuicError errorCode() {
         return errorCode;
     }
 


### PR DESCRIPTION
While I'm working on test cases, @normanmaurer would you please review the API?

Motivation:

At the moment we basically only use `SSLException`, `SSLHandshakeException` and `IOException` for QUIC. It would be better to be a bit more fine-grained here to make it easier for people to understand why something failed. Covers #26.

Modifications:

* `QuicheException` that extends `IOException` and carries `QuicheError` error code.

Result:

Failure reason is transperent.