### PR TITLE
Fix javadoc error

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -146,7 +146,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     /**
      * Set the application protocols to use. These are converted to wire-format.
      *
-     * @see {@link #applicationProtocols(byte[])}.
+     * @see #applicationProtocols(byte[])
      *
      * @param protocols the application protocols.
      * @return          the instance itself.


### PR DESCRIPTION
Motivation:

We should not see any errors due javadocs

Modification:

Fix javadoc error

Result:

./mvnw javadoc:javadoc dont fail