### PR TITLE
Update to netty 4.1.56.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <javaModuleName>io.netty.incubator.codec.quic</javaModuleName>
     <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
     <skipTests>false</skipTests>
-    <netty.version>4.1.55.Final</netty.version>
+    <netty.version>4.1.56.Final</netty.version>
     <netty.build.version>28</netty.build.version>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <jniLibName>netty_quiche_${os.detected.name}_${os.detected.arch}</jniLibName>


### PR DESCRIPTION
Motivation:

A new netty release is out

Modifications:

Update to latest version

Result:

Use latest netty release