### PR TITLE
Delay creation of native configuration until handler is added to the …

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
@@ -24,7 +24,7 @@ import io.netty.channel.ChannelHandler;
 public final class QuicClientCodecBuilder extends QuicCodecBuilder<QuicClientCodecBuilder> {
 
     @Override
-    protected ChannelHandler build(long config) {
+    protected ChannelHandler build(QuicheConfig config) {
         return new QuicheQuicClientCodec(config);
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -225,6 +225,15 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
         return self();
     }
 
+    private QuicheConfig createConfig() {
+        return new QuicheConfig(certPath, keyPath, verifyPeer, grease, earlyData,
+                protos, maxIdleTimeout, maxUdpPayloadSize, initialMaxData,
+                initialMaxStreamDataBidiLocal, initialMaxStreamDataBidiRemote,
+                initialMaxStreamDataUni, initialMaxStreamsBidi, initialMaxStreamsUni,
+                ackDelayExponent, maxAckDelay, disableActiveMigration, enableHystart,
+                congestionControlAlgorithm);
+    }
+
     /**
      * Validate the configuration before building the codec.
      */
@@ -239,85 +248,5 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
         return build(createConfig());
     }
 
-    protected abstract ChannelHandler build(long config);
-
-    /**
-     * Creates the native config object and return it.
-     */
-    private long createConfig() {
-        long config = Quiche.quiche_config_new(Quiche.QUICHE_PROTOCOL_VERSION);
-        try {
-            if (certPath != null && Quiche.quiche_config_load_cert_chain_from_pem_file(config, certPath) != 0) {
-                throw new IllegalArgumentException("Unable to load certificate chain");
-            }
-            if (keyPath != null && Quiche.quiche_config_load_priv_key_from_pem_file(config, keyPath) != 0) {
-                throw new IllegalArgumentException("Unable to load private key");
-            }
-            if (verifyPeer != null) {
-                Quiche.quiche_config_verify_peer(config, verifyPeer);
-            }
-            if (grease != null) {
-                Quiche.quiche_config_grease(config, grease);
-            }
-            if (earlyData) {
-                Quiche.quiche_config_enable_early_data(config);
-            }
-            if (protos != null) {
-                Quiche.quiche_config_set_application_protos(config, protos);
-            }
-            if (maxIdleTimeout != null) {
-                Quiche.quiche_config_set_max_idle_timeout(config, maxIdleTimeout);
-            }
-            if (maxUdpPayloadSize != null) {
-                Quiche.quiche_config_set_max_udp_payload_size(config, maxUdpPayloadSize);
-            }
-            if (initialMaxData != null) {
-                Quiche.quiche_config_set_initial_max_data(config, initialMaxData);
-            }
-            if (initialMaxStreamDataBidiLocal != null) {
-                Quiche.quiche_config_set_initial_max_stream_data_bidi_local(config, initialMaxStreamDataBidiLocal);
-            }
-            if (initialMaxStreamDataBidiRemote != null) {
-                Quiche.quiche_config_set_initial_max_stream_data_bidi_remote(config, initialMaxStreamDataBidiRemote);
-            }
-            if (initialMaxStreamDataUni != null) {
-                Quiche.quiche_config_set_initial_max_stream_data_uni(config, initialMaxStreamDataUni);
-            }
-            if (initialMaxStreamsBidi != null) {
-                Quiche.quiche_config_set_initial_max_streams_bidi(config, initialMaxStreamsBidi);
-            }
-            if (initialMaxStreamsUni != null) {
-                Quiche.quiche_config_set_initial_max_streams_uni(config, initialMaxStreamsUni);
-            }
-            if (ackDelayExponent != null) {
-                Quiche.quiche_config_set_ack_delay_exponent(config, ackDelayExponent);
-            }
-            if (maxAckDelay != null) {
-                Quiche.quiche_config_set_max_ack_delay(config, maxAckDelay);
-            }
-            if (disableActiveMigration != null) {
-                Quiche.quiche_config_set_disable_active_migration(config, disableActiveMigration);
-            }
-            if (enableHystart != null) {
-                Quiche.quiche_config_enable_hystart(config, enableHystart);
-            }
-            if (congestionControlAlgorithm != null) {
-                switch (congestionControlAlgorithm) {
-                    case RENO:
-                        Quiche.quiche_config_set_cc_algorithm(config, Quiche.QUICHE_CC_RENO);
-                        break;
-                    case CUBIC:
-                        Quiche.quiche_config_set_cc_algorithm(config, Quiche.QUICHE_CC_CUBIC);
-                        break;
-                    default:
-                        throw new IllegalArgumentException(
-                                "Unknown congestionControlAlgorithm: " + congestionControlAlgorithm);
-                }
-            }
-            return config;
-        } catch (Throwable cause) {
-            Quiche.quiche_config_free(config);
-            throw cause;
-        }
-    }
+    protected abstract ChannelHandler build(QuicheConfig config);
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -125,7 +125,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     }
 
     @Override
