### PR TITLE
Correctly handle half-closure support to be inline with other DuplexC…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/DefaultQuicStreamChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/DefaultQuicStreamChannelConfig.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.DefaultChannelConfig;
+import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.WriteBufferWaterMark;
+
+import java.util.Map;
+
+final class DefaultQuicStreamChannelConfig extends DefaultChannelConfig implements QuicStreamChannelConfig {
+    private volatile boolean allowHalfClosure;
+
+    DefaultQuicStreamChannelConfig(QuicStreamChannel channel) {
+        super(channel);
+    }
+
+    @Override
+    public Map<ChannelOption<?>, Object> getOptions() {
+        if (isAllowHalfClosure()) {
+            return getOptions(super.getOptions(), ChannelOption.ALLOW_HALF_CLOSURE);
+        }
+        return super.getOptions();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getOption(ChannelOption<T> option) {
+        if (option == ChannelOption.ALLOW_HALF_CLOSURE) {
+            return (T) Boolean.valueOf(isAllowHalfClosure());
+        }
+
+        return super.getOption(option);
+    }
+
+    @Override
+    public <T> boolean setOption(ChannelOption<T> option, T value) {
+        validate(option, value);
+
+        if (option == ChannelOption.ALLOW_HALF_CLOSURE) {
+            if (isHalfClosureSupported()) {
+                setAllowHalfClosure((Boolean) value);
+                return true;
+            }
+            return false;
+        } else {
+            return super.setOption(option, value);
+        }
+    }
+
+    @Override
+    public QuicStreamChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis) {
+        super.setConnectTimeoutMillis(connectTimeoutMillis);
+        return this;
+    }
+
+    @Override
+    public QuicStreamChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead) {
+        super.setMaxMessagesPerRead(maxMessagesPerRead);
+        return this;
+    }
+
+    @Override
+    public QuicStreamChannelConfig setWriteSpinCount(int writeSpinCount) {
+        super.setWriteSpinCount(writeSpinCount);
+        return this;
+    }
+
+    @Override
+    public QuicStreamChannelConfig setAllocator(ByteBufAllocator allocator) {
+        super.setAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public QuicStreamChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
+        super.setRecvByteBufAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public QuicStreamChannelConfig setAutoRead(boolean autoRead) {
+        super.setAutoRead(autoRead);
+        return this;
+    }
+
+    @Override
+    public QuicStreamChannelConfig setAutoClose(boolean autoClose) {
+        super.setAutoClose(autoClose);
+        return this;
+    }
+
+    @Override
+    public QuicStreamChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
+        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
+        return this;
+    }
+
+    @Override
+    public QuicStreamChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
+        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
+        return this;
+    }
+
+    @Override
+    public QuicStreamChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
+        super.setWriteBufferWaterMark(writeBufferWaterMark);
+        return this;
+    }
+
+    @Override
+    public QuicStreamChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
+        super.setMessageSizeEstimator(estimator);
+        return this;
+    }
+
+    @Override
+    public QuicStreamChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
+        if (!isHalfClosureSupported()) {
+            throw new UnsupportedOperationException("Undirectional streams don't support half-closure");
+        }
+        this.allowHalfClosure = allowHalfClosure;
+        return this;
+    }
+
+    @Override
+    public boolean isAllowHalfClosure() {
+        return allowHalfClosure;
+    }
+
+    private boolean isHalfClosureSupported() {
+        return ((QuicStreamChannel) channel).type() == QuicStreamType.BIDIRECTIONAL;
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/DefaultQuicStreamChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/DefaultQuicStreamChannelConfig.java
@@ -33,7 +33,7 @@ final class DefaultQuicStreamChannelConfig extends DefaultChannelConfig implemen
 
     @Override
     public Map<ChannelOption<?>, Object> getOptions() {
-        if (isAllowHalfClosure()) {
+        if (isHalfClosureSupported()) {
             return getOptions(super.getOptions(), ChannelOption.ALLOW_HALF_CLOSURE);
         }
         return super.getOptions();

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.socket.DuplexChannelConfig;
+
+/**
+ * {@link DuplexChannelConfig} for QUIC streams.
+ */
+public interface QuicStreamChannelConfig extends DuplexChannelConfig {
+
+    @Override
+    QuicStreamChannelConfig setAllowHalfClosure(boolean allowHalfClosure);
+
+    @Override
+    QuicStreamChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead);
+
+    @Override
+    QuicStreamChannelConfig setWriteSpinCount(int writeSpinCount);
+
+    @Override
+    QuicStreamChannelConfig setAllocator(ByteBufAllocator allocator);
+
+    @Override
+    QuicStreamChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator);
+
+    @Override
+    QuicStreamChannelConfig setAutoRead(boolean autoRead);
+
+    @Override
+    QuicStreamChannelConfig setAutoClose(boolean autoClose);
+
+    @Override
+    QuicStreamChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator);
+
+    @Override
+    QuicStreamChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark);
+
+    @Override
+    QuicStreamChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis);
+
+    @Override
+    QuicStreamChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
+
+    @Override
+    QuicStreamChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
+}

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamHalfClosureTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamHalfClosureTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.socket.ChannelInputShutdownEvent;
+import io.netty.channel.socket.ChannelInputShutdownReadComplete;
+import io.netty.util.ReferenceCountUtil;
+import org.junit.Test;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class QuicStreamHalfClosureTest {
+
+    @Test
+    public void testCloseHalfClosureUnidirectional() throws Exception {
+        testCloseHalfClosure(QuicStreamType.UNIDIRECTIONAL);
+    }
+
+    @Test
+    public void testCloseHalfClosureBidirectional() throws Exception {
+        testCloseHalfClosure(QuicStreamType.BIDIRECTIONAL);
+    }
+
+    private static void testCloseHalfClosure(QuicStreamType type) throws Exception {
+        Channel server = null;
+        Channel channel = null;
+        try {
+            StreamHandler handler = new StreamHandler();
+            server = QuicTestUtils.newServer(null, handler);
+            channel = QuicTestUtils.newClient();
+            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+                    .handler(new StreamCreationHandler(type))
+                    .streamHandler(new ChannelInboundHandlerAdapter())
+                    .remoteAddress(server.localAddress())
+                    .connect()
+                    .get();
+
+            handler.assertSequence();
+            quicChannel.closeFuture().sync();
+        } finally {
+            QuicTestUtils.closeIfNotNull(channel);
+            QuicTestUtils.closeIfNotNull(server);
+        }
+    }
+
+    private static final class StreamCreationHandler extends ChannelInboundHandlerAdapter {
+        private final QuicStreamType type;
+
+        StreamCreationHandler(QuicStreamType type) {
+            this.type = type;
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) {
+            QuicChannel channel = (QuicChannel) ctx.channel();
+            channel.createStream(type, new ChannelInboundHandlerAdapter() {
+                @Override
+                public void channelActive(ChannelHandlerContext ctx)  {
+                    // Do the write and close the channel
+                    ctx.writeAndFlush(Unpooled.buffer().writeZero(8))
+                            .addListener(ChannelFutureListener.CLOSE);
+                }
+            });
+        }
+    }
+
+    private static final class StreamHandler extends ChannelInboundHandlerAdapter {
+        private final BlockingQueue<Integer> queue = new LinkedBlockingQueue<>();
+        private boolean halfClosureSupported;
+        @Override
+        public void channelRegistered(ChannelHandlerContext ctx) {
+            halfClosureSupported = ((QuicStreamChannel) ctx.channel()).type() == QuicStreamType.BIDIRECTIONAL;
+            assertEquals(halfClosureSupported,
+                    ctx.channel().config().setOption(ChannelOption.ALLOW_HALF_CLOSURE, true));
+            queue.add(0);
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) {
+            queue.add(3);
+            // Close the QUIC channel as well.
+            ctx.channel().parent().close();
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+            ReferenceCountUtil.release(msg);
+        }
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            if (evt == ChannelInputShutdownEvent.INSTANCE) {
+                queue.add(1);
+            } else if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
+                queue.add(2);
+                ctx.close();
+            }
+        }
+
+        void assertSequence() throws Exception {
+            assertEquals(0, (int) queue.take());
+            if (halfClosureSupported) {
+                assertEquals(1, (int) queue.take());
+                assertEquals(2, (int) queue.take());
+            }
+            assertEquals(3, (int) queue.take());
+            assertTrue(queue.isEmpty());
+        }
+    }
+}


### PR DESCRIPTION
…hannel implementations

Motivation:

We need to correctly handle half-closure in QuicheQuicStreamChannel and so mimic other DuplexChannel implementations

Modifications:

- Add QuicStreamChannelConfig and its implementation, use it in QuicheQuicStreamChannel
- Correctly handle half closure when we receive a fin when the stream supports it.
- Add unit tests

Result:

Correctly handle half-closure