### PR TITLE
Run apt-get update before trying to install dependencies

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,7 +64,7 @@ jobs:
     #   make bootstrap
     #   make release
     - name: Install tools / libraries 
-      run: sudo apt-get -y install autoconf automake libtool make tar cmake perl ninja-build git cargo
+      run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool make tar cmake perl ninja-build git cargo
 
     - name: Build project
       run: ./mvnw clean package -DskipTests=true


### PR DESCRIPTION
Motivation:

We need to run apt-get update before trying to install dependencies as otherwise we may see 404 errors

Modifications:

run apt-get update

Result:

No more failures due 404