### PR TITLE
Add QuicChannel.newStreamBootstrap()

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/Quic.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quic.java
@@ -18,6 +18,7 @@ package io.netty.incubator.codec.quic;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.util.AttributeKey;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 
@@ -153,6 +154,32 @@ public final class Quic {
         } catch (Throwable t) {
             logger.warn(
                     "Failed to set channel option '{}' with value '{}' for channel '{}'", option, value, channel, t);
+        }
+    }
+
+    /**
+     * Allow to specify a {@link ChannelOption} which is used for the {@link QuicStreamChannel} instances once they got
+     * created. Use a value of {@code null} to remove a previous set {@link ChannelOption}.
+     */
+    static <T> void updateOptions(Map<ChannelOption<?>, Object> options, ChannelOption<T> option, T value) {
+        ObjectUtil.checkNotNull(option, "option");
+        if (value == null) {
+            options.remove(option);
+        } else {
+            options.put(option, value);
+        }
+    }
+
+    /**
+     * Allow to specify an initial attribute of the newly created {@link QuicStreamChannel}. If the {@code value} is
+     * {@code null}, the attribute of the specified {@code key} is removed.
+     */
+    static <T> void updateAttributes(Map<AttributeKey<?>, Object> attributes, AttributeKey<T> key, T value) {
+        ObjectUtil.checkNotNull(key, "key");
+        if (value == null) {
+            attributes.remove(key);
+        } else {
+            attributes.put(key, value);
         }
     }
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -39,7 +39,9 @@ public interface QuicChannel extends Channel {
      * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} automatically.
      */
-    Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler);
+    default Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler) {
+        return createStream(type, handler, eventLoop().newPromise());
+    }
 
     /**
      * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Promise} once done.
@@ -48,6 +50,16 @@ public interface QuicChannel extends Channel {
      */
     Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler,
                                            Promise<QuicStreamChannel> promise);
+
+    /**
+     * Returns a new {@link QuicStreamChannelBootstrap} which makes it easy to bootstrap new {@link QuicStreamChannel}s
+     * with custom options and attributes. For simpler use-cases you may want to consider using
+     * {@link #createStream(QuicStreamType, ChannelHandler)} or
+     * {@link #createStream(QuicStreamType, ChannelHandler, Promise)} directly.
+     */
+    default QuicStreamChannelBootstrap newStreamBootstrap() {
+        return new QuicStreamChannelBootstrap(this);
+    }
 
     /**
      * Returns the negotiated ALPN protocol or {@code null} if none has been negotiated.
@@ -63,7 +75,9 @@ public interface QuicChannel extends Channel {
      * @param reason            the reason for the closure (which may be an empty {@link ByteBuf}.
      * @return                  the future that is notified.
      */
-    ChannelFuture close(boolean applicationClose, int error, ByteBuf reason);
+    default ChannelFuture close(boolean applicationClose, int error, ByteBuf reason) {
+        return close(applicationClose, error, reason, newPromise());
+    }
 
     /**
      * Close the {@link QuicChannel}
@@ -80,7 +94,9 @@ public interface QuicChannel extends Channel {
     /**
      * Collects statistics about the connection and notifies the {@link Future} once done.
      */
-    Future<QuicConnectionStats> collectStats();
+    default Future<QuicConnectionStats> collectStats() {
+        return collectStats(eventLoop().newPromise());
+    }
 
     /**
      * Collects statistics about the connection and notifies the {@link Promise} once done.

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
@@ -41,9 +41,9 @@ public final class QuicChannelBootstrap {
     private final Channel parent;
     // The order in which ChannelOptions are applied is important they may depend on each other for validation
     // purposes.
-    private final Map<ChannelOption<?>, Object> options = new LinkedHashMap<ChannelOption<?>, Object>();
-    private final Map<AttributeKey<?>, Object> attrs = new HashMap<AttributeKey<?>, Object>();
-    private final Map<ChannelOption<?>, Object> streamOptions = new LinkedHashMap<ChannelOption<?>, Object>();
+    private final Map<ChannelOption<?>, Object> options = new LinkedHashMap<>();
+    private final Map<AttributeKey<?>, Object> attrs = new HashMap<>();
+    private final Map<ChannelOption<?>, Object> streamOptions = new LinkedHashMap<>();
     private final Map<AttributeKey<?>, Object> streamAttrs = new HashMap<>();
     private ChannelHandler handler;
     private ChannelHandler streamHandler;
@@ -62,12 +62,7 @@ public final class QuicChannelBootstrap {
      * created. Use a value of {@code null} to remove a previous set {@link ChannelOption}.
      */
     public <T> QuicChannelBootstrap option(ChannelOption<T> option, T value) {
-        ObjectUtil.checkNotNull(option, "option");
-        if (value == null) {
-            options.remove(option);
-        } else {
-            options.put(option, value);
-        }
+        Quic.updateOptions(options, option, value);
         return this;
     }
 
