### PR TITLE
Optimize handling of writable streams

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -257,6 +257,7 @@ final class QuicheQuicStreamChannel extends AbstractChannel implements QuicStrea
         }
 
         if (!parent().streamSendMultiple(streamId(), alloc(), channelOutboundBuffer)) {
+            parent().streamHasPendingWrites(streamId());
             flushPending = true;
         }
     }


### PR DESCRIPTION
Motivation:

Or implementation that we used before to handle writable streams was very wasteful as we basically had to iterate over all the streams all the time even tho most of the time streams should not have any pending writes which need to be handled here.

Modifications:

Keep track of streams that have pending writes by ourselves and only process these when QuicheQuicChannel.writable() is called.

Result:

Less overhead, fixes https://github.com/netty/netty-incubator-codec-quic/issues/42.