### PR TITLE
Support sending direct CompositeByteBuf without extra memory copy

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -511,6 +511,11 @@ final class Quiche {
                 buffer_memory_address(buf.internalNioBuffer(buf.readerIndex(), buf.readableBytes()));
     }
 
+    static long memoryAddress(ByteBuffer buf) {
+        assert buf.isDirect();
+        return buffer_memory_address(buf);
+    }
+
     static String errorAsString(int err) {
         return QuicError.valueOf(err).message();
     }


### PR DESCRIPTION
Motivation:

We should support sending a CompositeByteBuf without extra memory copies if it only contains direct ByteBuffer.

Modifications:

- Special handling of ByteBuf that have more then 1 nioBuffer.
- Add unit tests

Result:

Less memory copies needed