@@ -76,12 +71,7 @@ public final class QuicChannelBootstrap {
      * {@code null}, the attribute of the specified {@code key} is removed.
      */
     public <T> QuicChannelBootstrap attr(AttributeKey<T> key, T value) {
-        ObjectUtil.checkNotNull(key, "key");
-        if (value == null) {
-            attrs.remove(key);
-        } else {
-            attrs.put(key, value);
-        }
+        Quic.updateAttributes(attrs, key, value);
         return this;
     }
 
@@ -99,12 +89,7 @@ public final class QuicChannelBootstrap {
      * created. Use a value of {@code null} to remove a previous set {@link ChannelOption}.
      */
     public <T> QuicChannelBootstrap streamOption(ChannelOption<T> option, T value) {
-        ObjectUtil.checkNotNull(option, "option");
-        if (value == null) {
-            streamOptions.remove(option);
-        } else {
-            streamOptions.put(option, value);
-        }
+        Quic.updateOptions(streamOptions, option, value);
         return this;
     }
 
@@ -113,12 +98,7 @@ public final class QuicChannelBootstrap {
      * {@code null}, the attribute of the specified {@code key} is removed.
      */
     public <T> QuicChannelBootstrap streamAttr(AttributeKey<T> key, T value) {
-        ObjectUtil.checkNotNull(key, "key");
-        if (value == null) {
-            streamAttrs.remove(key);
-        } else {
-            streamAttrs.put(key, value);
-        }
+        Quic.updateAttributes(streamAttrs, key, value);
         return this;
     }
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -46,12 +46,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
      * created. Use a value of {@code null} to remove a previous set {@link ChannelOption}.
      */
     public <T> QuicServerCodecBuilder option(ChannelOption<T> option, T value) {
-        ObjectUtil.checkNotNull(option, "option");
-        if (value == null) {
-            options.remove(option);
-        } else {
-            options.put(option, value);
-        }
+        Quic.updateOptions(options, option, value);
         return self();
     }
 
@@ -60,12 +55,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
      * {@code null}, the attribute of the specified {@code key} is removed.
      */
     public <T> QuicServerCodecBuilder attr(AttributeKey<T> key, T value) {
-        ObjectUtil.checkNotNull(key, "key");
-        if (value == null) {
-            attrs.remove(key);
-        } else {
-            attrs.put(key, value);
-        }
+        Quic.updateAttributes(attrs, key, value);
         return self();
     }
 
@@ -83,12 +73,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
      * created. Use a value of {@code null} to remove a previous set {@link ChannelOption}.
      */
     public <T> QuicServerCodecBuilder streamOption(ChannelOption<T> option, T value) {
-        ObjectUtil.checkNotNull(option, "option");
-        if (value == null) {
-            streamOptions.remove(option);
-        } else {
-            streamOptions.put(option, value);
-        }
+        Quic.updateOptions(streamOptions, option, value);
         return self();
     }
 
@@ -97,12 +82,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
      * {@code null}, the attribute of the specified {@code key} is removed.
      */
     public <T> QuicServerCodecBuilder streamAttr(AttributeKey<T> key, T value) {
-        ObjectUtil.checkNotNull(key, "key");
-        if (value == null) {
-            streamAttrs.remove(key);
-        } else {
-            streamAttrs.put(key, value);
-        }
+        Quic.updateAttributes(streamAttrs, key, value);
         return self();
     }
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelBootstrap.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelBootstrap.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Allows to bootstrap outgoing {@link QuicStreamChannel}s.
+ */
+public final class QuicStreamChannelBootstrap {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(QuicStreamChannelBootstrap.class);
+
+    private final QuicChannel parent;
+    private final Map<ChannelOption<?>, Object> options = new LinkedHashMap<>();
+    private final Map<AttributeKey<?>, Object> attrs = new HashMap<>();
+    private ChannelHandler handler;
+    private QuicStreamType type = QuicStreamType.BIDIRECTIONAL;
+
+    /**
+     * Creates a new instance which uses the given {@link Channel} to bootstrap the {@link QuicChannel}.
+     * This {@link io.netty.channel.ChannelPipeline} of the {@link Channel} needs to have the quic codec in the
+     * pipeline.
+     */
+    QuicStreamChannelBootstrap(QuicChannel parent) {
+        this.parent = ObjectUtil.checkNotNull(parent, "parent");
+    }
+
+    /**
+     * Allow to specify a {@link ChannelOption} which is used for the {@link QuicStreamChannel} instances once they got
+     * created. Use a value of {@code null} to remove a previous set {@link ChannelOption}.
+     */
+    public <T> QuicStreamChannelBootstrap option(ChannelOption<T> option, T value) {
+        Quic.updateOptions(options, option, value);
+        return this;
+    }
+
+    /**
+     * Allow to specify an initial attribute of the newly created {@link QuicStreamChannel}. If the {@code value} is
+     * {@code null}, the attribute of the specified {@code key} is removed.
+     */
+    public <T> QuicStreamChannelBootstrap attr(AttributeKey<T> key, T value) {
+        Quic.updateAttributes(attrs, key, value);
+        return this;
+    }
+
+    /**
+     * Set the {@link ChannelHandler} that is added to the {@link io.netty.channel.ChannelPipeline} of the
+     * {@link QuicStreamChannel} once created.
+     */
+    public QuicStreamChannelBootstrap handler(ChannelHandler streamHandler) {
+        this.handler = ObjectUtil.checkNotNull(streamHandler, "streamHandler");
+        return this;
+    }
+
+    /**
+     * Set the {@link QuicStreamType} to use for the {@link QuicStreamChannel}, default is
+     * {@link QuicStreamType#BIDIRECTIONAL}.
+     */
+    public QuicStreamChannelBootstrap type(QuicStreamType type) {
+        this.type = ObjectUtil.checkNotNull(type, "type");
+        return this;
+    }
+
+    /**
+     * Creates a new {@link QuicStreamChannel} and notifies the {@link Future}.
+     */
+    public Future<QuicStreamChannel> create() {
+        return create(parent.eventLoop().newPromise());
+    }
+
+    /**
+     * Creates a new {@link QuicStreamChannel} and notifies the {@link Future}.
+     */
+    public Future<QuicStreamChannel> create(Promise<QuicStreamChannel> promise) {
+        if (handler == null) {
+            throw new IllegalStateException("streamHandler not set");
+        }
+
+        return parent.createStream(type, new QuicStreamChannelBootstrapHandler(handler,
+                Quic.optionsArray(options), Quic.attributesArray(attrs)), promise);
+    }
+
+    private static final class QuicStreamChannelBootstrapHandler extends ChannelInitializer<QuicStreamChannel> {
+        private final ChannelHandler streamHandler;
+        private final Map.Entry<ChannelOption<?>, Object>[] streamOptions;
+        private final Map.Entry<AttributeKey<?>, Object>[] streamAttrs;
+
+        QuicStreamChannelBootstrapHandler(ChannelHandler streamHandler,
+                                          Map.Entry<ChannelOption<?>, Object>[] streamOptions,
+                                          Map.Entry<AttributeKey<?>, Object>[] streamAttrs) {
+            this.streamHandler = streamHandler;
+            this.streamOptions = streamOptions;
+            this.streamAttrs = streamAttrs;
+        }
+        @Override
+        protected void initChannel(QuicStreamChannel ch) {
+            Quic.setChannelOptions(ch, streamOptions, logger);
+            Quic.setAttributes(ch, streamAttrs);
+            ch.pipeline().addLast(streamHandler);
+        }
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelBootstrap.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelBootstrap.java
@@ -43,9 +43,7 @@ public final class QuicStreamChannelBootstrap {
     private QuicStreamType type = QuicStreamType.BIDIRECTIONAL;
 
     /**
-     * Creates a new instance which uses the given {@link Channel} to bootstrap the {@link QuicChannel}.
-     * This {@link io.netty.channel.ChannelPipeline} of the {@link Channel} needs to have the quic codec in the
-     * pipeline.
+     * Creates a new instance which uses the given {@link QuicChannel} to bootstrap {@link QuicStreamChannel}s.
      */
     QuicStreamChannelBootstrap(QuicChannel parent) {
         this.parent = ObjectUtil.checkNotNull(parent, "parent");

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -298,11 +298,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     @Override
-    public Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler) {
-        return createStream(type, handler, eventLoop().newPromise());
-    }
-
-    @Override
     public Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler,
                                                   Promise<QuicStreamChannel> promise) {
         if (eventLoop().inEventLoop()) {
@@ -324,11 +319,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             return null;
         }
         return Quiche.quiche_conn_application_proto(connAddr);
-    }
-
-    @Override
-    public ChannelFuture close(boolean applicationClose, int error, ByteBuf reason) {
-        return close(applicationClose, error, reason, newPromise());
     }
 
     @Override
@@ -1009,11 +999,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         QuicheQuicChannelAddress(QuicheQuicChannel channel) {
             this.channel = channel;
         }
-    }
-
-    @Override
-    public Future<QuicConnectionStats> collectStats() {
-        return collectStats(eventLoop().newPromise());
     }
 
     @Override

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOption;
+import io.netty.util.AttributeKey;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class QuicStreamChannelCreationTest {
+
+    private static final AttributeKey<String> ATTRIBUTE_KEY = AttributeKey.newInstance("testKey");
+    private static final String ATTRIBUTE_VALUE = "Test";
+
+    @Test
+    public void testCreateStream() throws Throwable {
+        Channel server = QuicTestUtils.newServer(new ChannelInboundHandlerAdapter(),
+                new ChannelInboundHandlerAdapter());
+        InetSocketAddress address = (InetSocketAddress) server.localAddress();
+        ChannelFuture future = null;
+        try {
+            future = QuicTestUtils.newChannelBuilder(new ChannelInboundHandlerAdapter(), null)
+                    .connect(QuicConnectionAddress.random(address)).sync();
+            assertTrue(future.await().isSuccess());
+
+            QuicChannel channel = (QuicChannel) future.channel();
+            CountDownLatch latch = new CountDownLatch(1);
+            QuicStreamChannel stream = channel.createStream(QuicStreamType.UNIDIRECTIONAL,
+                    new ChannelInboundHandlerAdapter() {
+               @Override
+               public void channelRegistered(ChannelHandlerContext ctx) {
+                   assertQuicStreamChannel((QuicStreamChannel) ctx.channel(),
+                           QuicStreamType.UNIDIRECTIONAL, Boolean.TRUE, null);
+                   latch.countDown();
+               }
+            }).sync().get();
+            assertQuicStreamChannel(stream, QuicStreamType.UNIDIRECTIONAL, Boolean.TRUE, null);
+            latch.await();
+            stream.close().sync();
+        } finally {
+            server.close().syncUninterruptibly();
+            // Close the parent Datagram channel as well.
+            QuicTestUtils.closeParent(future);
+        }
+    }
+
+    @Test
+    public void testCreateStreamViaBootstrap() throws Throwable {
+        Channel server = QuicTestUtils.newServer(new ChannelInboundHandlerAdapter(),
+                new ChannelInboundHandlerAdapter());
+        InetSocketAddress address = (InetSocketAddress) server.localAddress();
+        ChannelFuture future = null;
+        try {
+            future = QuicTestUtils.newChannelBuilder(new ChannelInboundHandlerAdapter(), null)
+                    .connect(QuicConnectionAddress.random(address)).sync();
+            assertTrue(future.await().isSuccess());
+
+            QuicChannel channel = (QuicChannel) future.channel();
+            CountDownLatch latch = new CountDownLatch(1);
+            QuicStreamChannel stream = channel.newStreamBootstrap()
+                    .type(QuicStreamType.UNIDIRECTIONAL)
+                    .attr(ATTRIBUTE_KEY, ATTRIBUTE_VALUE)
+                    .option(ChannelOption.AUTO_READ,  Boolean.FALSE)
+                    .handler(new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void channelRegistered(ChannelHandlerContext ctx) {
+                            assertQuicStreamChannel((QuicStreamChannel) ctx.channel(),
+                                    QuicStreamType.UNIDIRECTIONAL, Boolean.FALSE, ATTRIBUTE_VALUE);
+                            latch.countDown();
+                        }
+                    }).create().sync().get();
+            assertQuicStreamChannel(stream, QuicStreamType.UNIDIRECTIONAL, Boolean.FALSE, ATTRIBUTE_VALUE);
+            latch.await();
+            stream.close().sync();
+        } finally {
+            server.close().syncUninterruptibly();
+            // Close the parent Datagram channel as well.
+            QuicTestUtils.closeParent(future);
+        }
+    }
+
+    private static void assertQuicStreamChannel(QuicStreamChannel channel, QuicStreamType expectedType,
+                                                Boolean expectedAutoRead, String expectedAttribute) {
+        assertEquals(expectedType, channel.type());
+        assertEquals(expectedAutoRead, channel.config().getOption(ChannelOption.AUTO_READ));
+        assertEquals(expectedAttribute, channel.attr(ATTRIBUTE_KEY).get());
+    }
+}


### PR DESCRIPTION
Motivation:

Sometimes a user may need a bit more flexibility when creating streams.

Modifications:
- Introduce QuicChannel.newStreamBootstrap() which returns a QuicStreamChannelBootstrap that allows more flexibility.
- Share some more code
- Add testcases
- Use default methods for some cases

Result:

More flexibility when creating streams without the need for the user to create boilerplate code.