### PR TITLE
Use TimeUnit in builder to make it more clear what the exact unit is

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -18,6 +18,8 @@ package io.netty.incubator.codec.quic;
 import io.netty.channel.ChannelHandler;
 
 
+import java.util.concurrent.TimeUnit;
+
 import static io.netty.util.internal.ObjectUtil.checkInRange;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
@@ -148,13 +150,15 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * See <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_max_idle_timeout">
      *     set_max_idle_timeout</a>.
      *
-     * @param millis    the maximum idle timeout.
+     * @param amount    the maximum idle timeout.
+     * @param unit      the {@link TimeUnit}.
      * @return          the instance itself.
      */
-    public final B maxIdleTimeout(long millis) {
-        this.maxIdleTimeout = checkPositiveOrZero(millis, "value");
+    public final B maxIdleTimeout(long amount, TimeUnit unit) {
+        this.maxIdleTimeout = unit.toMillis(checkPositiveOrZero(amount, "amount"));
         return self();
     }
+
     /**
      * See <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_max_udp_payload_size">
      *     set_max_udp_payload_size</a>.
@@ -262,11 +266,12 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_max_ack_delay">
      *     set_max_ack_delay</a>.
      *
-     * @param value   the max ack delay.
-     * @return        the instance itself.
+     * @param amount    the max ack delay.
+     * @param unit      the {@link TimeUnit}.
+     * @return          the instance itself.
      */
-    public final B maxAckDelay(long value) {
-        this.maxAckDelay = checkPositiveOrZero(value, "value");
+    public final B maxAckDelay(long amount, TimeUnit unit) {
+        this.maxAckDelay = unit.toMillis(checkPositiveOrZero(amount, "amount"));
         return self();
     }
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicClientExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicClientExample.java
@@ -28,6 +28,7 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
 
 public final class QuicClientExample {
 
@@ -47,7 +48,7 @@ public final class QuicClientExample {
                     .certificateChain("./src/test/resources/cert.crt")
                     .privateKey("./src/test/resources/cert.key")
                     .applicationProtocols(proto)
-                    .maxIdleTimeout(5000)
+                    .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
                     .maxUdpPayloadSize(Quic.MAX_DATAGRAM_SIZE)
                     .initialMaxData(10000000)
                     .initialMaxStreamDataBidirectionalLocal(1000000)

--- a/src/test/java/io/netty/incubator/codec/quic/QuicExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicExample.java
@@ -29,6 +29,7 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
 
 public final class QuicExample {
 
@@ -49,7 +50,7 @@ public final class QuicExample {
                 .certificateChain("./src/test/resources/cert.crt")
                 .privateKey("./src/test/resources/cert.key")
                 .applicationProtocols(proto)
-                .maxIdleTimeout(5000)
+                .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
                 .maxUdpPayloadSize(Quic.MAX_DATAGRAM_SIZE)
                 .initialMaxData(10000000)
                 .initialMaxStreamDataBidirectionalLocal(1000000)

--- a/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
@@ -24,6 +24,7 @@ import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.util.NetUtil;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
 
 final class QuicTestUtils {
 
@@ -63,7 +64,7 @@ final class QuicTestUtils {
                 .certificateChain("./src/test/resources/cert.crt")
                 .privateKey("./src/test/resources/cert.key")
                 .applicationProtocols(PROTOS)
-                .maxIdleTimeout(5000)
+                .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
                 .maxUdpPayloadSize(Quic.MAX_DATAGRAM_SIZE)
                 .initialMaxData(10000000)
                 .initialMaxStreamDataBidirectionalLocal(1000000)
@@ -80,7 +81,7 @@ final class QuicTestUtils {
                 .certificateChain("./src/test/resources/cert.crt")
                 .privateKey("./src/test/resources/cert.key")
                 .applicationProtocols(PROTOS)
-                .maxIdleTimeout(5000)
+                .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
                 .maxUdpPayloadSize(Quic.MAX_DATAGRAM_SIZE)
                 .initialMaxData(10000000)
                 .initialMaxStreamDataBidirectionalLocal(1000000)


### PR DESCRIPTION
Motivation:

It's not easy to understand at the moment what the time unit of some builder options are.

Modifications:

Use TimeUnit in the builder methods and convert the amount to the right unit internally

Result:

Easier to configure the builders