### PR TITLE
Add support for QuicStreamFrame

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/DefaultQuicStreamChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/DefaultQuicStreamChannelConfig.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 final class DefaultQuicStreamChannelConfig extends DefaultChannelConfig implements QuicStreamChannelConfig {
     private volatile boolean allowHalfClosure;
+    private volatile boolean readFrames;
 
     DefaultQuicStreamChannelConfig(QuicStreamChannel channel) {
         super(channel);
@@ -34,7 +35,7 @@ final class DefaultQuicStreamChannelConfig extends DefaultChannelConfig implemen
     @Override
     public Map<ChannelOption<?>, Object> getOptions() {
         if (isHalfClosureSupported()) {
-            return getOptions(super.getOptions(), ChannelOption.ALLOW_HALF_CLOSURE);
+            return getOptions(super.getOptions(), ChannelOption.ALLOW_HALF_CLOSURE, QuicChannelOption.READ_FRAMES);
         }
         return super.getOptions();
     }
@@ -45,7 +46,9 @@ final class DefaultQuicStreamChannelConfig extends DefaultChannelConfig implemen
         if (option == ChannelOption.ALLOW_HALF_CLOSURE) {
             return (T) Boolean.valueOf(isAllowHalfClosure());
         }
-
+        if (option == QuicChannelOption.READ_FRAMES) {
+            return (T) Boolean.valueOf(isReadFrames());
+        }
         return super.getOption(option);
     }
 
@@ -59,9 +62,22 @@ final class DefaultQuicStreamChannelConfig extends DefaultChannelConfig implemen
                 return true;
             }
             return false;
-        } else {
-            return super.setOption(option, value);
         }
+        if (option == QuicChannelOption.READ_FRAMES) {
+            setReadFrames((Boolean) value);
+        }
+        return super.setOption(option, value);
+    }
+
+    @Override
+    public QuicStreamChannelConfig setReadFrames(boolean readFrames) {
+        this.readFrames = readFrames;
+        return this;
+    }
+
+    @Override
+    public boolean isReadFrames() {
+        return readFrames;
     }
 
     @Override

