### PR TITLE
Add support for QUIC datagram extension

### DIFF
--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -303,14 +303,25 @@ static jint netty_quiche_stream_iter_next(JNIEnv* env, jclass clazz, jlong iter,
     return i;
 }
 
-
 static jint netty_quiche_conn_dgram_max_writable_len(JNIEnv* env, jclass clazz, jlong conn) {
     return (jint) quiche_conn_dgram_max_writable_len((quiche_conn *) conn);
+}
+
+static jint netty_quiche_conn_dgram_recv(JNIEnv* env, jclass clazz, jlong conn, jlong buf, jint buf_len) {
+    return (jint) quiche_conn_dgram_recv((quiche_conn *) conn, (uint8_t *) buf, (size_t) buf_len);
+}
+
+static jint netty_quiche_conn_dgram_send(JNIEnv* env, jclass clazz, jlong conn, jlong buf, jint buf_len) {
+    return (jint) quiche_conn_dgram_send((quiche_conn *) conn, (uint8_t *) buf, (size_t) buf_len);
 }
 
 static jlong netty_quiche_config_new(JNIEnv* env, jclass clazz, jint version) {
     quiche_config* config = quiche_config_new((uint32_t) version);
     return config == NULL ? -1 : (jlong) config;
+}
+
+static void netty_quiche_config_enable_dgram(JNIEnv* env, jclass clazz, jlong config, jboolean enabled, jint recv_queue_len, jint send_queue_len) {
+    quiche_config_enable_dgram((quiche_config*) config, enabled == JNI_TRUE ? true : false, (size_t) recv_queue_len, (size_t) send_queue_len);
 }
 
 static jint netty_quiche_config_load_cert_chain_from_pem_file(JNIEnv* env, jclass clazz, jlong config, jstring path) {
@@ -498,7 +509,10 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_stream_iter_free", "(J)V", (void *) netty_quiche_stream_iter_free },
   { "quiche_stream_iter_next", "(J[J)I", (void *) netty_quiche_stream_iter_next },
   { "quiche_conn_dgram_max_writable_len", "(J)I", (void* ) netty_quiche_conn_dgram_max_writable_len },
+  { "quiche_conn_dgram_recv", "(JJI)I", (void* ) netty_quiche_conn_dgram_recv },
+  { "quiche_conn_dgram_send", "(JJI)I", (void* ) netty_quiche_conn_dgram_send },
   { "quiche_config_new", "(I)J", (void *) netty_quiche_config_new },
+  { "quiche_config_enable_dgram", "(JZII)V", (void *) netty_quiche_config_enable_dgram },
   { "quiche_config_load_cert_chain_from_pem_file", "(JLjava/lang/String;)I", (void *) netty_quiche_config_load_cert_chain_from_pem_file },
   { "quiche_config_load_priv_key_from_pem_file", "(JLjava/lang/String;)I", (void *) netty_quiche_config_load_priv_key_from_pem_file },
   { "quiche_config_verify_peer", "(JZ)V", (void *) netty_quiche_config_verify_peer },

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.netty.util.internal.ObjectUtil.checkInRange;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
@@ -370,13 +371,32 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
         return self();
     }
 
