### PR TITLE
ChannelOption to identify peer cert server name for quiche::connect

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/DefaultQuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/DefaultQuicChannelConfig.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import java.util.Map;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.DefaultChannelConfig;
+
+/**
+ * A QUIC {@link ChannelConfig}.
+ */
+public class DefaultQuicChannelConfig extends DefaultChannelConfig implements QuicChannelConfig {
+
+    private String peerCertServerName;
+
+    public DefaultQuicChannelConfig(Channel channel) {
+        super(channel);
+    }
+
+    @Override
+    public Map<ChannelOption<?>, Object> getOptions() {
+        return getOptions(super.getOptions(), QuicChannelConfig.QUIC_PEER_CERT_SERVER_NAME);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getOption(ChannelOption<T> option) {
+        if (option == QuicChannelConfig.QUIC_PEER_CERT_SERVER_NAME) {
+            return (T) String.valueOf(getPeerCertServerName());
+        }
+
+        return super.getOption(option);
+    }
+
+    @Override
+    public <T> boolean setOption(ChannelOption<T> option, T value) {
+        validate(option, value);
+
+        if (option == QuicChannelConfig.QUIC_PEER_CERT_SERVER_NAME) {
+            setPeerCertServerName((String) value);
+        } else {
+            return super.setOption(option, value);
+        }
+
+        return true;
+    }
+
+    public String getPeerCertServerName() {
+        return peerCertServerName;
+    }
+
+    public DefaultQuicChannelConfig setPeerCertServerName(String peerCertServerName) {
+        this.peerCertServerName = peerCertServerName;
+        return this;
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/DefaultQuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/DefaultQuicChannelConfig.java
@@ -17,30 +17,38 @@ package io.netty.incubator.codec.quic;
 
 import java.util.Map;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultChannelConfig;
+import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.WriteBufferWaterMark;
 
 /**
  * A QUIC {@link ChannelConfig}.
  */
 public class DefaultQuicChannelConfig extends DefaultChannelConfig implements QuicChannelConfig {
 
+    /**
+     * Optional parameter to verify peer's certificate.
+     * See <a href="https://docs.rs/quiche/0.6.0/quiche/fn.connect.html">server_name</a>.
+     */
     private String peerCertServerName;
 
-    public DefaultQuicChannelConfig(Channel channel) {
+    DefaultQuicChannelConfig(Channel channel) {
         super(channel);
     }
 
     @Override
     public Map<ChannelOption<?>, Object> getOptions() {
-        return getOptions(super.getOptions(), QuicChannelConfig.QUIC_PEER_CERT_SERVER_NAME);
+        return getOptions(super.getOptions(), QuicChannelOption.PEER_CERT_SERVER_NAME);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public <T> T getOption(ChannelOption<T> option) {
-        if (option == QuicChannelConfig.QUIC_PEER_CERT_SERVER_NAME) {
+        if (option == QuicChannelOption.PEER_CERT_SERVER_NAME) {
             return (T) String.valueOf(getPeerCertServerName());
         }
 
@@ -51,7 +59,7 @@ public class DefaultQuicChannelConfig extends DefaultChannelConfig implements Qu
     public <T> boolean setOption(ChannelOption<T> option, T value) {
         validate(option, value);
 
-        if (option == QuicChannelConfig.QUIC_PEER_CERT_SERVER_NAME) {
+        if (option == QuicChannelOption.PEER_CERT_SERVER_NAME) {
             setPeerCertServerName((String) value);
         } else {
             return super.setOption(option, value);
@@ -60,10 +68,79 @@ public class DefaultQuicChannelConfig extends DefaultChannelConfig implements Qu
         return true;
     }
 
+    @Override
+    public DefaultQuicChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis) {
+        super.setConnectTimeoutMillis(connectTimeoutMillis);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public DefaultQuicChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead) {
+        super.setMaxMessagesPerRead(maxMessagesPerRead);
+        return this;
+    }
+
+    @Override
+    public DefaultQuicChannelConfig setWriteSpinCount(int writeSpinCount) {
+        super.setWriteSpinCount(writeSpinCount);
+        return this;
+    }
+
+    @Override
+    public DefaultQuicChannelConfig setAllocator(ByteBufAllocator allocator) {
+        super.setAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public DefaultQuicChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
+        super.setRecvByteBufAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public DefaultQuicChannelConfig setAutoRead(boolean autoRead) {
+        super.setAutoRead(autoRead);
+        return this;
+    }
+
+    @Override
+    public DefaultQuicChannelConfig setAutoClose(boolean autoClose) {
+        super.setAutoClose(autoClose);
+        return this;
+    }
+
+    @Override
+    public DefaultQuicChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
+        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
+        return this;
+    }
+
+    @Override
+    public DefaultQuicChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
+        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
+        return this;
+    }
+
+    @Override
+    public DefaultQuicChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
+        super.setWriteBufferWaterMark(writeBufferWaterMark);
+        return this;
+    }
+
+    @Override
+    public DefaultQuicChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
+        super.setMessageSizeEstimator(estimator);
+        return this;
+    }
+
+    @Override
     public String getPeerCertServerName() {
         return peerCertServerName;
     }
 
+    @Override
     public DefaultQuicChannelConfig setPeerCertServerName(String peerCertServerName) {
         this.peerCertServerName = peerCertServerName;
         return this;

--- a/src/main/java/io/netty/incubator/codec/quic/DefaultQuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/DefaultQuicChannelConfig.java
@@ -28,7 +28,7 @@ import io.netty.channel.WriteBufferWaterMark;
 /**
  * A QUIC {@link ChannelConfig}.
  */
-public class DefaultQuicChannelConfig extends DefaultChannelConfig implements QuicChannelConfig {
+final class DefaultQuicChannelConfig extends DefaultChannelConfig implements QuicChannelConfig {
 
     /**
      * Optional parameter to verify peer's certificate.

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -29,6 +29,12 @@ import io.netty.util.concurrent.Promise;
 public interface QuicChannel extends Channel {
 
     /**
+     * Returns the configuration of this channel.
+     */
+    @Override
+    QuicChannelConfig config();
+
+    /**
      * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Future} once done.
      * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} automatically.

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelOption;
+
+/**
+ * A QUIC {@link ChannelConfig}.
+ */
+public interface QuicChannelConfig extends ChannelConfig {
+
+    /**
+     * Optional parameter to verify peer's certificate.
+     * See <a href="https://docs.rs/quiche/0.6.0/quiche/fn.connect.html">server_name</a>.
+     */
+    ChannelOption<String> QUIC_PEER_CERT_SERVER_NAME = ChannelOption.valueOf("QUIC_PEER_CERT_SERVER_NAME");
+
+    String getPeerCertServerName();
+
+    ChannelConfig setPeerCertServerName(String peerCertServerName);
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelConfig.java
@@ -15,21 +15,61 @@
  */
 package io.netty.incubator.codec.quic;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelConfig;
-import io.netty.channel.ChannelOption;
+import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.WriteBufferWaterMark;
 
 /**
  * A QUIC {@link ChannelConfig}.
  */
 public interface QuicChannelConfig extends ChannelConfig {
 
-    /**
-     * Optional parameter to verify peer's certificate.
-     * See <a href="https://docs.rs/quiche/0.6.0/quiche/fn.connect.html">server_name</a>.
-     */
-    ChannelOption<String> QUIC_PEER_CERT_SERVER_NAME = ChannelOption.valueOf("QUIC_PEER_CERT_SERVER_NAME");
+    @Override
+    @Deprecated
+    QuicChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead);
 
+    @Override
+    QuicChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis);
+
+    @Override
+    QuicChannelConfig setWriteSpinCount(int writeSpinCount);
+
+    @Override
+    QuicChannelConfig setAllocator(ByteBufAllocator allocator);
+
+    @Override
+    QuicChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator);
+
+    @Override
+    QuicChannelConfig setAutoRead(boolean autoRead);
+
+    @Override
+    QuicChannelConfig setAutoClose(boolean autoClose);
+
+    @Override
+    QuicChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
+
+    @Override
+    QuicChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
+
+    @Override
+    QuicChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark);
+
+    @Override
+    QuicChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator);
+
+    /**
+     * Return the server name parameter used to verify peer's certificate.
+     */
     String getPeerCertServerName();
 
-    ChannelConfig setPeerCertServerName(String peerCertServerName);
+    /**
+     * Set set server name for peer's certificate verification.
+     *
+     * <strong>Be aware this config setting can only be adjusted before the
+     * connection is established.</strong>
+     */
+    QuicChannelConfig setPeerCertServerName(String peerCertServerName);
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelOption.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelOption.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.channel.ChannelOption;
+
+public final class QuicChannelOption<T> extends ChannelOption<T> {
+
+    /**
+     * Optional parameter to verify peer's certificate.
+     * See <a href="https://docs.rs/quiche/0.6.0/quiche/fn.connect.html">server_name</a>.
+     */
+    public static final ChannelOption<String> PEER_CERT_SERVER_NAME =
+        valueOf(QuicChannelOption.class, "PEER_CERT_SERVER_NAME");
+
+    @SuppressWarnings({ "deprecation" })
+    private QuicChannelOption() {
+        super(null);
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -206,7 +206,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         assert this.traceId == null;
         assert this.key == null;
         ByteBuf idBuffer = alloc().directBuffer(connectId.remaining()).writeBytes(connectId.duplicate());
-        final String serverName = config().getOption(QuicChannelConfig.QUIC_PEER_CERT_SERVER_NAME);
+        final String serverName = config().getOption(QuicChannelOption.PEER_CERT_SERVER_NAME);
         try {
             long connection = Quiche.quiche_connect(serverName, idBuffer.memoryAddress() + idBuffer.readerIndex(),
                     idBuffer.readableBytes(), configAddr);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
@@ -97,7 +96,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     // TODO: Consider using quiche_conn_stream_init_application_data(...) and quiche_conn_stream_application_data(...)
     private final LongObjectMap<QuicheQuicStreamChannel> streams = new LongObjectHashMap<>();
     private final Queue<Long> flushPendingQueue = new ArrayDeque<>();
-    private final ChannelConfig config;
+    private final QuicChannelConfig config;
     private final boolean server;
     private final QuicStreamIdGenerator idGenerator;
     private final ChannelHandler streamHandler;
@@ -436,7 +435,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     @Override
-    public ChannelConfig config() {
+    public QuicChannelConfig config() {
         return config;
     }
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -31,7 +31,6 @@ import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.ConnectTimeoutException;
-import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.DefaultChannelPipeline;
 import io.netty.channel.EventLoop;
 import io.netty.channel.socket.DatagramPacket;
@@ -171,7 +170,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                               Map.Entry<ChannelOption<?>, Object>[] streamOptionsArray,
                               Map.Entry<AttributeKey<?>, Object>[] streamAttrsArray) {
         super(parent);
-        config = new DefaultChannelConfig(this);
+        config = new DefaultQuicChannelConfig(this);
         this.server = server;
         this.idGenerator = new QuicStreamIdGenerator(server);
         this.key = key;
@@ -207,8 +206,9 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         assert this.traceId == null;
         assert this.key == null;
         ByteBuf idBuffer = alloc().directBuffer(connectId.remaining()).writeBytes(connectId.duplicate());
+        final String serverName = config().getOption(QuicChannelConfig.QUIC_PEER_CERT_SERVER_NAME);
         try {
-            long connection = Quiche.quiche_connect(null, idBuffer.memoryAddress() + idBuffer.readerIndex(),
+            long connection = Quiche.quiche_connect(serverName, idBuffer.memoryAddress() + idBuffer.readerIndex(),
                     idBuffer.readableBytes(), configAddr);
             if (connection == -1) {
                 ConnectException connectException = new ConnectException();

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -205,7 +205,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         assert this.traceId == null;
         assert this.key == null;
         ByteBuf idBuffer = alloc().directBuffer(connectId.remaining()).writeBytes(connectId.duplicate());
-        final String serverName = config().getOption(QuicChannelOption.PEER_CERT_SERVER_NAME);
+        final String serverName = config().getPeerCertServerName();
         try {
             long connection = Quiche.quiche_connect(serverName, idBuffer.memoryAddress() + idBuffer.readerIndex(),
                     idBuffer.readableBytes(), configAddr);


### PR DESCRIPTION
Motivation:

`quiche::connect` function takes an option `server_name` argument for peer's certificate verification. Previously was always set to NULL.

Modifications:

* Defines `QuicChannelConfig` to be used instead of default with additional `QUIC_PEER_CERT_SERVER_NAME` option
* When creating Quiche connection, uses `server_name` set into the config (if any)


Result:

Full coverage for `quiche::connect` arguments, fixes #16