--- a/src/main/java/io/netty/incubator/codec/quic/DefaultQuicStreamFrame.java
+++ b/src/main/java/io/netty/incubator/codec/quic/DefaultQuicStreamFrame.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DefaultByteBufHolder;
+
+public final class DefaultQuicStreamFrame extends DefaultByteBufHolder implements QuicStreamFrame {
+
+    private final boolean fin;
+
+    public DefaultQuicStreamFrame(ByteBuf data, boolean fin) {
+        super(data);
+        this.fin = fin;
+    }
+
+    @Override
+    public boolean hasFin() {
+        return fin;
+    }
+
+    @Override
+    public QuicStreamFrame copy() {
+        return new DefaultQuicStreamFrame(content().copy(), fin);
+    }
+
+    @Override
+    public QuicStreamFrame duplicate() {
+        return new DefaultQuicStreamFrame(content().duplicate(), fin);
+    }
+
+    @Override
+    public QuicStreamFrame retainedDuplicate() {
+        return new DefaultQuicStreamFrame(content().retainedDuplicate(), fin);
+    }
+
+    @Override
+    public QuicStreamFrame replace(ByteBuf content) {
+        return new DefaultQuicStreamFrame(content, fin);
+    }
+
+    @Override
+    public QuicStreamFrame retain() {
+        super.retain();
+        return this;
+    }
+
+    @Override
+    public QuicStreamFrame retain(int increment) {
+        super.retain(increment);
+        return this;
+    }
+
+    @Override
+    public QuicStreamFrame touch() {
+        super.touch();
+        return this;
+    }
+
+    @Override
+    public QuicStreamFrame touch(Object hint) {
+        super.touch(hint);
+        return this;
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelOption.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelOption.java
@@ -29,6 +29,14 @@ public final class QuicChannelOption<T> extends ChannelOption<T> {
     public static final ChannelOption<String> PEER_CERT_SERVER_NAME =
         valueOf(QuicChannelOption.class, "PEER_CERT_SERVER_NAME");
 
+    /**
+     * If set to {@code true} the {@link QuicStreamChannel} will read {@link QuicStreamFrame}s and fire it through
+     * the pipeline, if {@code false} it will read {@link io.netty.buffer.ByteBuf} and translate the FIN flag to
+     * events.
+     */
+    public static final ChannelOption<Boolean> READ_FRAMES =
+            valueOf(QuicChannelOption.class, "READ_FRAMES");
+
     @SuppressWarnings({ "deprecation" })
     private QuicChannelOption() {
         super(null);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelConfig.java
@@ -25,6 +25,17 @@ import io.netty.channel.socket.DuplexChannelConfig;
  * {@link DuplexChannelConfig} for QUIC streams.
  */
 public interface QuicStreamChannelConfig extends DuplexChannelConfig {
+    /**
+     * Set this to {@code true} if the {@link QuicStreamChannel} should read {@link QuicStreamFrame}s and fire these
+     * through the {@link io.netty.channel.ChannelPipeline}, {@code false} if it uses {@link io.netty.buffer.ByteBuf}.
+     */
+    QuicStreamChannelConfig setReadFrames(boolean readFrames);
+
+    /**
+     * Returns {@code true} if the {@link QuicStreamChannel} will read {@link QuicStreamFrame}s and fire these through
+     * the {@link io.netty.channel.ChannelPipeline}, {@code false} if it uses {@link io.netty.buffer.ByteBuf}.
+     */
+    boolean isReadFrames();
 
     @Override
     QuicStreamChannelConfig setAllowHalfClosure(boolean allowHalfClosure);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamFrame.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamFrame.java
@@ -15,37 +15,41 @@
  */
 package io.netty.incubator.codec.quic;
 
-import io.netty.channel.socket.DuplexChannel;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
 
 /**
- * A QUIC stream.
+ * A QUIC STREAM_FRAME.
  */
-public interface QuicStreamChannel extends DuplexChannel {
-
-    @Override
-    QuicStreamAddress localAddress();
-
-    @Override
-    QuicStreamAddress remoteAddress();
+public interface QuicStreamFrame extends ByteBufHolder {
 
     /**
-     * Returns {@code true} if the stream was created locally.
+     * Returns {@code true} if the frame has the FIN set, which means it notifies the remote peer that
+     * there will be no more writing happen. {@code false} otherwise.
      */
-    boolean isLocalCreated();
-
-    /**
-     * Returns the {@link QuicStreamType} of the stream.
-     */
-    QuicStreamType type();
-
-    /**
-     * The id of the stream.
-     */
-    long streamId();
+    boolean hasFin();
 
     @Override
-    QuicChannel parent();
+    QuicStreamFrame copy();
 
     @Override
-    QuicStreamChannelConfig config();
+    QuicStreamFrame duplicate();
+
+    @Override
+    QuicStreamFrame retainedDuplicate();
+
+    @Override
+    QuicStreamFrame replace(ByteBuf content);
+
+    @Override
+    QuicStreamFrame retain();
+
+    @Override
+    QuicStreamFrame retain(int increment);
+
+    @Override
+    QuicStreamFrame touch();
+
+    @Override
+    QuicStreamFrame touch(Object hint);
 }

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.junit.Test;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class QuicStreamFrameTest {
+
+    @Test
+    public void testCloseHalfClosureUnidirectional() throws Exception {
+        testCloseHalfClosure(QuicStreamType.UNIDIRECTIONAL);
+    }
+
+    @Test
+    public void testCloseHalfClosureBidirectional() throws Exception {
+        testCloseHalfClosure(QuicStreamType.BIDIRECTIONAL);
+    }
+
+    private static void testCloseHalfClosure(QuicStreamType type) throws Exception {
+        Channel server = null;
+        Channel channel = null;
+        try {
+            StreamHandler handler = new StreamHandler();
+            server = QuicTestUtils.newServer(null, handler);
+            channel = QuicTestUtils.newClient();
+            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+                    .handler(new StreamCreationHandler(type))
+                    .streamHandler(new ChannelInboundHandlerAdapter())
+                    .remoteAddress(server.localAddress())
+                    .connect()
+                    .get();
+
+            handler.assertSequence();
+            quicChannel.closeFuture().sync();
+        } finally {
+            QuicTestUtils.closeIfNotNull(channel);
+            QuicTestUtils.closeIfNotNull(server);
+        }
+    }
+
+    private static final class StreamCreationHandler extends ChannelInboundHandlerAdapter {
+        private final QuicStreamType type;
+
+        StreamCreationHandler(QuicStreamType type) {
+            this.type = type;
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) {
+            QuicChannel channel = (QuicChannel) ctx.channel();
+            channel.createStream(type, new ChannelInboundHandlerAdapter() {
+                @Override
+                public void channelActive(ChannelHandlerContext ctx)  {
+                    // Do the write and close the channel
+                    ctx.writeAndFlush(Unpooled.buffer().writeZero(8))
+                            .addListener(ChannelFutureListener.CLOSE);
+                }
+            });
+        }
+    }
+
+    private static final class StreamHandler extends ChannelInboundHandlerAdapter {
+        private final BlockingQueue<Integer> queue = new LinkedBlockingQueue<>();
+        @Override
+        public void channelRegistered(ChannelHandlerContext ctx) {
+            ctx.channel().config().setOption(QuicChannelOption.READ_FRAMES, true);
+            queue.add(0);
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) {
+            queue.add(2);
+            // Close the QUIC channel as well.
+            ctx.channel().parent().close();
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+            QuicStreamFrame frame = (QuicStreamFrame) msg;
+            if (frame.hasFin()) {
+                queue.add(1);
+                if (((QuicStreamChannel) ctx.channel()).type() == QuicStreamType.BIDIRECTIONAL) {
+                    // Let's write back a fin which will also close the channel and so call channelInactive(...)
+                    ctx.writeAndFlush(new DefaultQuicStreamFrame(Unpooled.EMPTY_BUFFER, true));
+                }
+            }
+            frame.release();
+        }
+
+        void assertSequence() throws Exception {
+            assertEquals(0, (int) queue.take());
+            assertEquals(1, (int) queue.take());
+            assertEquals(2, (int) queue.take());
+            assertTrue(queue.isEmpty());
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

For a lot of use-cases just using ByteBuf on top of the QuicStreamChannel is good enough. That said there are situations where a user may want to have some more control about when the FIN is sent etc. For this cases we should directly support QuicStreamFrame which basically wraps a ByteBuf but also allows to specify if a FIN flag should be send or not. Beside this the user may want to also receive QuicStreamFrame's directly and so have fine grained control

Modifications:

- Add QuicStreamFrame and a default implementation
- Add support to write QuicStreamFrame
- Add support to directly read QuichStreamFrame and fire these through the pipeline. This needs to be enabled by the user via a configuration option and is not the default.
- Add new ChannelOption and setter / getter to enable reading frames to QuicStreamChannel
- Let QuicStreamChannel.config() return QuicStreamChannelConfig
- Add unit tests

Result:

More flexible usage of QUIC codec possible