### PR TITLE
Support read limits when using Datagrams

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -133,7 +133,12 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private ByteBuffer key;
     private CloseData closeData;
     private QuicConnectionStats statsAtClose;
+
     private boolean supportsDatagram;
+    private boolean recvDatagramPending;
+    private boolean inRecvDatagram;
+    private boolean datagramReadable;
+    private boolean inRecv;
 
     private static final int CLOSED = 0;
     private static final int OPEN = 1;
@@ -402,7 +407,10 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
     @Override
     protected void doBeginRead() {
-        // TODO: handle this
+        recvDatagramPending = true;
+        if (datagramReadable) {
+            ((QuicChannelUnsafe) unsafe()).recvDatagram();
+        }
     }
 
     @Override
@@ -993,140 +1001,170 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             if (isConnDestroyed()) {
                 return;
             }
-
-            ByteBuf tmpBuffer = null;
-            // We need to make a copy if the buffer is read only as recv(...) may modify the input buffer as well.
-            // See https://docs.rs/quiche/0.6.0/quiche/struct.Connection.html#method.recv
-            if (buffer.isReadOnly()) {
-                tmpBuffer = alloc().directBuffer(buffer.readableBytes());
-                tmpBuffer.writeBytes(buffer);
-                buffer = tmpBuffer;
-            }
-            int bufferReadable = buffer.readableBytes();
-            int bufferReaderIndex = buffer.readerIndex();
-            long memoryAddress = Quiche.memoryAddress(buffer) + bufferReaderIndex;
-
-            // We need to call quiche_conn_send(...),
-            // see https://docs.rs/quiche/0.6.0/quiche/struct.Connection.html#method.send
-            connectionSendNeeded = true;
+            inRecv = true;
             try {
-                do  {
-                    // Call quiche_conn_recv(...) until we consumed all bytes or we did receive some error.
-                    int res = Quiche.quiche_conn_recv(connAddr, memoryAddress, bufferReadable);
-                    boolean done;
-                    try {
-                        done = Quiche.throwIfError(res);
-                    } catch (Exception e) {
-                        pipeline().fireExceptionCaught(e);
-                        done = true;
-                    }
+                ByteBuf tmpBuffer = null;
+                // We need to make a copy if the buffer is read only as recv(...) may modify the input buffer as well.
+                // See https://docs.rs/quiche/0.6.0/quiche/struct.Connection.html#method.recv
+                if (buffer.isReadOnly()) {
+                    tmpBuffer = alloc().directBuffer(buffer.readableBytes());
+                    tmpBuffer.writeBytes(buffer);
+                    buffer = tmpBuffer;
+                }
+                int bufferReadable = buffer.readableBytes();
+                int bufferReaderIndex = buffer.readerIndex();
+                long memoryAddress = Quiche.memoryAddress(buffer) + bufferReaderIndex;
 
-                    // Handle pending channelActive if needed.
-                    if (handlePendingChannelActive()) {
-                        // Connection was closed right away.
-                        return;
-                    }
-
-                    if (Quiche.quiche_conn_is_established(connAddr) || Quiche.quiche_conn_is_in_early_data(connAddr)) {
-                        if (supportsDatagram) {
-                            recvDatagram();
+                // We need to call quiche_conn_send(...),
+                // see https://docs.rs/quiche/0.6.0/quiche/struct.Connection.html#method.send
+                connectionSendNeeded = true;
+                try {
+                    do  {
+                        // Call quiche_conn_recv(...) until we consumed all bytes or we did receive some error.
+                        int res = Quiche.quiche_conn_recv(connAddr, memoryAddress, bufferReadable);
+                        boolean done;
+                        try {
+                            done = Quiche.throwIfError(res);
+                        } catch (Exception e) {
+                            pipeline().fireExceptionCaught(e);
+                            done = true;
                         }
-                        long readableIterator = Quiche.quiche_conn_readable(connAddr);
-                        if (readableIterator != -1) {
-                            try {
-                                for (;;) {
-                                    int readable = Quiche.quiche_stream_iter_next(readableIterator, readableStreams);
-                                    for (int i = 0; i < readable; i++) {
-                                        long streamId = readableStreams[i];
-                                        QuicheQuicStreamChannel streamChannel = streams.get(streamId);
-                                        if (streamChannel == null) {
-                                            // We create a new channel and fire it through the pipeline which
-                                            // means we also need to ensure we call fireChannelReadCompletePending.
-                                            fireChannelReadCompletePending = true;
-                                            streamChannel = addNewStreamChannel(streamId);
-                                            streamChannel.readable();
-                                            pipeline().fireChannelRead(streamChannel);
-                                        } else {
-                                            streamChannel.readable();
+
+                        // Handle pending channelActive if needed.
+                        if (handlePendingChannelActive()) {
+                            // Connection was closed right away.
+                            return;
+                        }
+
+                        if (Quiche.quiche_conn_is_established(connAddr) ||
+                                Quiche.quiche_conn_is_in_early_data(connAddr)) {
+                            datagramReadable = true;
+                            recvDatagram();
+
+                            long readableIterator = Quiche.quiche_conn_readable(connAddr);
+                            if (readableIterator != -1) {
+                                try {
+                                    for (;;) {
+                                        int readable = Quiche.quiche_stream_iter_next(
+                                                readableIterator, readableStreams);
+                                        for (int i = 0; i < readable; i++) {
+                                            long streamId = readableStreams[i];
+                                            QuicheQuicStreamChannel streamChannel = streams.get(streamId);
+                                            if (streamChannel == null) {
+                                                // We create a new channel and fire it through the pipeline which
+                                                // means we also need to ensure we call fireChannelReadCompletePending.
+                                                fireChannelReadCompletePending = true;
+                                                streamChannel = addNewStreamChannel(streamId);
+                                                streamChannel.readable();
+                                                pipeline().fireChannelRead(streamChannel);
+                                            } else {
+                                                streamChannel.readable();
+                                            }
+                                        }
+                                        if (readable < readableStreams.length) {
+                                            break;
                                         }
                                     }
-                                    if (readable < readableStreams.length) {
-                                        break;
-                                    }
+                                } finally {
+                                    Quiche.quiche_stream_iter_free(readableIterator);
                                 }
-                            } finally {
-                                Quiche.quiche_stream_iter_free(readableIterator);
                             }
                         }
-                    }
 
-                    if (done) {
-                        break;
-                    } else {
-                        memoryAddress += res;
-                        bufferReadable -= res;
+                        if (done) {
+                            break;
+                        } else {
+                            memoryAddress += res;
+                            bufferReadable -= res;
+                        }
+                    } while (bufferReadable > 0);
+                } finally {
+                    buffer.skipBytes((int) (memoryAddress - Quiche.memoryAddress(buffer)));
+                    if (tmpBuffer != null) {
+                        tmpBuffer.release();
                     }
-                } while (bufferReadable > 0);
-            } finally {
-                buffer.skipBytes((int) (memoryAddress - Quiche.memoryAddress(buffer)));
-                if (tmpBuffer != null) {
-                    tmpBuffer.release();
                 }
+            } finally {
+                inRecv = false;
             }
         }
 
         private void recvDatagram() {
-            @SuppressWarnings("deprecation")
-            RecvByteBufAllocator.Handle recvHandle = recvBufAllocHandle();
-            recvHandle.reset(config());
-
-            // TODO: respect AUTO_READ via recvHandle.continueReading()?
-            for (;;) {
-                ByteBuf datagramBuffer = recvHandle.allocate(alloc());
-                int written;
-                int writerIndex;
-
-                for (;;) {
-                    writerIndex = datagramBuffer.writerIndex();
-                    written = Quiche.quiche_conn_dgram_recv(connAddr, datagramBuffer.memoryAddress() + writerIndex,
-                            datagramBuffer.writableBytes());
-                    if (written == Quiche.QUICHE_ERR_BUFFER_TOO_SHORT) {
-                        // Let's grow the buffer and use 65536 as the upper limit as this is the biggest that
-                        // will fit into a QUIC packet.
-                        // See https://tools.ietf.org/html/draft-ietf-quic-datagram-01#section-3
-                        int newCapacity = (int) (datagramBuffer.writableBytes() * 1.5);
-                        datagramBuffer.capacity(alloc().calculateNewCapacity(
-                                Math.min(newCapacity, MAX_DATAGRAM_BUFFER_SIZE), MAX_DATAGRAM_BUFFER_SIZE));
-                    } else {
-                        // the buffer was big enough.
-                        break;
-                    }
-                }
-                try {
-                    if (Quiche.throwIfError(written)) {
-                        datagramBuffer.release();
-                        break;
-                    }
-                } catch (Exception e) {
-                    datagramBuffer.release();
-                    pipeline().fireExceptionCaught(e);
-                }
-                recvHandle.lastBytesRead(written);
-                recvHandle.incMessagesRead(1);
-
-                datagramBuffer.writerIndex(writerIndex + written);
-
-                pipeline().fireChannelRead(datagramBuffer);
-                fireChannelReadCompletePending = true;
+            if (!supportsDatagram || inRecvDatagram || isConnDestroyed()) {
+                return;
             }
-            recvHandle.readComplete();
+            inRecvDatagram = true;
+            try {
+                while (recvDatagramPending && datagramReadable) {
+                    @SuppressWarnings("deprecation")
+                    RecvByteBufAllocator.Handle recvHandle = recvBufAllocHandle();
+                    recvHandle.reset(config());
+
+                    int numMessagesRead = 0;
+                    do {
+                        ByteBuf datagramBuffer = recvHandle.allocate(alloc());
+                        int written;
+                        int writerIndex;
+
+                        for (;;) {
+                            writerIndex = datagramBuffer.writerIndex();
+                            written = Quiche.quiche_conn_dgram_recv(connAddr,
+                                    datagramBuffer.memoryAddress() + writerIndex, datagramBuffer.writableBytes());
+                            if (written == Quiche.QUICHE_ERR_BUFFER_TOO_SHORT) {
+                                // Let's grow the buffer and use 65536 as the upper limit as this is the biggest that
+                                // will fit into a QUIC packet.
+                                // See https://tools.ietf.org/html/draft-ietf-quic-datagram-01#section-3
+                                int newCapacity = (int) (datagramBuffer.writableBytes() * 1.5);
+                                datagramBuffer.capacity(alloc().calculateNewCapacity(
+                                        Math.min(newCapacity, MAX_DATAGRAM_BUFFER_SIZE), MAX_DATAGRAM_BUFFER_SIZE));
+                            } else {
+                                // the buffer was big enough.
+                                break;
+                            }
+                        }
+                        try {
+                            if (Quiche.throwIfError(written)) {
+                                datagramBuffer.release();
+                                // We did consume all datagram packets.
+                                datagramReadable = false;
+                                break;
+                            }
+                        } catch (Exception e) {
+                            datagramBuffer.release();
+                            pipeline().fireExceptionCaught(e);
+                        }
+                        recvHandle.lastBytesRead(written);
+                        recvHandle.incMessagesRead(1);
+                        numMessagesRead++;
+                        datagramBuffer.writerIndex(writerIndex + written);
+                        recvDatagramPending = false;
+
+                        pipeline().fireChannelRead(datagramBuffer);
+                    } while (recvHandle.continueReading());
+                    recvHandle.readComplete();
+
+                    // Check if we produced any messages.
+                    if (numMessagesRead > 0) {
+                        if (inRecv) {
+                            // If we are currently in the main recv method that is only triggered from the
+                            // QuicheQuicCodec we also need to set fireChannelReadCompletePending to false as otherwise
+                            // may get multiple notifications.
+                            // That set we should also set connectionSendNeeded to true so we ensure we call send().
+                            fireChannelReadCompletePending = false;
+                            connectionSendNeeded = true;
+                        }
+                        pipeline().fireChannelReadComplete();
+                    }
+                }
+            } finally {
+                inRecvDatagram = false;
+            }
         }
 
         private boolean handlePendingChannelActive() {
             if (server) {
                 if (state == OPEN && Quiche.quiche_conn_is_established(connAddr)) {
-
-                    // We didnt notify before about channelActive... Update state and fire the event.
+                    // We didn't notify before about channelActive... Update state and fire the event.
                     state = ACTIVE;
                     pipeline().fireChannelActive();
                     fireDatagramExtensionEvent();


### PR DESCRIPTION
Motivation:

We should support using AUTO_READ false and also be able to set read limits in general.

Modifications:

- Support manually reading
- Support limit the number of datagrams to read per read() operations.

Result:

Related to https://github.com/netty/netty-incubator-codec-quic/issues/95