### PR TITLE
Make the usage of QuicConnectionAddress optional

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicConnectionAddress.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicConnectionAddress.java
@@ -15,7 +15,6 @@
  */
 package io.netty.incubator.codec.quic;
 
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Objects;
@@ -27,45 +26,39 @@ public final class QuicConnectionAddress extends SocketAddress {
 
     // Accessed by QuicheQuicheChannel
     final ByteBuffer connId;
-    final InetSocketAddress remote;
 
     /**
      * Create a new instance
      *
      * @param connId the connection id to use.
-     * @param remote the remote address of the host to talk to.
      */
-    public QuicConnectionAddress(byte[] connId, InetSocketAddress remote) {
-        this(ByteBuffer.wrap(connId.clone()), remote);
+    public QuicConnectionAddress(byte[] connId) {
+        this(ByteBuffer.wrap(connId.clone()));
     }
 
     /**
      * Create a new instance
      *
      * @param connId the connection id to use.
-     * @param remote the remote address of the host to talk to.
      */
-    public QuicConnectionAddress(ByteBuffer connId, InetSocketAddress remote) {
+    public QuicConnectionAddress(ByteBuffer connId) {
         Quic.ensureAvailability();
         if (connId.remaining() > Quiche.QUICHE_MAX_CONN_ID_LEN) {
             throw new IllegalArgumentException("Connection ID can only be of max length "
                     + Quiche.QUICHE_MAX_CONN_ID_LEN);
         }
         this.connId = connId;
-        this.remote = Objects.requireNonNull(remote, "remote");
     }
 
     @Override
     public String toString() {
         return "QuicConnectionAddress{" +
-                "connId=" + connId +
-                ", remote=" + remote +
-                '}';
+                "connId=" + connId + '}';
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(connId, remote);
+        return Objects.hash(connId);
     }
 
     @Override
@@ -74,17 +67,14 @@ public final class QuicConnectionAddress extends SocketAddress {
             return false;
         }
         QuicConnectionAddress address = (QuicConnectionAddress) obj;
-        if (!connId.equals(address.connId)) {
-            return false;
-        }
-        return Objects.equals(remote, address.remote);
+        return connId.equals(address.connId);
     }
 
     /**
      * Return a random generated {@link QuicConnectionAddress} that connects the {@link QuicChannel} to the given
      * remote address.
      */
-    public static QuicConnectionAddress random(InetSocketAddress remote) {
-        return new QuicConnectionAddress(Quic.randomGenerator().newId(), remote);
+    public static QuicConnectionAddress random() {
+        return new QuicConnectionAddress(Quic.randomGenerator().newId());
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -103,6 +103,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private final Map.Entry<ChannelOption<?>, Object>[] streamOptionsArray;
     private final Map.Entry<AttributeKey<?>, Object>[] streamAttrsArray;
     private final TimeoutHandler timeoutHandler = new TimeoutHandler();
+    private final InetSocketAddress remote;
 
     private long connAddr;
     private boolean inFireChannelReadCompleteQueue;
@@ -121,7 +122,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private static final int ACTIVE = 2;
     private volatile int state;
     private volatile String traceId;
-    private volatile InetSocketAddress remote;
 
     private QuicheQuicChannel(Channel parent, boolean server, ByteBuffer key, long connAddr, String traceId,
                       InetSocketAddress remote, ChannelHandler streamHandler,
@@ -142,11 +142,11 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         this.streamAttrsArray = streamAttrsArray;
     }
 
-    static QuicheQuicChannel forClient(Channel parent, ChannelHandler streamHandler,
+    static QuicheQuicChannel forClient(Channel parent, InetSocketAddress remote, ChannelHandler streamHandler,
                                        Map.Entry<ChannelOption<?>, Object>[] streamOptionsArray,
                                        Map.Entry<AttributeKey<?>, Object>[] streamAttrsArray) {
         return new QuicheQuicChannel(parent, false, null,
-                -1, null, (InetSocketAddress) parent.remoteAddress(), streamHandler,
+                -1, null, remote, streamHandler,
                 streamOptionsArray, streamAttrsArray);
     }
 
@@ -740,9 +740,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 QuicConnectionAddress address = (QuicConnectionAddress) remote;
                 connectPromise = channelPromise;
                 connectId = address.connId.duplicate();
-                if (address.remote != null) {
-                    QuicheQuicChannel.this.remote = address.remote;
-                }
 
                 // Schedule connect timeout.
                 int connectTimeoutMillis = config().getConnectTimeoutMillis();

--- a/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -48,7 +48,8 @@ public class QuicChannelConnectTest {
             ChannelStateVerifyHandler verifyHandler = new ChannelStateVerifyHandler();
             future = QuicTestUtils.newChannelBuilder(verifyHandler, null)
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10)
-                    .connect(QuicConnectionAddress.random((InetSocketAddress) socket.getLocalSocketAddress()));
+                    .remoteAddress(socket.getLocalSocketAddress())
+                    .connect();
             Throwable cause = future.await().cause();
             assertThat(cause, CoreMatchers.instanceOf(ConnectTimeoutException.class));
             ChannelFuture closeFuture = future.channel().closeFuture().await();
@@ -72,11 +73,11 @@ public class QuicChannelConnectTest {
         try {
             ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
             future = QuicTestUtils.newChannelBuilder(clientQuicChannelHandler, null)
-                    .connect(QuicConnectionAddress.random(address));
+                    .remoteAddress(address).connect();
             assertTrue(future.await().isSuccess());
 
             // Try to connect again
-            ChannelFuture connectFuture = future.channel().connect(QuicConnectionAddress.random(address));
+            ChannelFuture connectFuture = future.channel().connect(QuicConnectionAddress.random());
             Throwable cause = connectFuture.await().cause();
             assertThat(cause, CoreMatchers.instanceOf(AlreadyConnectedException.class));
             assertTrue(future.channel().close().await().isSuccess());
@@ -120,7 +121,7 @@ public class QuicChannelConnectTest {
         try {
             ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
             future = QuicTestUtils.newChannelBuilder(clientQuicChannelHandler, null)
-                    .connect(QuicConnectionAddress.random(address));
+                    .remoteAddress(address).connect();
             assertTrue(future.await().isSuccess());
 
             assertTrue(future.channel().close().await().isSuccess());

--- a/src/test/java/io/netty/incubator/codec/quic/QuicChannelEchoTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicChannelEchoTest.java
@@ -102,8 +102,8 @@ public class QuicChannelEchoTest {
         setAllocator(server);
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
         try {
-            future = QuicTestUtils.newChannelBuilder(new ChannelInboundHandlerAdapter(), ch)
-                    .connect(QuicConnectionAddress.random(address));
+            future = QuicTestUtils.newChannelBuilder(new ChannelInboundHandlerAdapter(), ch).remoteAddress(address)
+                    .connect();
             assertTrue(future.await().isSuccess());
             setAllocator(future.channel());
 
@@ -156,8 +156,8 @@ public class QuicChannelEchoTest {
         setAllocator(server);
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
         try {
-            future = QuicTestUtils.newChannelBuilder(new ChannelInboundHandlerAdapter(), null)
-                    .connect(QuicConnectionAddress.random(address));
+            future = QuicTestUtils.newChannelBuilder(new ChannelInboundHandlerAdapter(), null).
+                    remoteAddress(address).connect();
             assertTrue(future.await().isSuccess());
 
             QuicChannel channel = (QuicChannel) future.channel();

--- a/src/test/java/io/netty/incubator/codec/quic/QuicClientExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicClientExample.java
@@ -71,8 +71,8 @@ public final class QuicClientExample {
                             // stream and so send a fin.
                             ctx.close();
                         }
-                    }).connect(QuicConnectionAddress.random(
-                            new InetSocketAddress(NetUtil.LOCALHOST4, 9999))).sync().channel();
+                    }).remoteAddress(new InetSocketAddress(NetUtil.LOCALHOST4, 9999)).
+                            connect().sync().channel();
 
             QuicStreamChannel streamChannel = quicChannel.createStream(QuicStreamType.BIDIRECTIONAL,
                     new ChannelInboundHandlerAdapter() {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicConnectionAddressTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicConnectionAddressTest.java
@@ -17,7 +17,6 @@ package io.netty.incubator.codec.quic;
 
 import org.junit.Test;
 
-import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -26,23 +25,21 @@ import static org.junit.Assert.assertNotEquals;
 
 public class QuicConnectionAddressTest {
 
-    private static final InetSocketAddress ADDRESS = new InetSocketAddress(0);
-
     @Test(expected = NullPointerException.class)
     public void testNullByteArray() {
-        new QuicConnectionAddress((byte[]) null, ADDRESS);
+        new QuicConnectionAddress((byte[]) null);
     }
 
     @Test(expected = NullPointerException.class)
     public void testNullByteBuffer() {
-        new QuicConnectionAddress((ByteBuffer) null, ADDRESS);
+        new QuicConnectionAddress((ByteBuffer) null);
     }
 
     @Test
     public void testByteArrayIsCloned() {
         byte[] bytes = new byte[8];
         ThreadLocalRandom.current().nextBytes(bytes);
-        QuicConnectionAddress address = new QuicConnectionAddress(bytes, ADDRESS);
+        QuicConnectionAddress address = new QuicConnectionAddress(bytes);
         assertEquals(ByteBuffer.wrap(bytes), address.connId);
         ThreadLocalRandom.current().nextBytes(bytes);
         assertNotEquals(ByteBuffer.wrap(bytes), address.connId);
@@ -53,7 +50,7 @@ public class QuicConnectionAddressTest {
         byte[] bytes = new byte[8];
         ThreadLocalRandom.current().nextBytes(bytes);
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
-        QuicConnectionAddress address = new QuicConnectionAddress(bytes, ADDRESS);
+        QuicConnectionAddress address = new QuicConnectionAddress(bytes);
         assertEquals(buffer, address.connId);
         buffer.position(1);
         assertNotEquals(buffer, address.connId);

--- a/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
@@ -25,7 +25,6 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import org.junit.Test;
 
-import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -82,7 +81,7 @@ public class QuicConnectionStatsTest {
             });
 
             client = (QuicChannel) QuicTestUtils.newChannelBuilder(new ChannelInboundHandlerAdapter(), null)
-                    .connect(QuicConnectionAddress.random((InetSocketAddress) server.localAddress())).sync().channel();
+                    .remoteAddress(server.localAddress()).connect().sync().channel();
             assertNotNull(client.collectStats().sync().getNow());
             client.createStream(QuicStreamType.BIDIRECTIONAL, new ChannelInboundHandlerAdapter() {
                 private final int bufferSize = 8;

--- a/src/test/java/io/netty/incubator/codec/quic/QuicReadableTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicReadableTest.java
@@ -87,7 +87,7 @@ public class QuicReadableTest {
         ChannelFuture future = null;
         try {
             future = QuicTestUtils.newChannelBuilder(new ChannelInboundHandlerAdapter(), null)
-                    .connect(QuicConnectionAddress.random(address));
+                    .remoteAddress(server.localAddress()).connect();
             assertTrue(future.await().isSuccess());
             QuicChannel channel = (QuicChannel) future.channel();
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
@@ -44,9 +44,10 @@ public class QuicStreamChannelCloseTest {
         try {
             server = QuicTestUtils.newServer(new StreamCreationHandler(type),
                     new ChannelInboundHandlerAdapter());
-            client = (QuicChannel) QuicTestUtils.newChannelBuilder(new ChannelInboundHandlerAdapter(),
-                    new StreamHandler()).connect(
-                            QuicConnectionAddress.random((InetSocketAddress) server.localAddress())).sync().channel();
+            client = (QuicChannel) QuicTestUtils.newChannelBuilder(
+                    new ChannelInboundHandlerAdapter(), new StreamHandler())
+                    .remoteAddress(server.localAddress())
+                    .connect().sync().channel();
 
             // Wait till the client was closed
             client.closeFuture().sync();
@@ -74,7 +75,8 @@ public class QuicStreamChannelCloseTest {
         try {
             server = QuicTestUtils.newServer(null, new StreamHandler());
             client = (QuicChannel) QuicTestUtils.newChannelBuilder(new StreamCreationHandler(type), null)
-                    .connect(QuicConnectionAddress.random((InetSocketAddress) server.localAddress())).sync().channel();
+                    .remoteAddress(server.localAddress())
+                    .connect().sync().channel();
 
             // Close stream and quic channel
             client.closeFuture().sync();

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
@@ -42,7 +42,8 @@ public class QuicStreamChannelCreationTest {
         ChannelFuture future = null;
         try {
             future = QuicTestUtils.newChannelBuilder(new ChannelInboundHandlerAdapter(), null)
-                    .connect(QuicConnectionAddress.random(address)).sync();
+                    .remoteAddress(address)
+                    .connect().sync();
             assertTrue(future.await().isSuccess());
 
             QuicChannel channel = (QuicChannel) future.channel();
@@ -74,7 +75,8 @@ public class QuicStreamChannelCreationTest {
         ChannelFuture future = null;
         try {
             future = QuicTestUtils.newChannelBuilder(new ChannelInboundHandlerAdapter(), null)
-                    .connect(QuicConnectionAddress.random(address)).sync();
+                    .remoteAddress(address)
+                    .connect().sync();
             assertTrue(future.await().isSuccess());
 
             QuicChannel channel = (QuicChannel) future.channel();

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
@@ -60,7 +60,8 @@ public class QuicStreamLimitTest {
         try {
             future = QuicTestUtils.newChannelBuilder(
                     new ChannelInboundHandlerAdapter(), null)
-                    .connect(QuicConnectionAddress.random(address));
+                    .remoteAddress(address)
+                    .connect();
             assertTrue(future.await().isSuccess());
             QuicChannel channel = (QuicChannel) future.channel();
             QuicStreamChannel stream = channel.createStream(
@@ -130,10 +131,11 @@ public class QuicStreamLimitTest {
         ChannelFuture future = null;
         try {
             future = QuicTestUtils.newChannelBuilder(QuicTestUtils.newQuicClientBuilder()
-                    .initialMaxStreamsBidirectional(1).initialMaxStreamsUnidirectional(1)).handler(
-                            new ChannelInboundHandlerAdapter())
-                    .streamHandler(
-                            new ChannelInboundHandlerAdapter()).connect(QuicConnectionAddress.random(address));
+                    .initialMaxStreamsBidirectional(1).initialMaxStreamsUnidirectional(1))
+                    .handler(new ChannelInboundHandlerAdapter())
+                    .streamHandler(new ChannelInboundHandlerAdapter())
+                    .remoteAddress(address)
+                    .connect();
             assertTrue(future.await().isSuccess());
 
             streamPromise.sync();

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
@@ -25,8 +25,6 @@ import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
 import org.junit.Test;
 
-import java.net.InetSocketAddress;
-
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -58,7 +56,8 @@ public class QuicStreamTypeTest {
             });
 
             client = (QuicChannel) QuicTestUtils.newChannelBuilder(new ChannelInboundHandlerAdapter(), null)
-                    .connect(QuicConnectionAddress.random((InetSocketAddress) server.localAddress())).sync().channel();
+                    .remoteAddress(server.localAddress())
+                    .connect().sync().channel();
             QuicStreamChannel streamChannel = client.createStream(
                     QuicStreamType.UNIDIRECTIONAL, new ChannelInboundHandlerAdapter()).get();
             // Do the write which should succeed
@@ -120,7 +119,8 @@ public class QuicStreamTypeTest {
                     // Let's close the stream
                     ctx.close();
                 }
-            }).connect(QuicConnectionAddress.random((InetSocketAddress) server.localAddress())).sync().channel();
+            }).remoteAddress(server.localAddress())
+                    .connect().sync().channel();
 
             // Close stream and quic channel
             client.closeFuture().sync();

--- a/src/test/java/io/netty/incubator/codec/quic/QuicWritableTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicWritableTest.java
@@ -78,7 +78,8 @@ public class QuicWritableTest {
                     .initialMaxStreamDataBidirectionalLocal(bufferSize / 4))
                     .handler(new ChannelInboundHandlerAdapter())
                     .streamHandler(new ChannelInboundHandlerAdapter())
-                    .connect(QuicConnectionAddress.random(address));
+                    .remoteAddress(address)
+                    .connect();
             assertTrue(future.await().isSuccess());
             QuicChannel channel = (QuicChannel) future.channel();
             QuicStreamChannel stream = channel.createStream(


### PR DESCRIPTION
Motivation:

Most people should not need to worry about generating a QuicConnectionAddress at all and should just use the default implementation that we provide. Beside this it should be easier to use a connected Channel as transport layer.

Modification:

- Remove constructor and static method that takes InetSocketAddress as argument in QuicConnectionAddress.
- Add methods to QuicChannelBootstrap that allow to specify the remoteAddress (InetSocketAddress) and the connectionAddress(QuicConnectionAddress)
- If the remoteAddress is not configured try to obtain it from the parent Channel and so make it easier to use a connected Channel as transport
- if the connectionAddress is not configured generated a new random one
- Adjust tests / examples for new api

Result:

Less boilerplate code for most users and also more flexibility