### PR TITLE
Move QUIC header parsing to extra class and so make it re-usable.

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicHeaderParser.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicHeaderParser.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.ByteBuf;
+
+import java.net.InetSocketAddress;
+
+import static io.netty.incubator.codec.quic.Quiche.allocateNativeOrder;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
+/**
+ * Parses the QUIC packet header and notifies a callback once parsing was successful.
+ *
+ * Once the parser is not needed anymore the user needs to call {@link #close()} to ensure all resources are
+ * released. Failed to do so may lead to memory leaks.
+ *
+ * This class can be used for advanced use-cases. Usually you want to just use {@link QuicClientCodecBuilder} or
+ * {@link QuicServerCodecBuilder}.
+ */
+public final class QuicHeaderParser implements AutoCloseable {
+    private final int maxTokenLength;
+    private final int localConnectionIdLength;
+    private final ByteBuf versionBuffer;
+    private final ByteBuf typeBuffer;
+    private final ByteBuf scidLenBuffer;
+    private final ByteBuf scidBuffer;
+    private final ByteBuf dcidLenBuffer;
+    private final ByteBuf dcidBuffer;
+    private final ByteBuf tokenBuffer;
+    private final ByteBuf tokenLenBuffer;
+    private boolean closed;
+
+    public QuicHeaderParser(int maxTokenLength, int localConnectionIdLength) {
+        Quic.ensureAvailability();
+        this.maxTokenLength = checkPositiveOrZero(maxTokenLength, "maxTokenLength");
+        this.localConnectionIdLength = checkPositiveOrZero(localConnectionIdLength, "localConnectionIdLength");
+        versionBuffer = allocateNativeOrder(Integer.BYTES);
+        typeBuffer = allocateNativeOrder(Byte.BYTES);
+        scidBuffer = allocateNativeOrder(Quiche.QUICHE_MAX_CONN_ID_LEN);
+        scidLenBuffer = allocateNativeOrder(Integer.BYTES);
+        dcidBuffer = allocateNativeOrder(Quiche.QUICHE_MAX_CONN_ID_LEN);
+        dcidLenBuffer = allocateNativeOrder(Integer.BYTES);
+        tokenLenBuffer = allocateNativeOrder(Integer.BYTES);
+        tokenBuffer = allocateNativeOrder(maxTokenLength);
+    }
+
+    @Override
+    public void close() {
+        if (!closed) {
+            closed = true;
+            versionBuffer.release();
+            scidBuffer.release();
+            scidLenBuffer.release();
+            dcidBuffer.release();
+            dcidLenBuffer.release();
+            tokenLenBuffer.release();
+            tokenBuffer.release();
+        }
+    }
+
+    /**
+     * Parses a QUIC packet and extract the header values out of it. This method takes no ownership of the packet itself
+     * which means the caller of this method is expected to call {@link ByteBuf#release()} once the packet is not needed
+     * anymore.
+     *
+     * @param sender        the sender of the packet. This is directly passed to the {@link QuicHeaderProcessor} once
+     *                      parsing was successful.
+     * @param recipient     the recipient of the packet.This is directly passed to the {@link QuicHeaderProcessor} once
+     *                      parsing was successful.
+     * @param packet        raw QUIC packet itself. The ownership of the packet is not transferred. This is directly
+     *                      passed to the {@link QuicHeaderProcessor} once parsing was successful.
+     * @param callback      the {@link QuicHeaderProcessor} that is called once a QUIC packet could be parsed and all
+     *                      the header values be extracted.
+     * @throws Exception    thrown if we couldn't parse the header or if the {@link QuicHeaderProcessor} throws an
+     *                      exception.
+     */
+    public void parse(InetSocketAddress sender,
+                      InetSocketAddress recipient, ByteBuf packet, QuicHeaderProcessor callback) throws Exception {
+        if (closed) {
+            throw new IllegalStateException("QuicHeaderParser is already closed");
+        }
+        long contentAddress = Quiche.memoryAddress(packet) + packet.readerIndex();
+        int contentReadable = packet.readableBytes();
+
+        // Ret various len values so quiche_header_info can make use of these.
+        scidLenBuffer.setInt(0, Quiche.QUICHE_MAX_CONN_ID_LEN);
+        dcidLenBuffer.setInt(0, Quiche.QUICHE_MAX_CONN_ID_LEN);
+        tokenLenBuffer.setInt(0, maxTokenLength);
+
+        int res = Quiche.quiche_header_info(contentAddress, contentReadable, localConnectionIdLength,
+                Quiche.memoryAddress(versionBuffer), Quiche.memoryAddress(typeBuffer),
+                Quiche.memoryAddress(scidBuffer), Quiche.memoryAddress(scidLenBuffer),
+                Quiche.memoryAddress(dcidBuffer), Quiche.memoryAddress(dcidLenBuffer),
+                Quiche.memoryAddress(tokenBuffer), Quiche.memoryAddress(tokenLenBuffer));
+        if (res >= 0) {
+            int version = versionBuffer.getInt(0);
+            byte type = typeBuffer.getByte(0);
+            int scidLen = scidLenBuffer.getInt(0);
+            int dcidLen = dcidLenBuffer.getInt(0);
+            int tokenLen = tokenLenBuffer.getInt(0);
+
+            callback.process(sender, recipient, packet, QuicPacketType.of(type), version,
+                    scidBuffer.setIndex(0, scidLen),
+                    dcidBuffer.setIndex(0, dcidLen),
+                    tokenBuffer.setIndex(0, tokenLen));
+        } else {
+            throw Quiche.newException(res);
+        }
+    }
+
+    /**
+     * Called when a QUIC packet and its header could be parsed.
+     */
+    public interface QuicHeaderProcessor {
+
+        /**
+         * Called when a QUIC packet header was parsed.
+         *
+         * @param sender        the sender of the QUIC packet.
+         * @param recipient     the recipient of the QUIC packet.
+         * @param packet        the raw QUIC packet. The ownership is not transferred, which means you will need to call
+         *                      {@link ByteBuf#retain()} on it if you want to keep a reference after this method
+         *                      returns.
+         * @param type          the type of the packet.
+         * @param version       the version of the packet.
+         * @param scid          the source connection id. The ownership is not transferred and its generally not allowed
+         *                      to hold any references to this buffer outside of the method as it will be re-used.
+         * @param dcid          the destination connection id. The ownership is not transferred and its generally not
+         *                      allowed to hold any references to this buffer outside of the method as it will be
+         *                      re-used.
+         * @param token         the token.The ownership is not transferred and its generally not allowed
+         *                      to hold any references to this buffer outside of the method as it will be re-used.
+         * @throws Exception    throws if an error happens during processing.
+         */
+        void process(InetSocketAddress sender, InetSocketAddress recipient, ByteBuf packet,
+                     QuicPacketType type, int version, ByteBuf scid, ByteBuf dcid, ByteBuf token) throws Exception;
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicPacketType.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicPacketType.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+/**
+ * The type of the
+ * <a href="https://www.ietf.org/archive/id/draft-ietf-quic-transport-32.html#name-packets-and-frames">QUIC packet</a>.
+ */
+public enum QuicPacketType {
+    /**
+     * Initial packet.
+     */
+    INITIAL((byte) 1),
+
+    /**
+     * Retry packet.
+     */
+    RETRY((byte) 2),
+
+    /**
+     * Handshake packet.
+     */
+    HANDSHAKE((byte) 3),
+
+    /**
+     * 0-RTT packet.
+     */
+    ZERO_RTT((byte) 4),
+
+    /**
+     * 1-RTT short header packet.
+     */
+    SHORT((byte) 5),
+
+    /**
+     * Version negotiation packet.
+     */
+    VERSION_NEGOTIATION((byte) 6);
+
+    final byte type;
+
+    QuicPacketType(byte type) {
+        this.type = type;
+    }
+
+    /**
+     * Return the {@link QuicPacketType} for the given byte.
+     *
+     * @param type  the byte that represent the type.
+     * @return      the {@link QuicPacketType}.
+     */
+    static QuicPacketType of(byte type) {
+        switch(type) {
+            case 1:
+                return INITIAL;
+            case 2:
+                return RETRY;
+            case 3:
+                return HANDSHAKE;
+            case 4:
+                return ZERO_RTT;
+            case 5:
+                return SHORT;
+            case 6:
+                return VERSION_NEGOTIATION;
+            default:
+                throw new IllegalArgumentException("Unknown QUIC packet type: " + type);
+        }
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -17,6 +17,7 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.internal.NativeLibraryLoader;
 import io.netty.util.internal.PlatformDependent;
@@ -26,6 +27,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 final class Quiche {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Quiche.class);
@@ -508,6 +510,16 @@ final class Quiche {
     static long memoryAddress(ByteBuffer buf) {
         assert buf.isDirect();
         return buffer_memory_address(buf);
+    }
+
+    @SuppressWarnings("deprecation")
+    static ByteBuf allocateNativeOrder(int capacity) {
+        // Just use Unpooled as the life-time of these buffers is long.
+        ByteBuf buffer = Unpooled.directBuffer(capacity);
+
+        // As we use the buffers as pointers to int etc we need to ensure we use the right oder so we will
+        // see the right value when we read primitive values.
+        return PlatformDependent.BIG_ENDIAN_NATIVE_ORDER ? buffer : buffer.order(ByteOrder.LITTLE_ENDIAN);
     }
 
     static String errorAsString(int err) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
@@ -37,7 +37,7 @@ final class QuicheQuicClientCodec extends QuicheQuicCodec {
     @Override
     protected QuicheQuicChannel quicPacketRead(
             ChannelHandlerContext ctx, InetSocketAddress sender, InetSocketAddress recipient,
-            byte type, int version, ByteBuf scid, ByteBuf dcid,
+            QuicPacketType type, int version, ByteBuf scid, ByteBuf dcid,
             ByteBuf token) {
         ByteBuffer key = dcid.internalNioBuffer(dcid.readerIndex(), dcid.readableBytes());
         return getChannel(key);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -16,17 +16,14 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.DatagramPacket;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -45,14 +42,8 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
     private boolean needsFlush;
     private boolean inChannelRead;
 
-    private ByteBuf versionBuffer;
-    private ByteBuf typeBuffer;
-    private ByteBuf scidLenBuffer;
-    private ByteBuf scidBuffer;
-    private ByteBuf dcidLenBuffer;
-    private ByteBuf dcidBuffer;
-    private ByteBuf tokenBuffer;
-    private ByteBuf tokenLenBuffer;
+    private QuicHeaderParser headerParser;
+    private QuicHeaderParser.QuicHeaderProcessor parserCallback;
 
     protected final QuicheConfig config;
     protected final int localConnIdLength;
@@ -74,25 +65,19 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) {
-        versionBuffer = allocateNativeOrder(Integer.BYTES);
-        typeBuffer = allocateNativeOrder(Byte.BYTES);
-        scidBuffer = allocateNativeOrder(Quiche.QUICHE_MAX_CONN_ID_LEN);
-        scidLenBuffer = allocateNativeOrder(Integer.BYTES);
-        dcidBuffer = allocateNativeOrder(Quiche.QUICHE_MAX_CONN_ID_LEN);
-        dcidLenBuffer = allocateNativeOrder(Integer.BYTES);
-        tokenLenBuffer = allocateNativeOrder(Integer.BYTES);
-        tokenBuffer = allocateNativeOrder(maxTokenLength);
+        headerParser = new QuicHeaderParser(maxTokenLength, localConnIdLength);
+        parserCallback = (sender, recipient, buffer, type, version, scid, dcid, token) -> {
+            QuicheQuicChannel channel = quicPacketRead(ctx, sender, recipient,
+                    type, version, scid,
+                    dcid, token);
+            if (channel != null) {
+                channel.recv(buffer);
+                if (channel.markInFireChannelReadCompleteQueue()) {
+                    needsFireChannelReadComplete.add(channel);
+                }
+            }
+        };
         nativeConfig = config.createNativeConfig();
-    }
-
-    @SuppressWarnings("deprecation")
-    protected static ByteBuf allocateNativeOrder(int capacity) {
-        // Just use Unpooled as the life-time of these buffers is long.
-        ByteBuf buffer = Unpooled.directBuffer(capacity);
-
-        // As we use the buffers as pointers to int etc we need to ensure we use the right oder so we will
-        // see the right value when we read primitive values.
-        return PlatformDependent.BIG_ENDIAN_NATIVE_ORDER ? buffer : buffer.order(ByteOrder.LITTLE_ENDIAN);
     }
 
     @Override
@@ -105,14 +90,10 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
         needsFireChannelReadComplete.clear();
 
         Quiche.quiche_config_free(nativeConfig);
-
-        versionBuffer.release();
-        scidBuffer.release();
-        scidLenBuffer.release();
-        dcidBuffer.release();
-        dcidLenBuffer.release();
-        tokenLenBuffer.release();
-        tokenBuffer.release();
+        if (headerParser != null) {
+            headerParser.close();
+            headerParser = null;
+        }
     }
 
     @Override
@@ -126,53 +107,26 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
                 ByteBuf direct = ctx.alloc().directBuffer(buffer.readableBytes());
                 try {
                     direct.writeBytes(buffer, buffer.readerIndex(), buffer.readableBytes());
-                    channelRead(ctx, packet.sender(), packet.recipient(), direct);
+                    handleQuicPacket(packet.sender(), packet.recipient(), direct);
                 } finally {
                     direct.release();
                 }
             } else {
-                channelRead(ctx, packet.sender(), packet.recipient(), buffer);
+                handleQuicPacket(packet.sender(), packet.recipient(), buffer);
             }
         } finally {
             packet.release();
         }
     }
 
-    private void channelRead(ChannelHandlerContext ctx, InetSocketAddress sender,
-                             InetSocketAddress recipient, ByteBuf buffer) throws Exception {
-        long contentAddress = Quiche.memoryAddress(buffer) + buffer.readerIndex();
-        int contentReadable = buffer.readableBytes();
-
-        // Ret various len values so quiche_header_info can make use of these.
-        scidLenBuffer.setInt(0, Quiche.QUICHE_MAX_CONN_ID_LEN);
-        dcidLenBuffer.setInt(0, Quiche.QUICHE_MAX_CONN_ID_LEN);
-        tokenLenBuffer.setInt(0, maxTokenLength);
-
-        int res = Quiche.quiche_header_info(contentAddress, contentReadable, localConnIdLength,
-                Quiche.memoryAddress(versionBuffer), Quiche.memoryAddress(typeBuffer),
-                Quiche.memoryAddress(scidBuffer), Quiche.memoryAddress(scidLenBuffer),
-                Quiche.memoryAddress(dcidBuffer), Quiche.memoryAddress(dcidLenBuffer),
-                Quiche.memoryAddress(tokenBuffer), Quiche.memoryAddress(tokenLenBuffer));
-        if (res >= 0) {
-            int version = versionBuffer.getInt(0);
-            byte type = typeBuffer.getByte(0);
-            int scidLen = scidLenBuffer.getInt(0);
-            int dcidLen = dcidLenBuffer.getInt(0);
-            int tokenLen = tokenLenBuffer.getInt(0);
-
-            QuicheQuicChannel channel = quicPacketRead(ctx, sender, recipient,
-                    type, version, scidBuffer.setIndex(0, scidLen),
-                    dcidBuffer.setIndex(0, dcidLen), tokenBuffer.setIndex(0, tokenLen));
-            if (channel != null) {
-                channel.recv(buffer);
-                if (channel.markInFireChannelReadCompleteQueue()) {
-                    needsFireChannelReadComplete.add(channel);
-                }
-            }
-        } else {
-            LOGGER.debug("Unable to parse QUIC header via quiche_header_info: {}", Quiche.errorAsString(res));
+    private void handleQuicPacket(InetSocketAddress sender, InetSocketAddress recipient, ByteBuf buffer) {
+        try {
+            headerParser.parse(sender, recipient, buffer, parserCallback);
+        } catch (Exception e) {
+            LOGGER.debug("Error while processing QUIC packet", e);
         }
     }
+
     /**
      * Handle a QUIC packet and return {@code true} if we need to call {@link ChannelHandlerContext#flush()}.
      *
@@ -189,7 +143,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
      * @throws Exception  thrown if there is an error during processing.
      */
     protected abstract QuicheQuicChannel quicPacketRead(ChannelHandlerContext ctx, InetSocketAddress sender,
-                                                        InetSocketAddress recipient, byte type, int version,
+                                                        InetSocketAddress recipient, QuicPacketType type, int version,
                                                         ByteBuf scid, ByteBuf dcid, ByteBuf token) throws Exception;
 
     @Override

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -25,10 +25,11 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Map;
+
+import static io.netty.incubator.codec.quic.Quiche.allocateNativeOrder;
 
 /**
  * {@link QuicheQuicCodec} for QUIC servers.
@@ -71,7 +72,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) {
         super.handlerAdded(ctx);
-        connIdBuffer = allocateNativeOrder(localConnIdLength);
+        connIdBuffer = Quiche.allocateNativeOrder(localConnIdLength);
         mintTokenBuffer = allocateNativeOrder(tokenHandler.maxTokenLength());
     }
 
@@ -84,7 +85,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
 
     @Override
     protected QuicheQuicChannel quicPacketRead(ChannelHandlerContext ctx, InetSocketAddress sender,
-                                               InetSocketAddress recipient, byte type, int version,
+                                               InetSocketAddress recipient, QuicPacketType type, int version,
                                                ByteBuf scid, ByteBuf dcid, ByteBuf token) throws Exception {
         ByteBuffer dcidByteBuffer = dcid.internalNioBuffer(dcid.readerIndex(), dcid.readableBytes());
         QuicheQuicChannel channel = getChannel(dcidByteBuffer);
@@ -96,7 +97,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
     }
 
     private QuicheQuicChannel handleServer(ChannelHandlerContext ctx, InetSocketAddress sender,
-                                 @SuppressWarnings("unused") byte type, int version,
+                                 @SuppressWarnings("unused") QuicPacketType type, int version,
                                  ByteBuf scid, ByteBuf dcid, ByteBuf token) throws Exception {
         if (!Quiche.quiche_version_is_supported(version)) {
             // Version is not supported, try to negotiate it.

--- a/src/test/java/io/netty/incubator/codec/quic/QuicPacketTypeTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicPacketTypeTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class QuicPacketTypeTest {
+
+    @Test
+    public void testOfValidType() {
+        for (QuicPacketType type: QuicPacketType.values()) {
+            assertEquals(type, QuicPacketType.of(type.type));
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testOfInvalidType() {
+        QuicPacketType.of((byte) -1);
+    }
+}


### PR DESCRIPTION
Motivation:

For some more advanced use-cases it may be benefitional to be able to parse the QUIC header without the codecs.

Modifications:

- Move header parsing code to QuicHeaderParser
- Add QuicPacketType enum
- Re-use QuicHeaderParser in the codecs

Result:

More flexible usage possible for advanced use-cases