### PR TITLE
Fix javadoc errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,6 +440,7 @@
         <version>false</version>
         <author>false</author>
         <keywords>true</keywords>
+        <source>8</source>
       </configuration>
     </plugin>
     <plugin>

--- a/src/main/java/io/netty/incubator/codec/quic/Quic.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quic.java
@@ -49,6 +49,8 @@ public final class Quic {
 
     /**
      * Returns {@code true} if and only if the QUIC implementation is usable on the running platform is available.
+     *
+     * @return {@code true} if this QUIC implementation can be used on the current platform, {@code false} otherwise.
      */
     public static boolean isAvailable() {
         return UNAVAILABILITY_CAUSE == null;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -38,6 +38,11 @@ public interface QuicChannel extends Channel {
      * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Future} once done.
      * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} automatically.
+     *
+     * @param type      the {@link QuicStreamType} of the {@link QuicStreamChannel}.
+     * @param handler   the {@link ChannelHandler} that will be added to the {@link QuicStreamChannel}s
+     *                  {@link io.netty.channel.ChannelPipeline} during the stream creation.
+     * @return          the {@link Future} that will be notified once the operation completes.
      */
     default Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler) {
         return createStream(type, handler, eventLoop().newPromise());
@@ -47,6 +52,12 @@ public interface QuicChannel extends Channel {
      * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Promise} once done.
      * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} automatically.
+     *
+     * @param type      the {@link QuicStreamType} of the {@link QuicStreamChannel}.
+     * @param handler   the {@link ChannelHandler} that will be added to the {@link QuicStreamChannel}s
+     *                  {@link io.netty.channel.ChannelPipeline} during the stream creation.
+     * @param promise   the {@link ChannelPromise} that will be notified once the operation completes.
+     * @return          the {@link Future} that will be notified once the operation completes.
      */
     Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler,
                                            Promise<QuicStreamChannel> promise);
