### PR TITLE
Make the naming in the builder consistent

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -125,10 +125,11 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     /**
      * Enable the support of early data.
      *
+     * @param enable {@code true} if enabled, {@code false} otherwise
      * @return the instance itself.
      */
-    public final B enableEarlyData() {
-        earlyData = true;
+    public final B earlyData(boolean enable) {
+        earlyData = enable;
         return self();
     }
 
@@ -280,11 +281,11 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.set_disable_active_migration">
      *     set_disable_active_migration</a>.
      *
-     * @param value   {@code true} if migration should be disabled.
+     * @param enable  {@code true} if migration should be enabled, {@code false} otherwise.
      * @return        the instance itself.
      */
-    public final B disableActiveMigration(boolean value) {
-        this.disableActiveMigration = value;
+    public final B activeMigration(boolean enable) {
+        this.disableActiveMigration = !enable;
         return self();
     }
 
@@ -293,11 +294,11 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * <a href="https://docs.rs/quiche/0.6.0/quiche/struct.Config.html#method.enable_hystart">
      *     enable_hystart</a>.
      *
-     * @param value   {@code true} if Hystart should be enabled.
+     * @param enable  {@code true} if Hystart should be enabled.
      * @return        the instance itself.
      */
-    public final B enableHystart(boolean value) {
-        this.enableHystart = value;
+    public final B hystart(boolean enable) {
+        this.enableHystart = enable;
         return self();
     }
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicClientExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicClientExample.java
@@ -55,8 +55,8 @@ public final class QuicClientExample {
                     .initialMaxStreamDataBidirectionalRemote(1000000)
                     .initialMaxStreamsBidirectional(100)
                     .initialMaxStreamsUnidirectional(100)
-                    .disableActiveMigration(true)
-                    .enableEarlyData().build();
+                    .activeMigration(false)
+                    .earlyData(true).build();
 
             Bootstrap bs = new Bootstrap();
             Channel channel = bs.group(group)

--- a/src/test/java/io/netty/incubator/codec/quic/QuicExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicExample.java
@@ -57,8 +57,8 @@ public final class QuicExample {
                 .initialMaxStreamDataBidirectionalRemote(1000000)
                 .initialMaxStreamsBidirectional(100)
                 .initialMaxStreamsUnidirectional(100)
-                .disableActiveMigration(true)
-                .enableEarlyData()
+                .activeMigration(false)
+                .earlyData(true)
                 .tokenHandler(InsecureQuicTokenHandler.INSTANCE)
                 // ChannelHandler that is added into QuicChannel pipeline.
                 .handler(new ChannelInboundHandlerAdapter() {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
@@ -72,8 +72,8 @@ final class QuicTestUtils {
                 .initialMaxStreamsBidirectional(100)
                 .initialMaxStreamsUnidirectional(100)
                 .initialMaxStreamDataUnidirectional(1000000)
-                .disableActiveMigration(true)
-                .enableEarlyData();
+                .activeMigration(false)
+                .earlyData(true);
     }
 
     static QuicServerCodecBuilder newQuicServerBuilder() {
@@ -89,7 +89,7 @@ final class QuicTestUtils {
                 .initialMaxStreamDataUnidirectional(1000000)
                 .initialMaxStreamsBidirectional(100)
                 .initialMaxStreamsUnidirectional(100)
-                .disableActiveMigration(true);
+                .activeMigration(false);
     }
 
     private static Bootstrap newServerBootstrap(QuicServerCodecBuilder serverBuilder,


### PR DESCRIPTION
Motivation:

We had some inconsistency in the builder method naming.

Modifications:

Use same naming convention everywhere

Result:

More consistent naming