### PR TITLE
Make half-closure the default and also change shutdownOutput(...) to …

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/DefaultQuicStreamChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/DefaultQuicStreamChannelConfig.java
@@ -25,7 +25,9 @@ import io.netty.channel.WriteBufferWaterMark;
 import java.util.Map;
 
 final class DefaultQuicStreamChannelConfig extends DefaultChannelConfig implements QuicStreamChannelConfig {
-    private volatile boolean allowHalfClosure;
+    // We should use half-closure sementatics by default as this is what QUIC does by default.
+    // If you receive a FIN you should still keep the stream open until you write a FIN as well.
+    private volatile boolean allowHalfClosure = true;
     private volatile boolean readFrames;
 
     DefaultQuicStreamChannelConfig(QuicStreamChannel channel) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
@@ -15,12 +15,20 @@
  */
 package io.netty.incubator.codec.quic;
 
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.socket.DuplexChannel;
 
 /**
  * A QUIC stream.
  */
 public interface QuicStreamChannel extends DuplexChannel {
+
+    /**
+     * Should be added to a {@link ChannelFuture} when the FIN should be sent to the remote peer and no more
+     * writes will happen.
+     */
+    ChannelFutureListener SHUTDOWN_OUTPUT = f -> ((QuicStreamChannel) f.channel()).shutdownOutput();
 
     @Override
     QuicStreamAddress localAddress();

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -568,7 +568,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         }
     }
 
-    void streamClose(long streamId) throws Exception {
+    void streamSendFin(long streamId) throws Exception {
         try {
             // Just write an empty buffer and set fin to true.
             Quiche.throwIfError(streamSend(streamId, Unpooled.EMPTY_BUFFER, true));

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -143,13 +143,15 @@ final class QuicheQuicStreamChannel extends AbstractChannel implements QuicStrea
 
     private void shutdownOutput0(ChannelPromise channelPromise) {
         try {
+            // Just send a FIN to shutdown the output as we don't want to drop the already queued packets in the
+            // quic connection for this stream.
             sendFinIfNeeded();
         } catch (Throwable e) {
             channelPromise.setFailure(e);
             return;
         }
+        channelPromise.setSuccess();
         outputShutdown = true;
-        parent().streamShutdownWrite(streamId(), channelPromise);
         closeIfDone();
     }
 
@@ -175,6 +177,8 @@ final class QuicheQuicStreamChannel extends AbstractChannel implements QuicStrea
 
     private void shutdown0(ChannelPromise channelPromise) {
         try {
+            // Just send a FIN to shutdown the output as we don't want to drop the already queued packets in the
+            // quic connection for this stream.
             sendFinIfNeeded();
         } catch (Throwable e) {
             channelPromise.setFailure(e);
@@ -182,7 +186,7 @@ final class QuicheQuicStreamChannel extends AbstractChannel implements QuicStrea
         }
         inputShutdown = true;
         outputShutdown = true;
-        parent().streamShutdownReadAndWrite(streamId(), channelPromise);
+        parent().streamShutdownRead(streamId(), channelPromise);
         closeIfDone();
     }
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
@@ -20,6 +20,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.util.ReferenceCountUtil;
 
 import org.junit.Test;
@@ -116,6 +117,14 @@ public class QuicStreamChannelCloseTest {
         public void channelInactive(ChannelHandlerContext ctx) {
             // Close the QUIC channel as well.
             ctx.channel().parent().close();
+        }
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
+                // Received a FIN
+                ctx.close();
+            }
         }
 
         @Override


### PR DESCRIPTION
…send a FIN before shutdown the stream.

Motivation:

QUIC is half-closure by design which means you are expected to send a FIN to fully close the channel if the remote peer did send a FIN first.

Modifications:

- Change default to use half-closure semantics
- Change shutdownOutput(...) to send a FIN before shutdown the stream writing side
- Adjust unit test

Result:

More correct semantics that are also useful in protocols like HTTP3