### PR TITLE
Add support for configurable local connection ID length

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
@@ -153,8 +153,23 @@ public final class QuicChannelBootstrap {
         if (remote == null) {
             throw new IllegalStateException("remote not set");
         }
-        final QuicConnectionAddress address = connectionAddress == null ?
-                QuicConnectionAddress.random() : connectionAddress;
+        final QuicheQuicCodec codec = parent.pipeline().get(QuicheQuicCodec.class);
+        if (codec == null) {
+            throw new IllegalStateException("parent channel does not have a QuicheQuicCodec handler");
+        }
+        final int localConnIdLength = codec.localConnIdLength();
+        final QuicConnectionAddress address;
+
+        if (connectionAddress == null) {
+            address = QuicConnectionAddress.random(localConnIdLength);
+        } else {
+            if (connectionAddress.connId.remaining() != localConnIdLength) {
+                throw new IllegalStateException("connectionAddress has length "
+                        + connectionAddress.connId.remaining()
+                        + " instead of " + localConnIdLength);
+            }
+            address = connectionAddress;
+        }
 
         QuicChannel channel = QuicheQuicChannel.forClient(parent, (InetSocketAddress) remote,
                 streamHandler, Quic.optionsArray(streamOptions), Quic.attributesArray(streamAttrs));

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
@@ -47,7 +47,7 @@ public final class QuicChannelBootstrap {
     private final Map<ChannelOption<?>, Object> streamOptions = new LinkedHashMap<>();
     private final Map<AttributeKey<?>, Object> streamAttrs = new HashMap<>();
     private SocketAddress remote;
-    private QuicConnectionAddress connectionAddress;
+    private QuicConnectionAddress connectionAddress = QuicConnectionAddress.EPHEMERAL;
     private ChannelHandler handler;
     private ChannelHandler streamHandler;
 
@@ -153,24 +153,7 @@ public final class QuicChannelBootstrap {
         if (remote == null) {
             throw new IllegalStateException("remote not set");
         }
-        final QuicheQuicCodec codec = parent.pipeline().get(QuicheQuicCodec.class);
-        if (codec == null) {
-            throw new IllegalStateException("parent channel does not have a QuicheQuicCodec handler");
-        }
-        final int localConnIdLength = codec.localConnIdLength();
-        final QuicConnectionAddress address;
-
-        if (connectionAddress == null) {
-            address = QuicConnectionAddress.random(localConnIdLength);
-        } else {
-            if (connectionAddress.connId.remaining() != localConnIdLength) {
-                throw new IllegalStateException("connectionAddress has length "
-                        + connectionAddress.connId.remaining()
-                        + " instead of " + localConnIdLength);
-            }
-            address = connectionAddress;
-        }
-
+        final QuicConnectionAddress address = connectionAddress;
         QuicChannel channel = QuicheQuicChannel.forClient(parent, (InetSocketAddress) remote,
                 streamHandler, Quic.optionsArray(streamOptions), Quic.attributesArray(streamAttrs));
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
@@ -25,6 +25,6 @@ public final class QuicClientCodecBuilder extends QuicCodecBuilder<QuicClientCod
 
     @Override
     protected ChannelHandler build(QuicheConfig config) {
-        return new QuicheQuicClientCodec(config);
+        return new QuicheQuicClientCodec(config, localConnIdLength);
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
@@ -24,7 +24,7 @@ import io.netty.channel.ChannelHandler;
 public final class QuicClientCodecBuilder extends QuicCodecBuilder<QuicClientCodecBuilder> {
 
     @Override
-    protected ChannelHandler build(QuicheConfig config) {
+    protected ChannelHandler build(QuicheConfig config, int localConnIdLength) {
         return new QuicheQuicClientCodec(config, localConnIdLength);
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.channel.ChannelHandler;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * Abstract base class for {@code QUIC} codec builders.
@@ -41,7 +42,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     private Boolean disableActiveMigration;
     private Boolean enableHystart;
     private QuicCongestionControlAlgorithm congestionControlAlgorithm;
-    protected int localConnIdLength = Quiche.QUICHE_MAX_CONN_ID_LEN;
+    private int localConnIdLength = Quiche.QUICHE_MAX_CONN_ID_LEN;
 
     QuicCodecBuilder() {
         Quic.ensureAvailability();
@@ -228,8 +229,11 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
         return self();
     }
 
-    public final B localConnIdLength(int value) {
-        this.localConnIdLength = value;
+    /**
+     * Sets the local connection id length that is used.
+     */
+    public final B localConnectionIdLength(int value) {
+        this.localConnIdLength = ObjectUtil.checkPositiveOrZero(value, "value");
         return self();
     }
 
@@ -253,8 +257,8 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      */
     public final ChannelHandler build() {
         validate();
-        return build(createConfig());
+        return build(createConfig(), localConnIdLength);
     }
 
-    protected abstract ChannelHandler build(QuicheConfig config);
+    protected abstract ChannelHandler build(QuicheConfig config, int localConnIdLength);
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -41,6 +41,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     private Boolean disableActiveMigration;
     private Boolean enableHystart;
     private QuicCongestionControlAlgorithm congestionControlAlgorithm;
+    protected int localConnIdLength = Quiche.QUICHE_MAX_CONN_ID_LEN;
 
     QuicCodecBuilder() {
         Quic.ensureAvailability();
@@ -224,6 +225,11 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      */
     public final B enableHystart(boolean value) {
         this.enableHystart = value;
+        return self();
+    }
+
+    public final B localConnIdLength(int value) {
+        this.localConnIdLength = value;
         return self();
     }
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -233,7 +233,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * Sets the local connection id length that is used.
      */
     public final B localConnectionIdLength(int value) {
-        this.localConnIdLength = ObjectUtil.checkPositiveOrZero(value, "value");
+        this.localConnIdLength = ObjectUtil.checkInRange(value, 0, Quiche.QUICHE_MAX_CONN_ID_LEN,  "value");
         return self();
     }
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicConnectionAddress.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicConnectionAddress.java
@@ -71,9 +71,21 @@ public final class QuicConnectionAddress extends SocketAddress {
     }
 
     /**
-     * Return a random generated {@link QuicConnectionAddress} that can be used to connect a {@link QuicChannel}
+     * Return a random generated {@link QuicConnectionAddress} of a given length
+     * that can be used to connect a {@link QuicChannel}
+     *
+     * @param length the length of the {@link QuicConnectionAddress} to generate.
+     */
+    public static QuicConnectionAddress random(int length) {
+        return new QuicConnectionAddress(QuicConnectionIdGenerator.randomGenerator().newId(length));
+    }
+
+    /**
+     * Return a random generated {@link QuicConnectionAddress} of maximum size
+     * that can be used to connect a {@link QuicChannel}
      */
     public static QuicConnectionAddress random() {
-        return new QuicConnectionAddress(QuicConnectionIdGenerator.randomGenerator().newId());
+        return random(Quiche.QUICHE_MAX_CONN_ID_LEN);
     }
+
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicConnectionIdGenerator.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicConnectionIdGenerator.java
@@ -22,10 +22,6 @@ import java.nio.ByteBuffer;
  */
 public interface QuicConnectionIdGenerator {
     /**
-     * Creates a new {@link QuicConnectionAddress} with the maximum length.
-     */
-    ByteBuffer newId();
-    /**
      * Creates a new {@link QuicConnectionAddress} with the given length.
      */
     ByteBuffer newId(int length);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -134,7 +134,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
         }
         ChannelHandler handler = this.handler;
         ChannelHandler streamHandler = this.streamHandler;
-        return new QuicheQuicServerCodec(config, tokenHandler, generator,
+        return new QuicheQuicServerCodec(config, localConnIdLength, tokenHandler, generator,
                 handler, Quic.optionsArray(options), Quic.attributesArray(attrs),
                 streamHandler, Quic.optionsArray(streamOptions), Quic.attributesArray(streamAttrs));
     }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -125,7 +125,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     }
 
     @Override
-    protected ChannelHandler build(QuicheConfig config) {
+    protected ChannelHandler build(QuicheConfig config, int localConnIdLength) {
         validate();
         QuicTokenHandler tokenHandler = this.tokenHandler;
         QuicConnectionIdGenerator generator = connectionIdAddressGenerator;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -126,7 +126,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private ByteBuf finBuffer;
     private ChannelPromise connectPromise;
     private ScheduledFuture<?> connectTimeoutFuture;
-    //private ByteBuffer connectId;
     private QuicConnectionAddress connectAddress;
     private ByteBuffer key;
     private CloseData closeData;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -126,7 +126,8 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private ByteBuf finBuffer;
     private ChannelPromise connectPromise;
     private ScheduledFuture<?> connectTimeoutFuture;
-    private ByteBuffer connectId;
+    //private ByteBuffer connectId;
+    private QuicConnectionAddress connectAddress;
     private ByteBuffer key;
     private CloseData closeData;
     private QuicConnectionStats statsAtClose;
@@ -173,23 +174,28 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 streamHandler, streamOptionsArray, streamAttrsArray);
     }
 
-    private void connect(long configAddr) throws Exception {
+    private void connect(long configAddr, int localConnIdLength) throws Exception {
         assert this.connAddr == -1;
         assert this.traceId == null;
         assert this.key == null;
+        QuicConnectionAddress address = this.connectAddress;
+        if (address == QuicConnectionAddress.EPHEMERAL) {
+            address = QuicConnectionAddress.random(localConnIdLength);
+        } else {
+            if (address.connId.remaining() != localConnIdLength) {
+                failConnectPromiseAndThrow(new IllegalArgumentException("connectionAddress has length "
+                        + address.connId.remaining()
+                        + " instead of " + localConnIdLength));
+            }
+        }
+        ByteBuffer connectId = address.connId.duplicate();
         ByteBuf idBuffer = alloc().directBuffer(connectId.remaining()).writeBytes(connectId.duplicate());
         final String serverName = config().getPeerCertServerName();
         try {
             long connection = Quiche.quiche_connect(serverName, Quiche.memoryAddress(idBuffer) + idBuffer.readerIndex(),
                     idBuffer.readableBytes(), configAddr);
             if (connection == -1) {
-                ConnectException connectException = new ConnectException();
-                ChannelPromise promise = connectPromise;
-                if (promise != null) {
-                    connectPromise = null;
-                    promise.tryFailure(connectException);
-                }
-                throw connectException;
+                failConnectPromiseAndThrow(new ConnectException());
             }
             this.traceId = Quiche.traceId(connection, idBuffer);
             this.connAddr = connection;
@@ -199,6 +205,15 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         } finally {
             idBuffer.release();
         }
+    }
+
+    private void failConnectPromiseAndThrow(Exception e) throws Exception {
+        ChannelPromise promise = connectPromise;
+        if (promise != null) {
+            connectPromise = null;
+            promise.tryFailure(e);
+        }
+        throw e;
     }
 
     ByteBuffer key() {
@@ -788,7 +803,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
                 QuicConnectionAddress address = (QuicConnectionAddress) remote;
                 connectPromise = channelPromise;
-                connectId = address.connId.duplicate();
+                connectAddress = address;
 
                 // Schedule connect timeout.
                 int connectTimeoutMillis = config().getConnectTimeoutMillis();
@@ -944,11 +959,11 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     // TODO: Come up with something better.
-    static QuicheQuicChannel handleConnect(SocketAddress address, long config) throws Exception {
+    static QuicheQuicChannel handleConnect(SocketAddress address, long config, int localConnIdLength) throws Exception {
         if (address instanceof QuicheQuicChannel.QuicheQuicChannelAddress) {
             QuicheQuicChannel.QuicheQuicChannelAddress addr = (QuicheQuicChannel.QuicheQuicChannelAddress) address;
             QuicheQuicChannel channel = addr.channel;
-            channel.connect(config);
+            channel.connect(config, localConnIdLength);
             return channel;
         }
         return null;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
@@ -28,10 +28,10 @@ import java.nio.ByteBuffer;
  */
 final class QuicheQuicClientCodec extends QuicheQuicCodec {
 
-    QuicheQuicClientCodec(QuicheConfig config) {
+    QuicheQuicClientCodec(QuicheConfig config, int localConnIdLength) {
         // Let's just use Quic.MAX_DATAGRAM_SIZE as the maximum size for a token on the client side. This should be
         // safe enough and as we not have too many codecs at the same time this should be ok.
-        super(config, Quic.MAX_DATAGRAM_SIZE);
+        super(config, localConnIdLength, Quic.MAX_DATAGRAM_SIZE);
     }
 
     @Override

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
@@ -48,7 +48,7 @@ final class QuicheQuicClientCodec extends QuicheQuicCodec {
                         SocketAddress localAddress, ChannelPromise promise) {
         final QuicheQuicChannel channel;
         try {
-            channel = QuicheQuicChannel.handleConnect(remoteAddress, nativeConfig);
+            channel = QuicheQuicChannel.handleConnect(remoteAddress, nativeConfig, localConnIdLength);
         } catch (Exception e) {
             promise.setFailure(e);
             return;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -41,7 +41,6 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
     private final Map<ByteBuffer, QuicheQuicChannel> connections = new HashMap<>();
     private final Queue<QuicheQuicChannel> needsFireChannelReadComplete = new ArrayDeque<>();
-    private final int localConnIdLength;
     private final int maxTokenLength;
     private boolean needsFlush;
     private boolean inChannelRead;
@@ -56,6 +55,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
     private ByteBuf tokenLenBuffer;
 
     protected final QuicheConfig config;
+    protected final int localConnIdLength;
     protected long nativeConfig;
 
     QuicheQuicCodec(QuicheConfig config, int localConnIdLength, int maxTokenLength) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -72,10 +72,6 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
         connections.put(channel.key(), channel);
     }
 
-    int localConnIdLength() {
-        return this.localConnIdLength;
-    }
-
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) {
         versionBuffer = allocateNativeOrder(Integer.BYTES);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -41,6 +41,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
     private final Map<ByteBuffer, QuicheQuicChannel> connections = new HashMap<>();
     private final Queue<QuicheQuicChannel> needsFireChannelReadComplete = new ArrayDeque<>();
+    private final int localConnIdLength;
     private final int maxTokenLength;
     private boolean needsFlush;
     private boolean inChannelRead;
@@ -57,8 +58,9 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
     protected final QuicheConfig config;
     protected long nativeConfig;
 
-    QuicheQuicCodec(QuicheConfig config, int maxTokenLength) {
+    QuicheQuicCodec(QuicheConfig config, int localConnIdLength, int maxTokenLength) {
         this.config = config;
+        this.localConnIdLength = localConnIdLength;
         this.maxTokenLength = maxTokenLength;
     }
 
@@ -68,6 +70,10 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
     protected void putChannel(QuicheQuicChannel channel) {
         connections.put(channel.key(), channel);
+    }
+
+    int localConnIdLength() {
+        return this.localConnIdLength;
     }
 
     @Override
@@ -146,7 +152,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
         dcidLenBuffer.setInt(0, Quiche.QUICHE_MAX_CONN_ID_LEN);
         tokenLenBuffer.setInt(0, maxTokenLength);
 
-        int res = Quiche.quiche_header_info(contentAddress, contentReadable, Quiche.QUICHE_MAX_CONN_ID_LEN,
+        int res = Quiche.quiche_header_info(contentAddress, contentReadable, localConnIdLength,
                 Quiche.memoryAddress(versionBuffer), Quiche.memoryAddress(typeBuffer),
                 Quiche.memoryAddress(scidBuffer), Quiche.memoryAddress(scidLenBuffer),
                 Quiche.memoryAddress(dcidBuffer), Quiche.memoryAddress(dcidLenBuffer),

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -71,7 +71,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) {
         super.handlerAdded(ctx);
-        connIdBuffer = allocateNativeOrder(localConnIdLength());
+        connIdBuffer = allocateNativeOrder(localConnIdLength);
         mintTokenBuffer = allocateNativeOrder(tokenHandler.maxTokenLength());
     }
 
@@ -126,7 +126,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
             // The remote peer did not send a token.
             if (tokenHandler.writeToken(mintTokenBuffer, dcid, sender)) {
                 ByteBuffer connId = connectionIdAddressGenerator.newId(
-                        dcid.internalNioBuffer(dcid.readerIndex(), dcid.readableBytes()), localConnIdLength());
+                        dcid.internalNioBuffer(dcid.readerIndex(), dcid.readableBytes()), localConnIdLength);
                 connIdBuffer.writeBytes(connId);
 
                 ByteBuf out = ctx.alloc().directBuffer(Quic.MAX_DATAGRAM_SIZE);
@@ -160,9 +160,9 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         final long conn;
         if (noToken) {
             conn = Quiche.quiche_accept_no_token(
-                    Quiche.memoryAddress(dcid) + dcid.readerIndex(), localConnIdLength(), nativeConfig);
+                    Quiche.memoryAddress(dcid) + dcid.readerIndex(), localConnIdLength, nativeConfig);
         } else {
-            conn = Quiche.quiche_accept(Quiche.memoryAddress(dcid) + dcid.readerIndex(), localConnIdLength(),
+            conn = Quiche.quiche_accept(Quiche.memoryAddress(dcid) + dcid.readerIndex(), localConnIdLength,
                     Quiche.memoryAddress(token) + offset, token.readableBytes() - offset, nativeConfig);
         }
         if (conn < 0) {
@@ -171,7 +171,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         }
 
         // Now create the key to store the channel in the map.
-        byte[] key = new byte[localConnIdLength()];
+        byte[] key = new byte[localConnIdLength];
         dcid.getBytes(dcid.readerIndex(), key);
 
         QuicheQuicChannel channel = QuicheQuicChannel.forServer(

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -44,12 +44,12 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
     private final ChannelHandler streamHandler;
     private final Map.Entry<ChannelOption<?>, Object>[] streamOptionsArray;
     private final Map.Entry<AttributeKey<?>, Object>[] streamAttrsArray;
-    // TODO: Make this configurable ?
-    private static final int MAX_LOCAL_CONN_ID = Quiche.QUICHE_MAX_CONN_ID_LEN;
     private ByteBuf mintTokenBuffer;
     private ByteBuf connIdBuffer;
 
-    QuicheQuicServerCodec(QuicheConfig config, QuicTokenHandler tokenHandler,
+    QuicheQuicServerCodec(QuicheConfig config,
+                          int localConnIdLength,
+                          QuicTokenHandler tokenHandler,
                           QuicConnectionIdGenerator connectionIdAddressGenerator,
                           ChannelHandler handler,
                           Map.Entry<ChannelOption<?>, Object>[] optionsArray,
@@ -57,7 +57,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
                           ChannelHandler streamHandler,
                           Map.Entry<ChannelOption<?>, Object>[] streamOptionsArray,
                           Map.Entry<AttributeKey<?>, Object>[] streamAttrsArray) {
-        super(config, tokenHandler.maxTokenLength());
+        super(config, localConnIdLength, tokenHandler.maxTokenLength());
         this.tokenHandler = tokenHandler;
         this.connectionIdAddressGenerator = connectionIdAddressGenerator;
         this.handler = handler;
@@ -71,7 +71,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) {
         super.handlerAdded(ctx);
-        connIdBuffer = allocateNativeOrder(MAX_LOCAL_CONN_ID);
+        connIdBuffer = allocateNativeOrder(localConnIdLength());
         mintTokenBuffer = allocateNativeOrder(tokenHandler.maxTokenLength());
     }
 
@@ -126,7 +126,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
             // The remote peer did not send a token.
             if (tokenHandler.writeToken(mintTokenBuffer, dcid, sender)) {
                 ByteBuffer connId = connectionIdAddressGenerator.newId(
-                        dcid.internalNioBuffer(dcid.readerIndex(), dcid.readableBytes()), MAX_LOCAL_CONN_ID);
+                        dcid.internalNioBuffer(dcid.readerIndex(), dcid.readableBytes()), localConnIdLength());
                 connIdBuffer.writeBytes(connId);
 
                 ByteBuf out = ctx.alloc().directBuffer(Quic.MAX_DATAGRAM_SIZE);
@@ -160,9 +160,9 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         final long conn;
         if (noToken) {
             conn = Quiche.quiche_accept_no_token(
-                    Quiche.memoryAddress(dcid) + dcid.readerIndex(), MAX_LOCAL_CONN_ID, nativeConfig);
+                    Quiche.memoryAddress(dcid) + dcid.readerIndex(), localConnIdLength(), nativeConfig);
         } else {
-            conn = Quiche.quiche_accept(Quiche.memoryAddress(dcid) + dcid.readerIndex(), MAX_LOCAL_CONN_ID,
+            conn = Quiche.quiche_accept(Quiche.memoryAddress(dcid) + dcid.readerIndex(), localConnIdLength(),
                     Quiche.memoryAddress(token) + offset, token.readableBytes() - offset, nativeConfig);
         }
         if (conn < 0) {
@@ -171,7 +171,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         }
 
         // Now create the key to store the channel in the map.
-        byte[] key = new byte[MAX_LOCAL_CONN_ID];
+        byte[] key = new byte[localConnIdLength()];
         dcid.getBytes(dcid.readerIndex(), key);
 
         QuicheQuicChannel channel = QuicheQuicChannel.forServer(

--- a/src/main/java/io/netty/incubator/codec/quic/SecureRandomQuicConnectionIdGenerator.java
+++ b/src/main/java/io/netty/incubator/codec/quic/SecureRandomQuicConnectionIdGenerator.java
@@ -27,11 +27,6 @@ final class SecureRandomQuicConnectionIdGenerator implements QuicConnectionIdGen
     }
 
     @Override
-    public ByteBuffer newId() {
-        return newId(maxConnectionIdLength());
-    }
-
-    @Override
     public ByteBuffer newId(int length) {
         if (length > maxConnectionIdLength()) {
             throw new IllegalArgumentException();

--- a/src/test/java/io/netty/incubator/codec/quic/QuicConnectionIdGeneratorTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicConnectionIdGeneratorTest.java
@@ -30,8 +30,8 @@ public class QuicConnectionIdGeneratorTest {
     @Test
     public void testRandomness() {
         QuicConnectionIdGenerator idGenerator = QuicConnectionIdGenerator.randomGenerator();
-        ByteBuffer id = idGenerator.newId();
-        ByteBuffer id2 = idGenerator.newId();
+        ByteBuffer id = idGenerator.newId(Quiche.QUICHE_MAX_CONN_ID_LEN);
+        ByteBuffer id2 = idGenerator.newId(Quiche.QUICHE_MAX_CONN_ID_LEN);
         assertThat(id.remaining(), greaterThan(0));
         assertThat(id2.remaining(), greaterThan(0));
         assertNotEquals(id, id2);


### PR DESCRIPTION
Motivation:

We need to support connection IDs of variable length (from 0 to 20) on both client and server.

Modifications:

- Add QuicCodecBuilder.localConnIdLength(int value) method, which sets the local connection ID length
  inside the codec.
- Update QuicChannelBootstrap.connect(Promise<QuicChannel> promise) to ensure that the length of the connection
  address matches the codec.
- Add QuicConnectionAddress.random(int length)
- Remove QuicConnectionIdGenerator.newId() which does not take a length

Result:

Both client and server can use connection IDs of any length.