### PR TITLE
Don't use Quiche.quiche_conn_dgram_max_writable_len when sending data

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -763,14 +763,8 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         connectionSendNeeded = false;
         ChannelFuture lastFuture = null;
 
-        // Use the datagram size that was advertised by the remote peer, or if none was fallback to some safe default.
-        int len = Quiche.quiche_conn_dgram_max_writable_len(connAddr);
-        if (len <= 0) {
-            len = Quic.MAX_DATAGRAM_SIZE;
-        }
-
         for (;;) {
-            ByteBuf out = alloc().directBuffer(len);
+            ByteBuf out = alloc().directBuffer(Quic.MAX_DATAGRAM_SIZE);
             int writerIndex = out.writerIndex();
             int written = Quiche.quiche_conn_send(
                     connAddr, Quiche.memoryAddress(out) + writerIndex, out.writableBytes());


### PR DESCRIPTION
Motivation:

Quiche.quiche_conn_dgram_max_writable_len shouldnt be used for "normal" quic data. This should only be used when sending datagrams (datagram extension).

Modifications:

Remove usage of Quiche.quiche_conn_dgram_max_writable_len

Result:

Use correct length when allocating buffers