### PR TITLE
Allow to find a QuicStreamChannel by id when you have a reference to …

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -35,6 +35,12 @@ public interface QuicChannel extends Channel {
     QuicChannelConfig config();
 
     /**
+     * Returns the {@link QuicStreamChannel} for the given {@code streamId} or {@code null} if none for this id exists
+     * yet or exists anymore.
+     */
+    QuicStreamChannel stream(long streamId);
+
+    /**
      * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Future} once done.
      * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} automatically.

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -235,6 +235,19 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         return true;
     }
 
+    @Override
+    public QuicStreamChannel stream(long streamId) {
+        if (eventLoop().inEventLoop()) {
+            return streams.get(streamId);
+        }
+        try {
+            return eventLoop().submit(() -> streams.get(streamId)).await().getNow();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        }
+    }
+
     void forceClose() {
         if (isConnDestroyed()) {
             // Just return if we already destroyed the underlying connection.


### PR DESCRIPTION
…the QuicChannel

Motivation:

It may be useful to get a reference to QuicStreamChannel by id. For example if you want to send a GOAWAY frame in H3 but are currently on a request stream.

Modifications:

Add method which allows to get a QuicStreamChannel by id

Result:

Be able to access QuicStreamChannel per id.