@@ -56,6 +67,8 @@ public interface QuicChannel extends Channel {
      * with custom options and attributes. For simpler use-cases you may want to consider using
      * {@link #createStream(QuicStreamType, ChannelHandler)} or
      * {@link #createStream(QuicStreamType, ChannelHandler, Promise)} directly.
+     *
+     * @return {@link QuicStreamChannelBootstrap} that can be used to bootstrap a {@link QuicStreamChannel}.
      */
     default QuicStreamChannelBootstrap newStreamBootstrap() {
         return new QuicStreamChannelBootstrap(this);
@@ -63,6 +76,8 @@ public interface QuicChannel extends Channel {
 
     /**
      * Returns the negotiated ALPN protocol or {@code null} if none has been negotiated.
+     *
+     * @return the application protocol or {@code null} if none has been negotiated.
      */
     byte[] applicationProtocol();
 
@@ -93,6 +108,8 @@ public interface QuicChannel extends Channel {
 
     /**
      * Collects statistics about the connection and notifies the {@link Future} once done.
+     *
+     * @return the {@link Future} that is notified once the stats were collected.
      */
     default Future<QuicConnectionStats> collectStats() {
         return collectStats(eventLoop().newPromise());
@@ -100,12 +117,18 @@ public interface QuicChannel extends Channel {
 
     /**
      * Collects statistics about the connection and notifies the {@link Promise} once done.
+     *
+     * @param   promise the {@link ChannelPromise} that is notified once the stats were collected.
+     * @return          the {@link Future} that is notified once the stats were collected.
      */
     Future<QuicConnectionStats> collectStats(Promise<QuicConnectionStats> promise);
 
     /**
      * Creates a new {@link QuicChannelBootstrap} that can be used to create and connect new {@link QuicChannel}s to
      * endpoints using the given {@link Channel} as transport layer.
+     *
+     * @param channel   the {@link Channel} that is used as transport layer.
+     * @return          {@link QuicChannelBootstrap} that can be used to bootstrap a client side {@link QuicChannel}.
      */
     static QuicChannelBootstrap newBootstrap(Channel channel) {
         return new QuicChannelBootstrap(channel);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
@@ -55,6 +55,8 @@ public final class QuicChannelBootstrap {
      * Creates a new instance which uses the given {@link Channel} to bootstrap the {@link QuicChannel}.
      * This {@link io.netty.channel.ChannelPipeline} of the {@link Channel} needs to have the quic codec in the
      * pipeline.
+     *
+     * @param parent    the {@link Channel} that is used as the transport layer.
      */
     QuicChannelBootstrap(Channel parent) {
         Quic.ensureAvailability();
@@ -64,6 +66,11 @@ public final class QuicChannelBootstrap {
     /**
      * Allow to specify a {@link ChannelOption} which is used for the {@link QuicChannel} instances once they got
      * created. Use a value of {@code null} to remove a previous set {@link ChannelOption}.
+     *
+     * @param option    the {@link ChannelOption} to apply to the {@link QuicChannel}.
+     * @param value     the value of the option.
+     * @param <T>       the type of the value.
+     * @return          this instance.
      */
     public <T> QuicChannelBootstrap option(ChannelOption<T> option, T value) {
         Quic.updateOptions(options, option, value);
@@ -73,6 +80,11 @@ public final class QuicChannelBootstrap {
     /**
      * Allow to specify an initial attribute of the newly created {@link QuicChannel}.  If the {@code value} is
      * {@code null}, the attribute of the specified {@code key} is removed.
+     *
+     * @param key       the {@link AttributeKey} to apply to the {@link QuicChannel}.
+     * @param value     the value of the attribute.
+     * @param <T>       the type of the value.
+     * @return          this instance.
      */
     public <T> QuicChannelBootstrap attr(AttributeKey<T> key, T value) {
         Quic.updateAttributes(attrs, key, value);
@@ -82,6 +94,10 @@ public final class QuicChannelBootstrap {
     /**
      * Set the {@link ChannelHandler} that is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicChannel} once created.
+     *
+     * @param handler   the {@link ChannelHandler} that is added to the {@link QuicChannel}s
+     *                  {@link io.netty.channel.ChannelPipeline}.
+     * @return          this instance.
      */
     public QuicChannelBootstrap handler(ChannelHandler handler) {
         this.handler = ObjectUtil.checkNotNull(handler, "handler");
@@ -91,6 +107,11 @@ public final class QuicChannelBootstrap {
     /**
      * Allow to specify a {@link ChannelOption} which is used for the {@link QuicStreamChannel} instances once they got
      * created. Use a value of {@code null} to remove a previous set {@link ChannelOption}.
+     *
+     * @param option    the {@link ChannelOption} to apply to the {@link QuicStreamChannel}s.
+     * @param value     the value of the option.
+     * @param <T>       the type of the value.
+     * @return          this instance.
      */
     public <T> QuicChannelBootstrap streamOption(ChannelOption<T> option, T value) {
         Quic.updateOptions(streamOptions, option, value);
@@ -100,6 +121,11 @@ public final class QuicChannelBootstrap {
     /**
      * Allow to specify an initial attribute of the newly created {@link QuicStreamChannel}. If the {@code value} is
      * {@code null}, the attribute of the specified {@code key} is removed.
+     *
+     * @param key       the {@link AttributeKey} to apply to the {@link QuicStreamChannel}s.
+     * @param value     the value of the attribute.
+     * @param <T>       the type of the value.
+     * @return          this instance.
      */
     public <T> QuicChannelBootstrap streamAttr(AttributeKey<T> key, T value) {
         Quic.updateAttributes(streamAttrs, key, value);
@@ -109,6 +135,10 @@ public final class QuicChannelBootstrap {
     /**
      * Set the {@link ChannelHandler} that is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} once created.
+     *
+     * @param streamHandler     the {@link ChannelHandler} that is added to the {@link QuicStreamChannel}s
+     *                          {@link io.netty.channel.ChannelPipeline}.
+     * @return                  this instance.
      */
     public QuicChannelBootstrap streamHandler(ChannelHandler streamHandler) {
         this.streamHandler = ObjectUtil.checkNotNull(streamHandler, "streamHandler");
@@ -117,6 +147,9 @@ public final class QuicChannelBootstrap {
 
     /**
      * Set the remote address of the host to talk to.
+     *
+     * @param remote    the {@link SocketAddress} of the remote peer.
+     * @return          this instance.
      */
     public QuicChannelBootstrap remoteAddress(SocketAddress remote) {
         this.remote = ObjectUtil.checkNotNull(remote, "remote");
@@ -126,6 +159,9 @@ public final class QuicChannelBootstrap {
     /**
      * Set the {@link QuicConnectionAddress} to use. If none is specified a random address is generated on your
      * behalf.
+     *
+     * @param connectionAddress     the {@link QuicConnectionAddress} to use.
+     * @return                      this instance.
      */
     public QuicChannelBootstrap connectionAddress(QuicConnectionAddress connectionAddress) {
         this.connectionAddress = ObjectUtil.checkNotNull(connectionAddress, "connectionAddress");
@@ -134,6 +170,8 @@ public final class QuicChannelBootstrap {
 
     /**
      * Connects a {@link QuicChannel} to the remote peer and notifies the future once done.
+     *
+     * @return {@link Future} which is notified once the operation completes.
      */
     public Future<QuicChannel> connect() {
         return connect(parent.eventLoop().newPromise());
@@ -141,6 +179,10 @@ public final class QuicChannelBootstrap {
 
     /**
      * Connects a {@link QuicChannel} to the remote peer and notifies the promise once done.
+     *
+     * @param promise   the {@link Promise} which is notified once the operations completes.
+     * @return          {@link Future} which is notified once the operation completes.
+
      */
     public Future<QuicChannel> connect(Promise<QuicChannel> promise) {
         if (handler == null && streamHandler == null) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelConfig.java
@@ -62,6 +62,8 @@ public interface QuicChannelConfig extends ChannelConfig {
 
     /**
      * Return the server name parameter used to verify peer's certificate.
+     *
+     * @return the server name parameter.
      */
     String getPeerCertServerName();
 
@@ -70,6 +72,9 @@ public interface QuicChannelConfig extends ChannelConfig {
      *
      * <strong>Be aware this config setting can only be adjusted before the
      * connection is established.</strong>
+     *
+     * @param peerCertServerName    the server name parameter.
+     * @return                      the instance itself.
      */
     QuicChannelConfig setPeerCertServerName(String peerCertServerName);
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
@@ -23,6 +23,11 @@ import io.netty.channel.ChannelHandler;
  */
 public final class QuicClientCodecBuilder extends QuicCodecBuilder<QuicClientCodecBuilder> {
 
+    /**
+     * Creates a new instance.
+     */
+    public QuicClientCodecBuilder() { }
+
     @Override
     protected ChannelHandler build(QuicheConfig config, int localConnIdLength) {
         return new QuicheQuicClientCodec(config, localConnIdLength);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -24,6 +24,8 @@ import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
  * Abstract base class for {@code QUIC} codec builders.
+ *
+ * @param <B> the type of the {@link QuicCodecBuilder}.
  */
 public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
 
@@ -52,6 +54,11 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
         Quic.ensureAvailability();
     }
 
+    /**
+     * Returns itself.
+     *
+     * @return itself.
+     */
     @SuppressWarnings("unchecked")
     protected final B self() {
         return (B) this;
@@ -59,6 +66,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
 
     /**
      * Sets the congestion control algorithm to use.
+     *
+     * @param congestionControlAlgorithm    the {@link QuicCongestionControlAlgorithm} to use.
+     * @return                              the instance itself.
      */
     public final B congestionControlAlgorithm(QuicCongestionControlAlgorithm congestionControlAlgorithm) {
         this.congestionControlAlgorithm = congestionControlAlgorithm;
@@ -67,6 +77,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
 
     /**
      * Set the path to the certificate chain to use.
+     *
+     * @param path  the path to the chain.
+     * @return      the instance itself.
      */
     public final B certificateChain(String path) {
         certPath = checkNotNull(path, "path");
@@ -75,6 +88,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
 
     /**
      * Set the path to the private key to use.
+     *
+     * @param path  the path to the key.
+     * @return      the instance itself.
      */
     public final B privateKey(String path) {
         keyPath = checkNotNull(path, "path");
@@ -83,6 +99,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
 
     /**
      * Set if the remote peer should be verified or not.
+     *
+     * @param verify    {@code true} if verification should be done.
+     * @return          the instance itself.
      */
     public final B verifyPeer(boolean verify) {
         verifyPeer = verify;
@@ -92,6 +111,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     /**
      * Set if <a href="https://tools.ietf.org/html/draft-thomson-quic-bit-grease-00">greasing</a> should be enabled
      * or not.
+     *
+     * @param enable    {@code true} if enabled, {@code false} otherwise.
+     * @return          the instance itself.
      */
     public final B grease(boolean enable) {
         grease = enable;
@@ -100,6 +122,8 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
 
     /**
      * Enable the support of early data.
+     *
+     * @return the instance itself.
      */
     public final B enableEarlyData() {
         earlyData = true;
@@ -107,10 +131,13 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     }
 
     /**
-     * Set the application protocols to use. These are in wire.format and so prefixed with the length each.
+     * Set the application protocols to use. These are in wire-format and so prefixed with the length each.
      *
      * See <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_application_protos">
      *     set_application_protos</a>
+     *
+     * @param protos    the application protocols in wire-format.
+     * @return          the instance itself.
      */
     public final B applicationProtocols(byte[] protos) {
         this.protos = protos.clone();
@@ -120,6 +147,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     /**
      * See <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_max_idle_timeout">
      *     set_max_idle_timeout</a>.
+     *
+     * @param millis    the maximum idle timeout.
+     * @return          the instance itself.
      */
     public final B maxIdleTimeout(long millis) {
         this.maxIdleTimeout = checkPositiveOrZero(millis, "value");
@@ -128,6 +158,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     /**
      * See <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_max_udp_payload_size">
      *     set_max_udp_payload_size</a>.
+     *
+     * @param size    the maximum payload size that is advertised to the remote peer.
+     * @return        the instance itself.
      */
     public final B maxUdpPayloadSize(long size) {
         this.maxUdpPayloadSize = checkPositiveOrZero(size, "value");
@@ -137,6 +170,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     /**
      * See <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_initial_max_data">
      *     set_initial_max_data</a>.
+     *
+     * @param value   the initial maximum data limit.
+     * @return        the instance itself.
      */
     public final B initialMaxData(long value) {
         this.initialMaxData = checkPositiveOrZero(value, "value");
@@ -147,6 +183,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * See
      * <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_initial_max_stream_data_bidi_local">
      *     set_initial_max_stream_data_bidi_local</a>.
+     *
+     * @param value   the initial maximum data limit for local bidirectional streams.
+     * @return        the instance itself.
      */
     public final B initialMaxStreamDataBidirectionalLocal(long value) {
         this.initialMaxStreamDataBidiLocal = checkPositiveOrZero(value, "value");
@@ -157,6 +196,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * See
      * <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_initial_max_stream_data_bidi_remote">
      *     set_initial_max_stream_data_bidi_remote</a>.
+     *
+     * @param value   the initial maximum data limit for remote bidirectional streams.
+     * @return        the instance itself.
      */
     public final B initialMaxStreamDataBidirectionalRemote(long value) {
         this.initialMaxStreamDataBidiRemote = checkPositiveOrZero(value, "value");
@@ -167,6 +209,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * See
      * <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_initial_max_streams_uni">
      *     set_initial_max_streams_uni</a>.
+     *
+     * @param value   the initial maximum data limit for unidirectional streams.
+     * @return        the instance itself.
      */
     public final B initialMaxStreamDataUnidirectional(long value) {
         this.initialMaxStreamDataUni = checkPositiveOrZero(value, "value");
@@ -177,6 +222,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * See
      * <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_initial_max_streams_bidi">
      *     set_initial_max_streams_bidi</a>.
+     *
+     * @param value   the initial maximum stream limit for bidirectional streams.
+     * @return        the instance itself.
      */
     public final B initialMaxStreamsBidirectional(long value) {
         this.initialMaxStreamsBidi = checkPositiveOrZero(value, "value");
@@ -187,6 +235,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * See
      * <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_initial_max_streams_uni">
      *     set_initial_max_streams_uni</a>.
+     *
+     * @param value   the initial maximum stream limit for bidirectional streams.
+     * @return        the instance itself.
      */
     public final B initialMaxStreamsUnidirectional(long value) {
         this.initialMaxStreamsUni = checkPositiveOrZero(value, "value");
@@ -197,6 +248,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * See
      * <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_ack_delay_exponent">
      *     set_ack_delay_exponent</a>.
+     *
+     * @param value   the delay exponent used for ACKs.
+     * @return        the instance itself.
      */
     public final B ackDelayExponent(long value) {
         this.ackDelayExponent = checkPositiveOrZero(value, "value");
@@ -207,6 +261,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * See
      * <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_max_ack_delay">
      *     set_max_ack_delay</a>.
+     *
+     * @param value   the max ack delay.
+     * @return        the instance itself.
      */
     public final B maxAckDelay(long value) {
         this.maxAckDelay = checkPositiveOrZero(value, "value");
@@ -217,6 +274,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * See
      * <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_disable_active_migration">
      *     set_disable_active_migration</a>.
+     *
+     * @param value   {@code true} if migration should be disabled.
+     * @return        the instance itself.
      */
     public final B disableActiveMigration(boolean value) {
         this.disableActiveMigration = value;
@@ -227,6 +287,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * See
      * <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.enable_hystart">
      *     enable_hystart</a>.
+     *
+     * @param value   {@code true} if Hystart should be enabled.
+     * @return        the instance itself.
      */
     public final B enableHystart(boolean value) {
         this.enableHystart = value;
@@ -235,6 +298,9 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
 
     /**
      * Sets the local connection id length that is used.
+     *
+     * @param value   {@code true} the length of local generated connections ids.
+     * @return        the instance itself.
      */
     public final B localConnectionIdLength(int value) {
         this.localConnIdLength = checkInRange(value, 0, Quiche.QUICHE_MAX_CONN_ID_LEN,  "value");
@@ -256,13 +322,22 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     protected void validate() { }
 
     /**
-     * Build the QUIC codec that should be added to the {@link io.netty.channel.ChannelPipeline} of the underlying
+     * Builds the QUIC codec that should be added to the {@link io.netty.channel.ChannelPipeline} of the underlying
      * {@link io.netty.channel.Channel} which is used as transport for QUIC.
+     *
+     * @return the {@link ChannelHandler} which acts as QUIC codec.
      */
     public final ChannelHandler build() {
         validate();
         return build(createConfig(), localConnIdLength);
     }
 
+    /**
+     * Builds the QUIC codec.
+     *
+     * @param config            the {@link QuicheConfig} that should be used.
+     * @param localConnIdLength the local connection id length.
+     * @return                  the {@link ChannelHandler} which acts as codec.
+     */
     protected abstract ChannelHandler build(QuicheConfig config, int localConnIdLength);
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicConnectionAddress.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicConnectionAddress.java
@@ -96,7 +96,8 @@ public final class QuicConnectionAddress extends SocketAddress {
      * Return a random generated {@link QuicConnectionAddress} of a given length
      * that can be used to connect a {@link QuicChannel}
      *
-     * @param length the length of the {@link QuicConnectionAddress} to generate.
+     * @param length    the length of the {@link QuicConnectionAddress} to generate.
+     * @return          the generated address.
      */
     public static QuicConnectionAddress random(int length) {
         return new QuicConnectionAddress(QuicConnectionIdGenerator.randomGenerator().newId(length));
@@ -105,6 +106,8 @@ public final class QuicConnectionAddress extends SocketAddress {
     /**
      * Return a random generated {@link QuicConnectionAddress} of maximum size
      * that can be used to connect a {@link QuicChannel}
+     *
+     * @return the generated address.
      */
     public static QuicConnectionAddress random() {
         return random(Quiche.QUICHE_MAX_CONN_ID_LEN);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicConnectionIdGenerator.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicConnectionIdGenerator.java
@@ -23,22 +23,33 @@ import java.nio.ByteBuffer;
 public interface QuicConnectionIdGenerator {
     /**
      * Creates a new {@link QuicConnectionAddress} with the given length.
+     *
+     * @param length    the length of the id.
+     * @return          the id.
      */
     ByteBuffer newId(int length);
 
     /**
      * Creates a new connection id with the given length. The given input may be used to sign or
      * seed the id, or may be ignored (depending on the implementation).
+     *
+     * @param input     the input which may be used to generate the id.
+     * @param length    the length of the id.
+     * @return          the id.
      */
     ByteBuffer newId(ByteBuffer input, int length);
 
     /**
      * Returns the maximum length of a connection id.
+     *
+     * @return the maximum length of a connection id that is supported.
      */
     int maxConnectionIdLength();
 
     /**
      * Return a {@link QuicConnectionIdGenerator} which randomly generates new connection ids.
+     *
+     * @return a {@link QuicConnectionIdGenerator} which randomly generated ids.
      */
     static QuicConnectionIdGenerator randomGenerator() {
         return SecureRandomQuicConnectionIdGenerator.INSTANCE;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicException.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicException.java
@@ -31,6 +31,8 @@ public final class QuicException extends IOException {
 
     /**
      * Returns the {@link QuicError} which was the cause of the {@link QuicException}.
+     *
+     * @return  the {@link QuicError} that caused this {@link QuicException}.
      */
     public QuicError error() {
         return error;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -40,11 +40,19 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     private QuicConnectionIdGenerator connectionIdAddressGenerator;
     private QuicTokenHandler tokenHandler;
 
+    /**
+     * Creates a new instance.
+     */
     public QuicServerCodecBuilder() { }
 
     /**
      * Allow to specify a {@link ChannelOption} which is used for the {@link QuicChannel} instances once they got
      * created. Use a value of {@code null} to remove a previous set {@link ChannelOption}.
+     *
+     * @param option    the {@link ChannelOption} to apply to the {@link QuicChannel}.
+     * @param value     the value of the option.
+     * @param <T>       the type of the value.
+     * @return          this instance.
      */
     public <T> QuicServerCodecBuilder option(ChannelOption<T> option, T value) {
         Quic.updateOptions(options, option, value);
@@ -54,6 +62,11 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     /**
      * Allow to specify an initial attribute of the newly created {@link QuicChannel}.  If the {@code value} is
      * {@code null}, the attribute of the specified {@code key} is removed.
+     *
+     * @param key       the {@link AttributeKey} to apply to the {@link QuicChannel}.
+     * @param value     the value of the attribute.
+     * @param <T>       the type of the value.
+     * @return          this instance.
      */
     public <T> QuicServerCodecBuilder attr(AttributeKey<T> key, T value) {
         Quic.updateAttributes(attrs, key, value);
@@ -63,6 +76,10 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     /**
      * Set the {@link ChannelHandler} that is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicChannel} once created.
+     *
+     * @param handler   the {@link ChannelHandler} that is added to the {@link QuicChannel}s
+     *                  {@link io.netty.channel.ChannelPipeline}.
+     * @return          this instance.
      */
     public QuicServerCodecBuilder handler(ChannelHandler handler) {
         this.handler = ObjectUtil.checkNotNull(handler, "handler");
@@ -72,6 +89,11 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     /**
      * Allow to specify a {@link ChannelOption} which is used for the {@link QuicStreamChannel} instances once they got
      * created. Use a value of {@code null} to remove a previous set {@link ChannelOption}.
+     *
+     * @param option    the {@link ChannelOption} to apply to the {@link QuicStreamChannel}s.
+     * @param value     the value of the option.
+     * @param <T>       the type of the value.
+     * @return          this instance.
      */
     public <T> QuicServerCodecBuilder streamOption(ChannelOption<T> option, T value) {
         Quic.updateOptions(streamOptions, option, value);
@@ -81,6 +103,11 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     /**
      * Allow to specify an initial attribute of the newly created {@link QuicStreamChannel}. If the {@code value} is
      * {@code null}, the attribute of the specified {@code key} is removed.
+     *
+     * @param key       the {@link AttributeKey} to apply to the {@link QuicStreamChannel}s.
+     * @param value     the value of the attribute.
+     * @param <T>       the type of the value.
+     * @return          this instance.
      */
     public <T> QuicServerCodecBuilder streamAttr(AttributeKey<T> key, T value) {
         Quic.updateAttributes(streamAttrs, key, value);
@@ -90,6 +117,10 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     /**
      * Set the {@link ChannelHandler} that is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} once created.
+     *
+     * @param streamHandler     the {@link ChannelHandler} that is added to the {@link QuicStreamChannel}s
+     *                          {@link io.netty.channel.ChannelPipeline}.
+     * @return                  this instance.
      */
     public QuicServerCodecBuilder streamHandler(ChannelHandler streamHandler) {
         this.streamHandler = ObjectUtil.checkNotNull(streamHandler, "streamHandler");
@@ -98,6 +129,9 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
 
     /**
      * Sets the {@link QuicConnectionIdGenerator} to use.
+     *
+     * @param connectionIdAddressGenerator  the {@link QuicConnectionIdGenerator} to use.
+     * @return                              this instance.
      */
     public QuicServerCodecBuilder connectionIdAddressGenerator(
             QuicConnectionIdGenerator connectionIdAddressGenerator) {
@@ -107,6 +141,9 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
 
     /**
      * Set the {@link QuicTokenHandler} that is used to generate and validate tokens.
+     *
+     * @param tokenHandler  the {@link QuicTokenHandler} to use.
+     * @return              this instance.
      */
     public QuicServerCodecBuilder tokenHandler(QuicTokenHandler tokenHandler) {
         this.tokenHandler = ObjectUtil.checkNotNull(tokenHandler, "tokenHandler");

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamAddress.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamAddress.java
@@ -31,6 +31,8 @@ public final class QuicStreamAddress extends SocketAddress {
 
     /**
      * Return the id of the stream.
+     *
+     * @return the id.
      */
     public long streamId() {
         return streamId;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
@@ -38,16 +38,22 @@ public interface QuicStreamChannel extends DuplexChannel {
 
     /**
      * Returns {@code true} if the stream was created locally.
+     *
+     * @return {@code true} if created locally, {@code false} otherwise.
      */
     boolean isLocalCreated();
 
     /**
      * Returns the {@link QuicStreamType} of the stream.
+     *
+     * @return {@link QuicStreamType} of this stream.
      */
     QuicStreamType type();
 
     /**
      * The id of the stream.
+     *
+     * @return the stream id of this {@link QuicStreamChannel}.
      */
     long streamId();
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelBootstrap.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelBootstrap.java
@@ -43,6 +43,9 @@ public final class QuicStreamChannelBootstrap {
 
     /**
      * Creates a new instance which uses the given {@link QuicChannel} to bootstrap {@link QuicStreamChannel}s.
+     *
+     * @param parent    the {@link QuicChannel} that is used.
+
      */
     QuicStreamChannelBootstrap(QuicChannel parent) {
         this.parent = ObjectUtil.checkNotNull(parent, "parent");
@@ -51,6 +54,11 @@ public final class QuicStreamChannelBootstrap {
     /**
      * Allow to specify a {@link ChannelOption} which is used for the {@link QuicStreamChannel} instances once they got
      * created. Use a value of {@code null} to remove a previous set {@link ChannelOption}.
+     *
+     * @param option    the {@link ChannelOption} to apply to the {@link QuicStreamChannel}.
+     * @param value     the value of the option.
+     * @param <T>       the type of the value.
+     * @return          this instance.
      */
     public <T> QuicStreamChannelBootstrap option(ChannelOption<T> option, T value) {
         Quic.updateOptions(options, option, value);
@@ -60,6 +68,11 @@ public final class QuicStreamChannelBootstrap {
     /**
      * Allow to specify an initial attribute of the newly created {@link QuicStreamChannel}. If the {@code value} is
      * {@code null}, the attribute of the specified {@code key} is removed.
+     *
+     * @param key       the {@link AttributeKey} to apply to the {@link QuicChannel}.
+     * @param value     the value of the attribute.
+     * @param <T>       the type of the value.
+     * @return          this instance.
      */
     public <T> QuicStreamChannelBootstrap attr(AttributeKey<T> key, T value) {
         Quic.updateAttributes(attrs, key, value);
@@ -69,6 +82,10 @@ public final class QuicStreamChannelBootstrap {
     /**
      * Set the {@link ChannelHandler} that is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} once created.
+     *
+     * @param streamHandler     the {@link ChannelHandler} that is added to the {@link QuicStreamChannel}s
+     *                          {@link io.netty.channel.ChannelPipeline}.
+     * @return                  this instance.
      */
     public QuicStreamChannelBootstrap handler(ChannelHandler streamHandler) {
         this.handler = ObjectUtil.checkNotNull(streamHandler, "streamHandler");
@@ -78,6 +95,9 @@ public final class QuicStreamChannelBootstrap {
     /**
      * Set the {@link QuicStreamType} to use for the {@link QuicStreamChannel}, default is
      * {@link QuicStreamType#BIDIRECTIONAL}.
+     *
+     * @param type     the {@link QuicStreamType} of the  {@link QuicStreamChannel}.
+     * @return         this instance.
      */
     public QuicStreamChannelBootstrap type(QuicStreamType type) {
         this.type = ObjectUtil.checkNotNull(type, "type");
@@ -86,6 +106,8 @@ public final class QuicStreamChannelBootstrap {
 
     /**
      * Creates a new {@link QuicStreamChannel} and notifies the {@link Future}.
+     *
+     * @return  the {@link Future} that is notified once the operation completes.
      */
     public Future<QuicStreamChannel> create() {
         return create(parent.eventLoop().newPromise());
@@ -93,6 +115,9 @@ public final class QuicStreamChannelBootstrap {
 
     /**
      * Creates a new {@link QuicStreamChannel} and notifies the {@link Future}.
+     *
+     * @param promise   the {@link Promise} that is notified once the operation completes.
+     * @return          the {@link Future} that is notified once the operation completes.
      */
     public Future<QuicStreamChannel> create(Promise<QuicStreamChannel> promise) {
         if (handler == null) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelConfig.java
@@ -28,12 +28,20 @@ public interface QuicStreamChannelConfig extends DuplexChannelConfig {
     /**
      * Set this to {@code true} if the {@link QuicStreamChannel} should read {@link QuicStreamFrame}s and fire these
      * through the {@link io.netty.channel.ChannelPipeline}, {@code false} if it uses {@link io.netty.buffer.ByteBuf}.
+     *
+     * @param readFrames    {@code true} if {@link QuicStreamFrame}s should be used, {@code false} if
+     *                      {@link io.netty.buffer.ByteBuf} should be used.
+     * @return              this instance itself.
+     *
      */
     QuicStreamChannelConfig setReadFrames(boolean readFrames);
 
     /**
      * Returns {@code true} if the {@link QuicStreamChannel} will read {@link QuicStreamFrame}s and fire these through
      * the {@link io.netty.channel.ChannelPipeline}, {@code false} if it uses {@link io.netty.buffer.ByteBuf}.
+     *
+     * @return  {@code true} if {@link QuicStreamFrame}s should be used, {@code false} if
+     *          {@link io.netty.buffer.ByteBuf} should be used.
      */
     boolean isReadFrames();
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamFrame.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamFrame.java
@@ -26,6 +26,8 @@ public interface QuicStreamFrame extends ByteBufHolder {
     /**
      * Returns {@code true} if the frame has the FIN set, which means it notifies the remote peer that
      * there will be no more writing happen. {@code false} otherwise.
+     *
+     * @return {@code true} if the FIN flag should be set, {@code false} otherwise.
      */
     boolean hasFin();
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicTokenHandler.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicTokenHandler.java
@@ -27,17 +27,28 @@ public interface QuicTokenHandler {
     /**
      * Generate a new token for the given destination connection id and address. This token is written to {@code out}.
      * If no token should be generated and so no token validation should take place at all this method should return
-     * {@link false}.
+     * {@code false}.
+     *
+     * @param out       {@link ByteBuf} into which the token will be written.
+     * @param dcid      the destination connection id.
+     * @param address   the {@link InetSocketAddress} of the sender.
+     * @return          {@code true} if a token was written and so validation should happen, {@code false} otherwise.
      */
     boolean writeToken(ByteBuf out, ByteBuf dcid, InetSocketAddress address);
 
     /**
-     * Return the given toke and return the offset, {@code -1} is returned if the token is not valid.
+     * Validate the token and return the offset, {@code -1} is returned if the token is not valid.
+     *
+     * @param token     the {@link ByteBuf} that contains the token. The ownership is not transferred.
+     * @param address   the {@link InetSocketAddress} of the sender.
+     * @return          the start index after the token or {@code -1} if the token was not valid.
      */
     int validateToken(ByteBuf token, InetSocketAddress address);
 
     /**
      * Return the maximal token length.
+     *
+     * @return the maximal supported token length.
      */
     int maxTokenLength();
 }


### PR DESCRIPTION
Motivation:

We should not suppress javadoc errors but just not generate any errors in the first place.

Modifications:

Fix javadocs

Result:

No more errors during generation of javadocs