### PR TITLE
[DRAFT] Additional configuration for peer verification (server_name) and keys logging (keylog_path)

### DIFF
--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -172,6 +172,22 @@ static void netty_quic_quiche_conn_free(JNIEnv* env, jclass clazz, jlong conn) {
     quiche_conn_free((quiche_conn *) conn);
 }
 
+static jboolean netty_quic_quiche_conn_set_keylog_path(JNIEnv* env, jclass clazz, jlong conn, jstring keylog_path) {
+    if (keylog_path == NULL) {
+        return JNI_FALSE;
+    }
+
+    const char *path = NULL;
+    path = (*env)->GetStringUTFChars(env, keylog_path, 0);
+    if (path == NULL) {
+        return JNI_FALSE;
+    }
+
+    bool res = quiche_conn_set_keylog_path((quiche_conn *) conn, path);
+    (*env)->ReleaseStringUTFChars(env, keylog_path, path);
+    return res == true ? JNI_TRUE : JNI_FALSE;
+}
+
 static jlong netty_quic_quiche_connect(JNIEnv* env, jclass clazz, jstring server_name, jlong scid, jint scid_len, jlong config) {
     const char *name = NULL;
     if (server_name != NULL) {
@@ -353,6 +369,10 @@ static void netty_quic_quiche_config_grease(JNIEnv* env, jclass clazz, jlong con
     quiche_config_grease((quiche_config*) config, value == JNI_TRUE ? true : false);
 }
 
+static void netty_quic_quiche_config_log_keys(JNIEnv* env, jclass clazz, jlong config) {
+    quiche_config_log_keys((quiche_config*) config);
+}
+
 static void netty_quic_quiche_config_enable_early_data(JNIEnv* env, jclass clazz, jlong config) {
     quiche_config_enable_early_data((quiche_config*) config);
 }
@@ -488,6 +508,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_recv", "(JJI)I", (void *) netty_quic_quiche_conn_recv },
   { "quiche_conn_send", "(JJI)I", (void *) netty_quic_quiche_conn_send },
   { "quiche_conn_free", "(J)V", (void *) netty_quic_quiche_conn_free },
+  { "quiche_conn_set_keylog_path", "(JLjava/lang/String;)Z", (void *) netty_quic_quiche_conn_set_keylog_path },
   { "quiche_connect", "(Ljava/lang/String;JIJ)J", (void *) netty_quic_quiche_connect },
   { "quiche_conn_stream_recv", "(JJJIJ)I", (void *) netty_quic_quiche_conn_stream_recv },
   { "quiche_conn_stream_send", "(JJJIZ)I", (void *) netty_quic_quiche_conn_stream_send },
@@ -513,6 +534,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_config_load_priv_key_from_pem_file", "(JLjava/lang/String;)I", (void *) netty_quic_quiche_config_load_priv_key_from_pem_file },
   { "quiche_config_verify_peer", "(JZ)V", (void *) netty_quic_quiche_config_verify_peer },
   { "quiche_config_grease", "(JZ)V", (void *) netty_quic_quiche_config_grease },
+  { "quiche_config_log_keys", "(J)V", (void *) netty_quic_quiche_config_log_keys },
   { "quiche_config_enable_early_data", "(J)V", (void *) netty_quic_quiche_config_enable_early_data },
   { "quiche_config_set_application_protos", "(J[B)I", (void *) netty_quic_quiche_config_set_application_protos },
   { "quiche_config_set_max_idle_timeout", "(JJ)V", (void *) netty_quic_quiche_config_set_max_idle_timeout },

--- a/src/main/java/io/netty/incubator/codec/quic/DefaultQuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/DefaultQuicChannelConfig.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import java.util.Map;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.DefaultChannelConfig;
+
+/**
+ * A QUIC {@link ChannelConfig}.
+ */
+public class DefaultQuicChannelConfig extends DefaultChannelConfig {
+
+    private String keylogPath;
+
+    public DefaultQuicChannelConfig(Channel channel) {
+        super(channel);
+    }
+
+    @Override
+    public Map<ChannelOption<?>, Object> getOptions() {
+        return getOptions(super.getOptions(), QuicChannel.QUIC_KEYLOG_PATH);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getOption(ChannelOption<T> option) {
+        if (option == QuicChannel.QUIC_KEYLOG_PATH) {
+            return (T) String.valueOf(getKeylogPath());
+        }
+
+        return super.getOption(option);
+    }
+
+    @Override
+    public <T> boolean setOption(ChannelOption<T> option, T value) {
+        validate(option, value);
+
+        if (option == QuicChannel.QUIC_KEYLOG_PATH) {
+            setKeylogPath((String) value);
+        } else {
+            return super.setOption(option, value);
+        }
+
+        return true;
+    }
+
+    public String getKeylogPath() {
+        return keylogPath;
+    }
+
+    public DefaultQuicChannelConfig setKeylogPath(String keylogPath) {
+        this.keylogPath = keylogPath;
+        return this;
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicBuilder.java
@@ -26,6 +26,7 @@ public abstract class QuicBuilder<B extends QuicBuilder<B>> {
     private String keyPath;
     private Boolean verifyPeer;
     private Boolean grease;
+    private Boolean logKeys;
     private boolean earlyData;
     private byte[] protos;
     private Long maxIdleTimeout;
@@ -88,6 +89,14 @@ public abstract class QuicBuilder<B extends QuicBuilder<B>> {
      */
     public final B grease(boolean enable) {
         grease = enable;
+        return self();
+    }
+
+    /**
+     * Enables logging of secrets.
+     */
+    public final B logKeys() {
+        logKeys = true;
         return self();
     }
 
@@ -256,6 +265,9 @@ public abstract class QuicBuilder<B extends QuicBuilder<B>> {
             }
             if (grease != null) {
                 Quiche.quiche_config_grease(config, grease);
+            }
+            if (logKeys) {
+                Quiche.quiche_config_log_keys(config);
             }
             if (earlyData) {
                 Quiche.quiche_config_enable_early_data(config);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicBuilder.java
@@ -41,6 +41,7 @@ public abstract class QuicBuilder<B extends QuicBuilder<B>> {
     private Boolean disableActiveMigration;
     private Boolean enableHystart;
     private QuicCongestionControlAlgorithm congestionControlAlgorithm;
+    private String serverName;
 
     QuicBuilder() { }
 
@@ -223,6 +224,19 @@ public abstract class QuicBuilder<B extends QuicBuilder<B>> {
     public final B enableHystart(boolean value) {
         this.enableHystart = value;
         return self();
+    }
+
+    /**
+     * See server_name argument for
+     * <a href="https://docs.rs/quiche/0.6.0/quiche/fn.connect.html">quiche::connect</a>
+     */
+    public final B serverName(String serverName) {
+        this.serverName = serverName;
+        return self();
+    }
+
+    final String serverName() {
+        return serverName;
     }
 
     /**

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
@@ -27,6 +28,8 @@ import io.netty.util.concurrent.Promise;
  * A QUIC {@link Channel}.
  */
 public interface QuicChannel extends Channel {
+
+    ChannelOption<String> QUIC_KEYLOG_PATH = ChannelOption.valueOf("QUIC_KEYLOG_PATH");
 
     /**
      * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Future} once done.

--- a/src/main/java/io/netty/incubator/codec/quic/QuicClientBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicClientBuilder.java
@@ -28,7 +28,7 @@ public final class QuicClientBuilder extends QuicBuilder<QuicClientBuilder> {
      * Build a QUIC codec for the client side.
      */
     private ChannelHandler buildCodec() {
-        return new QuicheQuicClientCodec(createConfig());
+        return new QuicheQuicClientCodec(createConfig(), serverName());
     }
 
     /**

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -233,6 +233,12 @@ final class Quiche {
     static native void quiche_conn_free(long connAddr);
 
     /**
+     * See
+     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L235">quiche_conn_set_keylog_path</a>.
+     */
+    static native boolean quiche_conn_set_keylog_path(long connAddr, String path);
+
+    /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L211">quiche_connect</a>.
      */
     static native long quiche_connect(String server_name, long scidAddr, int scidLen, long configAddr);
@@ -391,6 +397,13 @@ final class Quiche {
      *     quiche_config_grease</a>.
      */
     static native void quiche_config_grease(long configAddr, boolean value);
+
+    /**
+     * See
+     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#132">
+     *     quiche_config_log_keys</a>.
+     */
+    static native void quiche_config_log_keys(long configAddr);
 
     /**
      * See

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -29,7 +29,6 @@ import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.ConnectTimeoutException;
-import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.collection.LongObjectHashMap;
@@ -158,7 +157,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private QuicheQuicChannel(Channel parent, boolean server, ByteBuffer key, long connAddr, String traceId,
                       InetSocketAddress remote) {
         super(parent);
-        config = new DefaultChannelConfig(this);
+        config = new DefaultQuicChannelConfig(this);
         this.server = server;
         this.idGenerator = new QuicStreamIdGenerator(server);
         this.key = key;
@@ -201,6 +200,12 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
             connectionSendNeeded = true;
             key = connectId;
+
+            final String keylogPath = config().getOption(QUIC_KEYLOG_PATH);
+            if (keylogPath != null) {
+                // TODO: handle "false" result, which means something when wrong (???)
+                Quiche.quiche_conn_set_keylog_path(connection, keylogPath);
+            }
         } finally {
             idBuffer.release();
         }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -179,13 +179,13 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         return new QuicheQuicChannel(parent, true, key, connAddr, traceId, remote);
     }
 
-    private void connect(long configAddr) throws Exception {
+    private void connect(long configAddr, String serverName) throws Exception {
         assert this.connAddr == -1;
         assert this.traceId == null;
         assert this.key == null;
         ByteBuf idBuffer = alloc().directBuffer(connectId.remaining()).writeBytes(connectId.duplicate());
         try {
-            long connection = Quiche.quiche_connect(null, idBuffer.memoryAddress() + idBuffer.readerIndex(),
+            long connection = Quiche.quiche_connect(serverName, idBuffer.memoryAddress() + idBuffer.readerIndex(),
                     idBuffer.readableBytes(), configAddr);
             if (connection == -1) {
                 ConnectException connectException = new ConnectException();
@@ -942,11 +942,11 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     // TODO: Come up with something better.
-    static QuicheQuicChannel handleConnect(SocketAddress address, long config) throws Exception {
+    static QuicheQuicChannel handleConnect(SocketAddress address, long config, String serverName) throws Exception {
         if (address instanceof QuicheQuicChannel.QuicheQuicChannelAddress) {
             QuicheQuicChannel.QuicheQuicChannelAddress addr = (QuicheQuicChannel.QuicheQuicChannelAddress) address;
             QuicheQuicChannel channel = addr.channel;
-            channel.connect(config);
+            channel.connect(config, serverName);
             return channel;
         }
         return null;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
@@ -28,10 +28,17 @@ import java.nio.ByteBuffer;
  */
 final class QuicheQuicClientCodec extends QuicheQuicCodec {
 
+    private final String serverName;
+
     QuicheQuicClientCodec(long config) {
+        this(config, null);
+    }
+
+    QuicheQuicClientCodec(long config, String serverName) {
         // Let's just use Quic.MAX_DATAGRAM_SIZE as the maximum size for a token on the client side. This should be
         // safe enough and as we not have too many codecs at the same time this should be ok.
         super(config, Quic.MAX_DATAGRAM_SIZE);
+        this.serverName = serverName;
     }
 
     @Override
@@ -48,7 +55,7 @@ final class QuicheQuicClientCodec extends QuicheQuicCodec {
                         SocketAddress localAddress, ChannelPromise promise) {
         final QuicheQuicChannel channel;
         try {
-            channel = QuicheQuicChannel.handleConnect(remoteAddress, config);
+            channel = QuicheQuicChannel.handleConnect(remoteAddress, config, serverName);
         } catch (Exception e) {
             promise.setFailure(e);
             return;

--- a/src/test/java/io/netty/incubator/codec/quic/QuicClientExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicClientExample.java
@@ -53,6 +53,7 @@ public final class QuicClientExample {
             Bootstrap quicClientBootstrap = new QuicClientBuilder()
                     .certificateChain("./src/test/resources/cert.crt")
                     .privateKey("./src/test/resources/cert.key")
+                    .logKeys()
                     .applicationProtocols(proto)
                     .maxIdleTimeout(5000)
                     .maxUdpPayloadSize(Quic.MAX_DATAGRAM_SIZE)
@@ -65,6 +66,7 @@ public final class QuicClientExample {
                     .enableEarlyData().buildBootstrap(channel);
 
             QuicChannel quicChannel = (QuicChannel) quicClientBootstrap
+                            .option(QuicChannel.QUIC_KEYLOG_PATH, "./srt/test/resources/keylog")
                             .handler(new QuicChannelInitializer(new ChannelInboundHandlerAdapter() {
                                 @Override
                                 public void channelActive(ChannelHandlerContext ctx) {


### PR DESCRIPTION
Another draft to discuss API/approach 😁 

There are a few additional configuration options that I'm working on:

* `server_name` for `quiche::connect`. I extended `QuicBuilder` with `serverName()` API and passed given configuration into `QuicheQuicClientCodec` as a constructor argument that later goes into `QuicheQuicChannel.handleConnect`. This seems to be a reasonable approach.

* `logKeys()` configuration option using JNI call to `quiche_config_log_keys`

* `ChannelOption` to set `keylog_path`. This one is interesting/questionable. Quiche does not store `keylog_path` as a part of configuration, there's  a separate API how to setup it for a given pointer to connect (I've implemented JNI wrapper  for it). Apparently, the reason is that I can use different files for different connections 🤔 I created new `ChannelOption` for this setting and use it after `connect` gives me `connAddr`. I'm not sure that the same approach would work for the server as when we perform `accept` within `QuicheQuicServerCodec::handleServer` I don't think I have access to `ChannelOptions` that were set to the `Bootstrap` object. So... either I need to store this configuration as a part of codec rather than channel (but how can I setup different files  for different connections?), or apply this in `channelActive` (which seems to be too late?) @normanmaurer WDYT?