### PR TITLE
Route stream creations through the pipeline

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -23,6 +23,8 @@ import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
+import java.net.SocketAddress;
+
 /**
  * A QUIC {@link Channel}.
  */
@@ -39,6 +41,11 @@ public interface QuicChannel extends Channel {
      * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} automatically.
      *
+     * As creating streams is kind of similar to create connections in other protocols this operation will flow
+     * through the {@link io.netty.channel.ChannelPipeline} by using
+     * {@link io.netty.channel.ChannelPipeline#connect(SocketAddress)} with a {@link QuicStreamAddress}. This allows
+     * you to intercept stream creation attempts if needed.
+     *
      * @param type      the {@link QuicStreamType} of the {@link QuicStreamChannel}.
      * @param handler   the {@link ChannelHandler} that will be added to the {@link QuicStreamChannel}s
      *                  {@link io.netty.channel.ChannelPipeline} during the stream creation.
@@ -52,6 +59,11 @@ public interface QuicChannel extends Channel {
      * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Promise} once done.
      * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} automatically.
+     *
+     * As creating streams is kind of similar to create connections in other protocols this operation will flow
+     * through the {@link io.netty.channel.ChannelPipeline} by using
+     * {@link io.netty.channel.ChannelPipeline#connect(SocketAddress, SocketAddress, ChannelPromise)}
+     * with a {@link QuicStreamAddress}. This allows you to intercept stream creation attempts if needed.
      *
      * @param type      the {@link QuicStreamType} of the {@link QuicStreamChannel}.
      * @param handler   the {@link ChannelHandler} that will be added to the {@link QuicStreamChannel}s

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamAddress.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamAddress.java
@@ -15,47 +15,30 @@
  */
 package io.netty.incubator.codec.quic;
 
+import io.netty.channel.ChannelHandler;
+import io.netty.util.concurrent.Promise;
+
 import java.net.SocketAddress;
-import java.util.Objects;
 
 /**
  * A {@link SocketAddress} for QUIC stream.
  */
 public final class QuicStreamAddress extends SocketAddress {
 
-    private final long streamId;
+    final QuicStreamType type;
+    final ChannelHandler handler;
+    final Promise<QuicStreamChannel> promise;
 
-    QuicStreamAddress(long streamId) {
-        this.streamId = streamId;
-    }
-
-    /**
-     * Return the id of the stream.
-     *
-     * @return the id.
-     */
-    public long streamId() {
-        return streamId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof QuicStreamAddress)) {
-            return false;
-        }
-        QuicStreamAddress that = (QuicStreamAddress) o;
-        return streamId == that.streamId;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(streamId);
+    QuicStreamAddress(QuicStreamType type, ChannelHandler handler, Promise<QuicStreamChannel> promise) {
+        this.type = type;
+        this.handler = handler;
+        this.promise = promise;
     }
 
     @Override
     public String toString() {
         return "QuicStreamAddress{" +
-                "streamId=" + streamId +
+                "type=" + type +
                 '}';
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -49,6 +49,7 @@ final class QuicheQuicStreamChannel extends AbstractChannel implements QuicStrea
             outputShutdown = true;
         }
     };
+    private final long streamId;
 
     private boolean readable;
     private boolean readPending;
@@ -61,10 +62,11 @@ final class QuicheQuicStreamChannel extends AbstractChannel implements QuicStrea
     private volatile boolean inputShutdown;
     private volatile boolean outputShutdown;
 
-    QuicheQuicStreamChannel(QuicheQuicChannel parent, long streamId) {
+    QuicheQuicStreamChannel(QuicheQuicChannel parent, QuicStreamAddress address, long streamId) {
         super(parent);
         config = new DefaultQuicStreamChannelConfig(this);
-        this.address = new QuicStreamAddress(streamId);
+        this.address = address;
+        this.streamId = streamId;
 
         // Local created unidirectional streams have the input shutdown by spec. There will never be any data for
         // these to be read.
@@ -95,7 +97,7 @@ final class QuicheQuicStreamChannel extends AbstractChannel implements QuicStrea
 
     @Override
     public long streamId() {
-        return address.streamId();
+        return streamId;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Creating streams is generally speaking some sort of establishing a connection. So it kind of make sense to re-use the connect(...) abstraction internally. This will also allow us to intercept these if needed and fail fast (like for example this will be useful in HTTP/3 when a go-away was already received

Modifications:

Let createStream(...) flow through the ChannelPipeline of QuicChannel

Result:

Be able to intercept stream creation attempts.