### PR TITLE
Let QuicChannelBootstrap.connect() return a Future<QuicChannel>

### DIFF
--- a/src/test/java/io/netty/incubator/codec/quic/QuicClientExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicClientExample.java
@@ -63,7 +63,7 @@ public final class QuicClientExample {
                     .handler(codec)
                     .bind(0).sync().channel();
 
-            QuicChannel quicChannel = (QuicChannel) QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
                     .streamHandler(new ChannelInboundHandlerAdapter() {
                         @Override
                         public void channelActive(ChannelHandlerContext ctx) {
@@ -71,8 +71,10 @@ public final class QuicClientExample {
                             // stream and so send a fin.
                             ctx.close();
                         }
-                    }).remoteAddress(new InetSocketAddress(NetUtil.LOCALHOST4, 9999)).
-                            connect().sync().channel();
+                    })
+                    .remoteAddress(new InetSocketAddress(NetUtil.LOCALHOST4, 9999))
+                    .connect()
+                    .get();
 
             QuicStreamChannel streamChannel = quicChannel.createStream(QuicStreamType.BIDIRECTIONAL,
                     new ChannelInboundHandlerAdapter() {


### PR DESCRIPTION
Motivation:

QuicStreamChannelBootstrap.create() returns a Future<QuicStreamChannel> which allows to use the channel without casting. We should do the same for QuicChannelBootstrap

Modifications:

- Change return type of QuicChannelBootstrap.connect() and add overload that takes Promise<QuicChannel>
- Adjust tests / examples for new API

Result:

More consistent API and also less casting by the user needed.