### PR TITLE
Correctly fire ChannelInputShutdown events

### DIFF
--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
@@ -128,12 +128,7 @@ public class QuicStreamFrameTest {
         void assertSequence() throws Exception {
             assertEquals(0, (int) queue.take());
             assertEquals(1, (int) queue.take());
-
-            if (type == QuicStreamType.BIDIRECTIONAL) {
-                // ChannelInputShutdownReadComplete is only triggered for BIDIRECTIONAL as UNIDIRECTIONAL outbound
-                // is not readable by design.
-                assertEquals(2, (int) queue.take());
-            }
+            assertEquals(2, (int) queue.take());
             assertEquals(3, (int) queue.take());
             assertTrue(queue.isEmpty());
         }


### PR DESCRIPTION
Motivation:

We need to ensure we always fire ChannelInputShutdown* events if we use half-closure as otherwise it will become complicated for users to make assumptions

Modifications:

- Always fire the events
- Adjust tests to match this

Result:

Easier to reason about events