### PR TITLE
Make it easier for people to have native libs for different platforms…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <netty.version>4.1.54.Final</netty.version>
     <netty.build.version>28</netty.build.version>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
+    <jniLibName>netty_quiche_${os.detected.name}_${os.detected.arch}</jniLibName>
     <jniUtilCheckoutDir>${project.build.directory}/netty-jni-util</jniUtilCheckoutDir>
     <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/src/c</jniUtilIncludeDir>
     <quicheCheckoutDir>${project.build.directory}/quiche</quicheCheckoutDir>
@@ -481,7 +482,7 @@
           <execution>
             <id>build-native-lib</id>
             <configuration>
-              <name>netty_quiche_${os.detected.arch}</name>
+              <name>${jniLibName}</name>
               <nativeSourceDirectory>${generatedSourcesDir}</nativeSourceDirectory>
               <libDirectory>${project.build.outputDirectory}</libDirectory>
               <!-- We use Maven's artifact classifier instead.

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.internal.NativeLibraryLoader;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -50,19 +49,14 @@ final class Quiche {
 
     private static void loadNativeLibrary() {
         // This needs to be kept in sync with what is defined in netty_quic_quiche.c
-        String staticLibName = "netty_quiche";
-        String sharedLibName = staticLibName + '_' + PlatformDependent.normalizedArch();
+        String libName = "netty_quiche" + '_' + PlatformDependent.normalizedOs()
+                + '_' + PlatformDependent.normalizedArch();
         ClassLoader cl = PlatformDependent.getClassLoader(Quiche.class);
         try {
-            NativeLibraryLoader.load(sharedLibName, cl);
-        } catch (UnsatisfiedLinkError e1) {
-            try {
-                NativeLibraryLoader.load(staticLibName, cl);
-                logger.debug("Failed to load {}", sharedLibName, e1);
-            } catch (UnsatisfiedLinkError e2) {
-                ThrowableUtil.addSuppressed(e1, e2);
-                throw e1;
-            }
+            NativeLibraryLoader.load(libName, cl);
+        } catch (UnsatisfiedLinkError e) {
+            logger.debug("Failed to load {}", libName, e);
+            throw e;
         }
     }
 


### PR DESCRIPTION
… on the classpath

Motivation:

We should include the os name in the libname to make it easier to have jars for multiple platforms on the classpath

Modifications:

Add os to libname and adjust loading code

Result:

Be able to have multiple libs on the classpath