-    protected ChannelHandler build(long config) {
+    protected ChannelHandler build(QuicheConfig config) {
         validate();
         QuicTokenHandler tokenHandler = this.tokenHandler;
         QuicConnectionIdGenerator generator = connectionIdAddressGenerator;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+final class QuicheConfig {
+    private final String certPath;
+    private final String keyPath;
+    private final Boolean verifyPeer;
+    private final Boolean grease;
+    private final  boolean earlyData;
+    private final byte[] protos;
+    private final Long maxIdleTimeout;
+    private final Long maxUdpPayloadSize;
+    private final Long initialMaxData;
+    private final Long initialMaxStreamDataBidiLocal;
+    private final Long initialMaxStreamDataBidiRemote;
+    private final Long initialMaxStreamDataUni;
+    private final Long initialMaxStreamsBidi;
+    private final Long initialMaxStreamsUni;
+    private final Long ackDelayExponent;
+    private final Long maxAckDelay;
+    private final Boolean disableActiveMigration;
+    private final Boolean enableHystart;
+    private final QuicCongestionControlAlgorithm congestionControlAlgorithm;
+
+    QuicheConfig(String certPath, String keyPath, Boolean verifyPeer, Boolean grease, boolean earlyData,
+                        byte[] protos, Long maxIdleTimeout, Long maxUdpPayloadSize, Long initialMaxData,
+                        Long initialMaxStreamDataBidiLocal, Long initialMaxStreamDataBidiRemote,
+                        Long initialMaxStreamDataUni, Long initialMaxStreamsBidi, Long initialMaxStreamsUni,
+                        Long ackDelayExponent, Long maxAckDelay, Boolean disableActiveMigration, Boolean enableHystart,
+                        QuicCongestionControlAlgorithm congestionControlAlgorithm) {
+        this.certPath = certPath;
+        this.keyPath = keyPath;
+        this.verifyPeer = verifyPeer;
+        this.grease = grease;
+        this.earlyData = earlyData;
+        this.protos = protos;
+        this.maxIdleTimeout = maxIdleTimeout;
+        this.maxUdpPayloadSize = maxUdpPayloadSize;
+        this.initialMaxData = initialMaxData;
+        this.initialMaxStreamDataBidiLocal = initialMaxStreamDataBidiLocal;
+        this.initialMaxStreamDataBidiRemote = initialMaxStreamDataBidiRemote;
+        this.initialMaxStreamDataUni = initialMaxStreamDataUni;
+        this.initialMaxStreamsBidi = initialMaxStreamsBidi;
+        this.initialMaxStreamsUni = initialMaxStreamsUni;
+        this.ackDelayExponent = ackDelayExponent;
+        this.maxAckDelay = maxAckDelay;
+        this.disableActiveMigration = disableActiveMigration;
+        this.enableHystart = enableHystart;
+        this.congestionControlAlgorithm = congestionControlAlgorithm;
+    }
+
+    /**
+     * Creates the native config object and return it.
+     */
+    long createNativeConfig() {
+        long config = Quiche.quiche_config_new(Quiche.QUICHE_PROTOCOL_VERSION);
+        try {
+            if (certPath != null && Quiche.quiche_config_load_cert_chain_from_pem_file(config, certPath) != 0) {
+                throw new IllegalArgumentException("Unable to load certificate chain");
+            }
+            if (keyPath != null && Quiche.quiche_config_load_priv_key_from_pem_file(config, keyPath) != 0) {
+                throw new IllegalArgumentException("Unable to load private key");
+            }
+            if (verifyPeer != null) {
+                Quiche.quiche_config_verify_peer(config, verifyPeer);
+            }
+            if (grease != null) {
+                Quiche.quiche_config_grease(config, grease);
+            }
+            if (earlyData) {
+                Quiche.quiche_config_enable_early_data(config);
+            }
+            if (protos != null) {
+                Quiche.quiche_config_set_application_protos(config, protos);
+            }
+            if (maxIdleTimeout != null) {
+                Quiche.quiche_config_set_max_idle_timeout(config, maxIdleTimeout);
+            }
+            if (maxUdpPayloadSize != null) {
+                Quiche.quiche_config_set_max_udp_payload_size(config, maxUdpPayloadSize);
+            }
+            if (initialMaxData != null) {
+                Quiche.quiche_config_set_initial_max_data(config, initialMaxData);
+            }
+            if (initialMaxStreamDataBidiLocal != null) {
+                Quiche.quiche_config_set_initial_max_stream_data_bidi_local(config, initialMaxStreamDataBidiLocal);
+            }
+            if (initialMaxStreamDataBidiRemote != null) {
+                Quiche.quiche_config_set_initial_max_stream_data_bidi_remote(config, initialMaxStreamDataBidiRemote);
+            }
+            if (initialMaxStreamDataUni != null) {
+                Quiche.quiche_config_set_initial_max_stream_data_uni(config, initialMaxStreamDataUni);
+            }
+            if (initialMaxStreamsBidi != null) {
+                Quiche.quiche_config_set_initial_max_streams_bidi(config, initialMaxStreamsBidi);
+            }
+            if (initialMaxStreamsUni != null) {
+                Quiche.quiche_config_set_initial_max_streams_uni(config, initialMaxStreamsUni);
+            }
+            if (ackDelayExponent != null) {
+                Quiche.quiche_config_set_ack_delay_exponent(config, ackDelayExponent);
+            }
+            if (maxAckDelay != null) {
+                Quiche.quiche_config_set_max_ack_delay(config, maxAckDelay);
+            }
+            if (disableActiveMigration != null) {
+                Quiche.quiche_config_set_disable_active_migration(config, disableActiveMigration);
+            }
+            if (enableHystart != null) {
+                Quiche.quiche_config_enable_hystart(config, enableHystart);
+            }
+            if (congestionControlAlgorithm != null) {
+                switch (congestionControlAlgorithm) {
+                    case RENO:
+                        Quiche.quiche_config_set_cc_algorithm(config, Quiche.QUICHE_CC_RENO);
+                        break;
+                    case CUBIC:
+                        Quiche.quiche_config_set_cc_algorithm(config, Quiche.QUICHE_CC_CUBIC);
+                        break;
+                    default:
+                        throw new IllegalArgumentException(
+                                "Unknown congestionControlAlgorithm: " + congestionControlAlgorithm);
+                }
+            }
+            return config;
+        } catch (Throwable cause) {
+            Quiche.quiche_config_free(config);
+            throw cause;
+        }
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
@@ -28,7 +28,7 @@ import java.nio.ByteBuffer;
  */
 final class QuicheQuicClientCodec extends QuicheQuicCodec {
 
-    QuicheQuicClientCodec(long config) {
+    QuicheQuicClientCodec(QuicheConfig config) {
         // Let's just use Quic.MAX_DATAGRAM_SIZE as the maximum size for a token on the client side. This should be
         // safe enough and as we not have too many codecs at the same time this should be ok.
         super(config, Quic.MAX_DATAGRAM_SIZE);
@@ -48,7 +48,7 @@ final class QuicheQuicClientCodec extends QuicheQuicCodec {
                         SocketAddress localAddress, ChannelPromise promise) {
         final QuicheQuicChannel channel;
         try {
-            channel = QuicheQuicChannel.handleConnect(remoteAddress, config);
+            channel = QuicheQuicChannel.handleConnect(remoteAddress, nativeConfig);
         } catch (Exception e) {
             promise.setFailure(e);
             return;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -54,9 +54,10 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
     private ByteBuf tokenBuffer;
     private ByteBuf tokenLenBuffer;
 
-    protected final long config;
+    protected final QuicheConfig config;
+    protected long nativeConfig;
 
-    QuicheQuicCodec(long config, int maxTokenLength) {
+    QuicheQuicCodec(QuicheConfig config, int maxTokenLength) {
         this.config = config;
         this.maxTokenLength = maxTokenLength;
     }
@@ -79,6 +80,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
         dcidLenBuffer = allocateNativeOrder(Integer.BYTES);
         tokenLenBuffer = allocateNativeOrder(Integer.BYTES);
         tokenBuffer = allocateNativeOrder(maxTokenLength);
+        nativeConfig = config.createNativeConfig();
     }
 
     @SuppressWarnings("deprecation")
@@ -100,7 +102,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
         needsFireChannelReadComplete.clear();
 
-        Quiche.quiche_config_free(config);
+        Quiche.quiche_config_free(nativeConfig);
 
         versionBuffer.release();
         scidBuffer.release();

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -49,7 +49,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
     private ByteBuf mintTokenBuffer;
     private ByteBuf connIdBuffer;
 
-    QuicheQuicServerCodec(long config, QuicTokenHandler tokenHandler,
+    QuicheQuicServerCodec(QuicheConfig config, QuicTokenHandler tokenHandler,
                           QuicConnectionIdGenerator connectionIdAddressGenerator,
                           ChannelHandler handler,
                           Map.Entry<ChannelOption<?>, Object>[] optionsArray,
@@ -160,10 +160,10 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         final long conn;
         if (noToken) {
             conn = Quiche.quiche_accept_no_token(
-                    Quiche.memoryAddress(dcid) + dcid.readerIndex(), MAX_LOCAL_CONN_ID, config);
+                    Quiche.memoryAddress(dcid) + dcid.readerIndex(), MAX_LOCAL_CONN_ID, nativeConfig);
         } else {
             conn = Quiche.quiche_accept(Quiche.memoryAddress(dcid) + dcid.readerIndex(), MAX_LOCAL_CONN_ID,
-                    Quiche.memoryAddress(token) + offset, token.readableBytes() - offset, config);
+                    Quiche.memoryAddress(token) + offset, token.readableBytes() - offset, nativeConfig);
         }
         if (conn < 0) {
             LOGGER.debug("quiche_accept failed");


### PR DESCRIPTION
…pipeline

Motivation:

To reduce the risk of memory leaks we should delay the creation of the native config as long as possible

Modifications:

Introduce QuicheConfig which is passed to the codecs. We will create the native config only in handlerAdded(...)

Result:

Less risk of memory leaks