+    private Integer recvQueueLen;
+    private Integer sendQueueLen;
+
+    /**
+     * If configured this will enable <a href="https://tools.ietf.org/html/draft-ietf-quic-datagram-01">
+     *     Datagram support.</a>
+     * @param recvQueueLen  the RECV queue length.
+     * @param sendQueueLen  the SEND queue length.
+     * @return              the instance itself.
+     */
+    public final B datagram(int recvQueueLen, int sendQueueLen) {
+        checkPositive(recvQueueLen, "recvQueueLen");
+        checkPositive(sendQueueLen, "sendQueueLen");
+
+        this.recvQueueLen = recvQueueLen;
+        this.sendQueueLen = sendQueueLen;
+        return self();
+    }
+
     private QuicheConfig createConfig() {
         return new QuicheConfig(certPath, keyPath, verifyPeer, grease, earlyData,
                 protos, maxIdleTimeout, maxUdpPayloadSize, initialMaxData,
                 initialMaxStreamDataBidiLocal, initialMaxStreamDataBidiRemote,
                 initialMaxStreamDataUni, initialMaxStreamsBidi, initialMaxStreamsUni,
                 ackDelayExponent, maxAckDelay, disableActiveMigration, enableHystart,
-                congestionControlAlgorithm);
+                congestionControlAlgorithm, recvQueueLen, sendQueueLen);
     }
 
     /**

--- a/src/main/java/io/netty/incubator/codec/quic/QuicDatagramExtensionEvent.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicDatagramExtensionEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.util.internal.ObjectUtil;
+
+/**
+ * Used when the remote peer supports the
+ * <a href="https://tools.ietf.org/html/draft-ietf-quic-datagram-01">QUIC DATAGRAM extension.</a>
+ */
+public final class QuicDatagramExtensionEvent implements QuicExtensionEvent {
+
+    private final int maxLength;
+
+    QuicDatagramExtensionEvent(int maxLength) {
+        this.maxLength = ObjectUtil.checkPositiveOrZero(maxLength, "maxLength");
+    }
+
+    /**
+     * The maximum datagram payload length the peer will accept. If you try to write bigger datagrams the write will
+     * fail.
+     *
+     * @return the max length.
+     */
+    public int maxLength() {
+        return maxLength;
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicExtensionEvent.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicExtensionEvent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+/**
+ * Marker interface for events that will be passed through the {@link io.netty.channel.ChannelPipeline} via
+ * {@link io.netty.channel.ChannelPipeline#fireUserEventTriggered(Object)} to notify the user about supported
+ * QUIC extensions by the remote peer.
+ */
+public interface QuicExtensionEvent {
+
+}

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -344,6 +344,20 @@ final class Quiche {
 
     /**
      * See
+     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L361">
+     *     quiche_conn_dgram_recv</a>.
+     */
+    static native int quiche_conn_dgram_recv(long connAddr, long buf, int size);
+
+    /**
+     * See
+     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L3651">
+     *     quiche_conn_dgram_send</a>.
+     */
+    static native int quiche_conn_dgram_send(long connAddr, long buf, int size);
+
+    /**
+     * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L115">quiche_config_new</a>.
      */
     static native long quiche_config_new(int version);
@@ -480,6 +494,14 @@ final class Quiche {
      *     quiche_config_enable_hystart</a>.
      */
     static native void quiche_config_enable_hystart(long configAddr, boolean value);
+
+    /**
+     * See
+     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L187">
+     *     quiche_config_enable_dgram</a>.
+     */
+    static native void quiche_config_enable_dgram(long configAddr, boolean enable,
+                                                  int recv_queue_len, int send_queue_len);
 
     /**
      * See

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
@@ -35,13 +35,16 @@ final class QuicheConfig {
     private final Boolean disableActiveMigration;
     private final Boolean enableHystart;
     private final QuicCongestionControlAlgorithm congestionControlAlgorithm;
+    private final Integer recvQueueLen;
+    private final Integer sendQueueLen;
 
     QuicheConfig(String certPath, String keyPath, Boolean verifyPeer, Boolean grease, boolean earlyData,
                         byte[] protos, Long maxIdleTimeout, Long maxUdpPayloadSize, Long initialMaxData,
                         Long initialMaxStreamDataBidiLocal, Long initialMaxStreamDataBidiRemote,
                         Long initialMaxStreamDataUni, Long initialMaxStreamsBidi, Long initialMaxStreamsUni,
                         Long ackDelayExponent, Long maxAckDelay, Boolean disableActiveMigration, Boolean enableHystart,
-                        QuicCongestionControlAlgorithm congestionControlAlgorithm) {
+                        QuicCongestionControlAlgorithm congestionControlAlgorithm,
+                 Integer recvQueueLen, Integer sendQueueLen) {
         this.certPath = certPath;
         this.keyPath = keyPath;
         this.verifyPeer = verifyPeer;
@@ -61,6 +64,12 @@ final class QuicheConfig {
         this.disableActiveMigration = disableActiveMigration;
         this.enableHystart = enableHystart;
         this.congestionControlAlgorithm = congestionControlAlgorithm;
+        this.recvQueueLen = recvQueueLen;
+        this.sendQueueLen = sendQueueLen;
+    }
+
+    boolean isDatagramSupported() {
+        return recvQueueLen != null && sendQueueLen != null;
     }
 
     /**
@@ -135,6 +144,9 @@ final class QuicheConfig {
                         throw new IllegalArgumentException(
                                 "Unknown congestionControlAlgorithm: " + congestionControlAlgorithm);
                 }
+            }
+            if (isDatagramSupported()) {
+                Quiche.quiche_config_enable_dgram(config, true, recvQueueLen, sendQueueLen);
             }
             return config;
         } catch (Throwable cause) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
@@ -48,7 +48,8 @@ final class QuicheQuicClientCodec extends QuicheQuicCodec {
                         SocketAddress localAddress, ChannelPromise promise) {
         final QuicheQuicChannel channel;
         try {
-            channel = QuicheQuicChannel.handleConnect(remoteAddress, nativeConfig, localConnIdLength);
+            channel = QuicheQuicChannel.handleConnect(remoteAddress, nativeConfig, localConnIdLength,
+                    config.isDatagramSupported());
         } catch (Exception e) {
             promise.setFailure(e);
             return;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -181,7 +181,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         }
 
         QuicheQuicChannel channel = QuicheQuicChannel.forServer(
-                ctx.channel(), key, conn, Quiche.traceId(conn, dcid), sender,
+                ctx.channel(), key, conn, Quiche.traceId(conn, dcid), sender, config.isDatagramSupported(),
                 streamHandler, streamOptionsArray, streamAttrsArray);
         Quic.setupChannel(channel, optionsArray, attrsArray, handler, LOGGER);
         putChannel(channel);

--- a/src/test/java/io/netty/incubator/codec/quic/QuicChannelDatagramTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicChannelDatagramTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.Promise;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class QuicChannelDatagramTest {
+
+    private static final Random random = new Random();
+    static final byte[] data = new byte[512];
+
+    static {
+        random.nextBytes(data);
+    }
+
+    @Test
+    public void testDatagramFlushInChannelRead() throws Throwable {
+        testDatagram(false, false);
+    }
+
+    @Test
+    public void testDatagramFlushInChannelReadComplete() throws Throwable {
+        testDatagram(true, false);
+    }
+
+    @Test
+    public void testDatagramFlushInChannelReadWriteDatagramPacket() throws Throwable {
+        testDatagram(false, true);
+    }
+
+    @Test
+    public void testDatagramFlushInChannelReadCompleteWriteDatagramPacket() throws Throwable {
+        testDatagram(true, true);
+    }
+
+    private void testDatagram(boolean flushInReadComplete, boolean writeDatagramPacket) throws Throwable {
+        AtomicReference<QuicDatagramExtensionEvent> serverEventRef = new AtomicReference<>();
+
+        Channel server = QuicTestUtils.newServer(QuicTestUtils.newQuicServerBuilder().datagram(10, 10),
+                InsecureQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter() {
+
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                if (msg instanceof ByteBuf) {
+                    final ChannelFuture future;
+                    final Object message;
+                    if (writeDatagramPacket) {
+                        message = new DatagramPacket((ByteBuf) msg, (InetSocketAddress) ctx.channel().remoteAddress());
+                    } else {
+                        message = msg;
+                    }
+                    if (!flushInReadComplete) {
+                        future = ctx.writeAndFlush(message);
+                    } else {
+                        future = ctx.write(message);
+                    }
+                    future.addListener(ChannelFutureListener.CLOSE);
+                } else {
+                    ctx.fireChannelRead(msg);
+                }
+            }
+
+            @Override
+            public void channelReadComplete(ChannelHandlerContext ctx) {
+                if (flushInReadComplete) {
+                    ctx.flush();
+                }
+            }
+
+            @Override
+            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                if (evt instanceof QuicDatagramExtensionEvent) {
+                    serverEventRef.set((QuicDatagramExtensionEvent) evt);
+                }
+            }
+        }, new ChannelInboundHandlerAdapter());
+        InetSocketAddress address = (InetSocketAddress) server.localAddress();
+
+        Promise<ByteBuf> receivedBuffer = ImmediateEventExecutor.INSTANCE.newPromise();
+        AtomicReference<QuicDatagramExtensionEvent> clientEventRef = new AtomicReference<>();
+        Channel channel = QuicTestUtils.newClient(QuicTestUtils.newQuicClientBuilder().datagram(10, 10));
+        try {
+            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+                    .handler(new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                            if (!receivedBuffer.trySuccess((ByteBuf) msg)) {
+                                ReferenceCountUtil.release(msg);
+                            }
+                        }
+
+                        @Override
+                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                            if (evt instanceof QuicDatagramExtensionEvent) {
+                                clientEventRef.set((QuicDatagramExtensionEvent) evt);
+                            }
+                        }
+
+                        @Override
+                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                            receivedBuffer.tryFailure(cause);
+                        }
+                    })
+                    .remoteAddress(address)
+                    .connect()
+                    .get();
+            quicChannel.writeAndFlush(Unpooled.copiedBuffer(data)).sync();
+
+            ByteBuf buffer = receivedBuffer.get();
+            ByteBuf expected = Unpooled.wrappedBuffer(data);
+            assertEquals(expected, buffer);
+            buffer.release();
+            expected.release();
+
+            assertNotEquals(0, serverEventRef.get().maxLength());
+            assertNotEquals(0, clientEventRef.get().maxLength());
+
+            quicChannel.close().sync();
+        } finally {
+            server.close().sync();
+            // Close the parent Datagram channel as well.
+            channel.close().sync();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Quiche supports the QUIC datagram extension, so should we.

Modifications:

- Add builder options to enable datagram extension support
- Add related code to QuicheQuicChannel
- Add unit tests

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/76