### PR TITLE
Expose keylog path configuration for quiche connection

### DIFF
--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -172,6 +172,22 @@ static void netty_quiche_conn_free(JNIEnv* env, jclass clazz, jlong conn) {
     quiche_conn_free((quiche_conn *) conn);
 }
 
+static jboolean netty_quiche_conn_set_keylog_path(JNIEnv* env, jclass clazz, jlong conn, jstring keylog_path) {
+    if (keylog_path == NULL) {
+        return JNI_FALSE;
+    }
+
+    const char *path = NULL;
+    path = (*env)->GetStringUTFChars(env, keylog_path, 0);
+    if (path == NULL) {
+        return JNI_FALSE;
+    }
+
+    bool res = quiche_conn_set_keylog_path((quiche_conn *) conn, path);
+    (*env)->ReleaseStringUTFChars(env, keylog_path, path);
+    return res == true ? JNI_TRUE : JNI_FALSE;
+}
+
 static jlong netty_quiche_connect(JNIEnv* env, jclass clazz, jstring server_name, jlong scid, jint scid_len, jlong config) {
     const char *name = NULL;
     if (server_name != NULL) {
@@ -234,6 +250,10 @@ static jbyteArray netty_quiche_conn_application_proto(JNIEnv* env, jclass clazz,
 
 static jboolean netty_quiche_conn_is_established(JNIEnv* env, jclass clazz, jlong conn) {
     return quiche_conn_is_established((quiche_conn *) conn) == true ? JNI_TRUE : JNI_FALSE;
+}
+
+static void netty_quiche_config_log_keys(JNIEnv* env, jclass clazz, jlong config) {
+    quiche_config_log_keys((quiche_config*) config);
 }
 
 static jboolean netty_quiche_conn_is_in_early_data(JNIEnv* env, jclass clazz, jlong conn) {
@@ -480,6 +500,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_recv", "(JJI)I", (void *) netty_quiche_conn_recv },
   { "quiche_conn_send", "(JJI)I", (void *) netty_quiche_conn_send },
   { "quiche_conn_free", "(J)V", (void *) netty_quiche_conn_free },
+  { "quiche_conn_set_keylog_path", "(JLjava/lang/String;)Z", (void *) netty_quiche_conn_set_keylog_path },
   { "quiche_connect", "(Ljava/lang/String;JIJ)J", (void *) netty_quiche_connect },
   { "quiche_conn_stream_recv", "(JJJIJ)I", (void *) netty_quiche_conn_stream_recv },
   { "quiche_conn_stream_send", "(JJJIZ)I", (void *) netty_quiche_conn_stream_send },
@@ -503,6 +524,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_config_load_priv_key_from_pem_file", "(JLjava/lang/String;)I", (void *) netty_quiche_config_load_priv_key_from_pem_file },
   { "quiche_config_verify_peer", "(JZ)V", (void *) netty_quiche_config_verify_peer },
   { "quiche_config_grease", "(JZ)V", (void *) netty_quiche_config_grease },
+  { "quiche_config_log_keys", "(J)V", (void *) netty_quiche_config_log_keys },
   { "quiche_config_enable_early_data", "(J)V", (void *) netty_quiche_config_enable_early_data },
   { "quiche_config_set_application_protos", "(J[B)I", (void *) netty_quiche_config_set_application_protos },
   { "quiche_config_set_max_idle_timeout", "(JJ)V", (void *) netty_quiche_config_set_max_idle_timeout },

--- a/src/main/java/io/netty/incubator/codec/quic/DefaultQuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/DefaultQuicChannelConfig.java
@@ -36,6 +36,11 @@ final class DefaultQuicChannelConfig extends DefaultChannelConfig implements Qui
      */
     private volatile String peerCertServerName;
 
+    /**
+     * Enables cryptographic secrets being logged to the specified file path.
+     */
+    private volatile String keylogPath;
+
     DefaultQuicChannelConfig(Channel channel) {
         super(channel);
     }
@@ -145,4 +150,16 @@ final class DefaultQuicChannelConfig extends DefaultChannelConfig implements Qui
         this.peerCertServerName = peerCertServerName;
         return this;
     }
+
+    @Override
+    public String getKeylogPath() {
+        return keylogPath;
+    }
+
+    @Override
+    public DefaultQuicChannelConfig setKeylogPath(String keylogPath) {
+        this.keylogPath = keylogPath;
+        return this;
+    }
+
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelConfig.java
@@ -72,4 +72,17 @@ public interface QuicChannelConfig extends ChannelConfig {
      * connection is established.</strong>
      */
     QuicChannelConfig setPeerCertServerName(String peerCertServerName);
+
+    /**
+     * Returns file path where cryptographic secrets are logged to.
+     */
+    String getKeylogPath();
+
+    /**
+     * Enables cryptographic secrets to be logged to the specified file path.
+     *
+     * <strong>Be aware this config setting can only be adjusted before the
+     * connection is established.</strong>
+     */
+    QuicChannelConfig setKeylogPath(String keylogPath);
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelOption.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelOption.java
@@ -29,6 +29,8 @@ public final class QuicChannelOption<T> extends ChannelOption<T> {
     public static final ChannelOption<String> PEER_CERT_SERVER_NAME =
         valueOf(QuicChannelOption.class, "PEER_CERT_SERVER_NAME");
 
+    public static final ChannelOption<String> KEYLOG_PATH = valueOf(QuicChannelOption.class, "KEYLOG_PATH");
+
     @SuppressWarnings({ "deprecation" })
     private QuicChannelOption() {
         super(null);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -26,6 +26,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     private String keyPath;
     private Boolean verifyPeer;
     private Boolean grease;
+    private boolean logKeys;
     private boolean earlyData;
     private byte[] protos;
     private Long maxIdleTimeout;
@@ -87,6 +88,14 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      */
     public final B grease(boolean enable) {
         grease = enable;
+        return self();
+    }
+
+    /**
+     * Enables logging of secrets.
+     */
+    public final B logKeys() {
+        logKeys = true;
         return self();
     }
 
@@ -226,7 +235,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     }
 
     private QuicheConfig createConfig() {
-        return new QuicheConfig(certPath, keyPath, verifyPeer, grease, earlyData,
+        return new QuicheConfig(certPath, keyPath, verifyPeer, grease, logKeys, earlyData,
                 protos, maxIdleTimeout, maxUdpPayloadSize, initialMaxData,
                 initialMaxStreamDataBidiLocal, initialMaxStreamDataBidiRemote,
                 initialMaxStreamDataUni, initialMaxStreamsBidi, initialMaxStreamsUni,

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -232,6 +232,12 @@ final class Quiche {
     static native void quiche_conn_free(long connAddr);
 
     /**
+     * See
+     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L235">quiche_conn_set_keylog_path</a>.
+     */
+    static native boolean quiche_conn_set_keylog_path(long connAddr, String path);
+
+    /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L211">quiche_connect</a>.
      */
     static native long quiche_connect(String server_name, long scidAddr, int scidLen, long configAddr);
@@ -378,6 +384,13 @@ final class Quiche {
      *     quiche_config_grease</a>.
      */
     static native void quiche_config_grease(long configAddr, boolean value);
+
+    /**
+     * See
+     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#132">
+     *     quiche_config_log_keys</a>.
+     */
+    static native void quiche_config_log_keys(long configAddr);
 
     /**
      * See

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
@@ -20,7 +20,8 @@ final class QuicheConfig {
     private final String keyPath;
     private final Boolean verifyPeer;
     private final Boolean grease;
-    private final  boolean earlyData;
+    private final boolean logKeys;
+    private final boolean earlyData;
     private final byte[] protos;
     private final Long maxIdleTimeout;
     private final Long maxUdpPayloadSize;
@@ -36,9 +37,9 @@ final class QuicheConfig {
     private final Boolean enableHystart;
     private final QuicCongestionControlAlgorithm congestionControlAlgorithm;
 
-    QuicheConfig(String certPath, String keyPath, Boolean verifyPeer, Boolean grease, boolean earlyData,
-                        byte[] protos, Long maxIdleTimeout, Long maxUdpPayloadSize, Long initialMaxData,
-                        Long initialMaxStreamDataBidiLocal, Long initialMaxStreamDataBidiRemote,
+    QuicheConfig(String certPath, String keyPath, Boolean verifyPeer, Boolean grease, boolean logKeys,
+                        boolean earlyData, byte[] protos, Long maxIdleTimeout, Long maxUdpPayloadSize,
+                        Long initialMaxData, Long initialMaxStreamDataBidiLocal, Long initialMaxStreamDataBidiRemote,
                         Long initialMaxStreamDataUni, Long initialMaxStreamsBidi, Long initialMaxStreamsUni,
                         Long ackDelayExponent, Long maxAckDelay, Boolean disableActiveMigration, Boolean enableHystart,
                         QuicCongestionControlAlgorithm congestionControlAlgorithm) {
@@ -46,6 +47,7 @@ final class QuicheConfig {
         this.keyPath = keyPath;
         this.verifyPeer = verifyPeer;
         this.grease = grease;
+        this.logKeys = logKeys;
         this.earlyData = earlyData;
         this.protos = protos;
         this.maxIdleTimeout = maxIdleTimeout;
@@ -80,6 +82,9 @@ final class QuicheConfig {
             }
             if (grease != null) {
                 Quiche.quiche_config_grease(config, grease);
+            }
+            if (logKeys) {
+                Quiche.quiche_config_log_keys(config);
             }
             if (earlyData) {
                 Quiche.quiche_config_enable_early_data(config);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -181,6 +181,11 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
             connectionSendNeeded = true;
             key = connectId;
+
+            final String keylogPath = config().getKeylogPath();
+            if (keylogPath != null) {
+                Quiche.quiche_conn_set_keylog_path(connection, keylogPath);
+            }
         } finally {
             idBuffer.release();
         }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -180,6 +180,12 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         Quic.setupChannel(channel, optionsArray, attrsArray, handler, LOGGER);
         putChannel(channel);
         ctx.channel().eventLoop().register(channel);
+
+        final String keylogPath = channel.config().getKeylogPath();
+        if (keylogPath != null) {
+            Quiche.quiche_conn_set_keylog_path(conn, keylogPath);
+        }
+
         return channel;
     }
 }


### PR DESCRIPTION
Motivation:

In order to debug quic traffic with tools like Wireshark, one should have access to connection secrets. Quiche provides API to log keys to a specified file in using [NSS Key Log Format](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format).

Modifications:

* JNI functions to work with corresponding configuration options
* New quic channel configuration `keylogPath`
* New quiche configuration `logKeys`

Result:

Now it's possible to log cryptographic secrets for a connection.