### PR TITLE
Disable debug logging during testsuite run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@
         <runOrder>random</runOrder>
         <systemPropertyVariables>
           <logback.configurationFile>src/test/resources/logback-test.xml</logback.configurationFile>
-          <logLevel>debug</logLevel>
+          <logLevel>info</logLevel>
         </systemPropertyVariables>
         <properties>
           <property>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -21,7 +21,7 @@
         </encoder>
     </appender>
 
-    <root level="${logLevel:-debug}">
+    <root level="${logLevel:-info}">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
Motivation:

Let's just not use debug logging during running the testsuite by default as it slows down stuff a lot.

Modifications:

Use info log level when running testsuite

Result:

Faster builds