### PR TITLE
Call Quic.ensureAvailability() before trying to use it and so fail fast

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/Quic.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quic.java
@@ -20,7 +20,6 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.util.AttributeKey;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 
 import java.util.Map;
@@ -38,12 +37,11 @@ public final class Quic {
     static {
         Throwable cause = null;
 
-        if (SystemPropertyUtil.getBoolean("io.netty.transport.noNative", false)) {
-            cause = new UnsupportedOperationException(
-                    "Native transport was explicit disabled with -Dio.netty.transport.noNative=true");
-        } else {
+        try {
             String version = Quiche.quiche_version();
             assert version != null;
+        } catch (Throwable error) {
+            cause = error;
         }
 
         UNAVAILABILITY_CAUSE = cause;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
@@ -57,6 +57,7 @@ public final class QuicChannelBootstrap {
      * pipeline.
      */
     QuicChannelBootstrap(Channel parent) {
+        Quic.ensureAvailability();
         this.parent = ObjectUtil.checkNotNull(parent, "parent");
     }
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -42,7 +42,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     private Boolean enableHystart;
     private QuicCongestionControlAlgorithm congestionControlAlgorithm;
 
-    QuicCodecBuilder() { }
+    QuicCodecBuilder() {
+        Quic.ensureAvailability();
+    }
 
     @SuppressWarnings("unchecked")
     protected final B self() {


### PR DESCRIPTION
Motivation:

We should call Quic.ensureAvailability() before trying to use quiche. This will ensure we fail fast and make it easier for users to detect whats wrong. Also we missed to catch an exception in the static block in Quic which would have lead to problems when use the code on platforms that we not support atm.

Modifications:

- Add Quic.ensureAvailability() calls
- Add try { ... } catch { ... } in Quiche

Result:

Fail fast on "safe" on platforms that we not support