### PR TITLE
Enforce timeouts in unit tests

### DIFF
--- a/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
@@ -23,7 +23,7 @@ import org.junit.rules.Timeout;
 public abstract class AbstractQuicTest {
 
     private static final int TEST_GLOBAL_TIMEOUT_VALUE = Integer.getInteger(
-            "io.netty.incubator.codec.quic.defaultTestTimeout",10);
+            "io.netty.incubator.codec.quic.defaultTestTimeout", 10);
 
     @Rule
     public final Timeout globalTimeout = Timeout.seconds(TEST_GLOBAL_TIMEOUT_VALUE);

--- a/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
@@ -15,13 +15,21 @@
  */
 package io.netty.incubator.codec.quic;
 
-import org.junit.Test;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
 
-public class QuicTest extends AbstractQuicTest {
+public abstract class AbstractQuicTest {
 
-    @Test
-    public void test() {
-        Quic.ensureAvailability();
-        System.err.println(Quiche.quiche_version());
+    private static final int TEST_GLOBAL_TIMEOUT_VALUE = Integer.getInteger(
+            "io.netty.incubator.codec.quic.defaultTestTimeout",10);
+
+    @Rule
+    public final Timeout globalTimeout = Timeout.seconds(TEST_GLOBAL_TIMEOUT_VALUE);
+
+    @BeforeClass
+    public static void assumeTrue() {
+       Assume.assumeTrue(Quic.isAvailable());
     }
 }

--- a/src/test/java/io/netty/incubator/codec/quic/InsecureQuicTokenHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/InsecureQuicTokenHandlerTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-public class InsecureQuicTokenHandlerTest {
+public class InsecureQuicTokenHandlerTest extends AbstractQuicTest {
 
     @Test
     public void testMaxTokenLength() {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class QuicChannelConnectTest {
+public class QuicChannelConnectTest extends AbstractQuicTest {
 
     @Test
     public void testAddressValidation() throws Throwable {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicChannelDatagramTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicChannelDatagramTest.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-public class QuicChannelDatagramTest {
+public class QuicChannelDatagramTest extends AbstractQuicTest {
 
     private static final Random random = new Random();
     static final byte[] data = new byte[512];

--- a/src/test/java/io/netty/incubator/codec/quic/QuicChannelEchoTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicChannelEchoTest.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
-public class QuicChannelEchoTest {
+public class QuicChannelEchoTest extends AbstractQuicTest {
 
     private static final Random random = new Random();
     static final byte[] data = new byte[1048576];

--- a/src/test/java/io/netty/incubator/codec/quic/QuicConnectionAddressTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicConnectionAddressTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-public class QuicConnectionAddressTest {
+public class QuicConnectionAddressTest extends AbstractQuicTest {
 
     @Test(expected = NullPointerException.class)
     public void testNullByteArray() {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicConnectionIdGeneratorTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicConnectionIdGeneratorTest.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-public class QuicConnectionIdGeneratorTest {
+public class QuicConnectionIdGeneratorTest extends AbstractQuicTest {
 
     @Test
     public void testRandomness() {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-public class QuicConnectionStatsTest {
+public class QuicConnectionStatsTest extends AbstractQuicTest {
 
     @Test
     public void testStatsAreCollected() throws Throwable {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicPacketTypeTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicPacketTypeTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class QuicPacketTypeTest {
+public class QuicPacketTypeTest extends AbstractQuicTest {
 
     @Test
     public void testOfValidType() {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicReadableTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicReadableTest.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class QuicReadableTest {
+public class QuicReadableTest extends AbstractQuicTest {
 
     @Test
     public void testCorrectlyHandleReadableStreams() throws Throwable  {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
@@ -25,7 +25,7 @@ import io.netty.util.ReferenceCountUtil;
 
 import org.junit.Test;
 
-public class QuicStreamChannelCloseTest {
+public class QuicStreamChannelCloseTest extends AbstractQuicTest {
 
     @Test
     public void testCloseFromServerWhileInActiveUnidirectional() throws Exception {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CountDownLatch;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class QuicStreamChannelCreationTest {
+public class QuicStreamChannelCreationTest extends AbstractQuicTest {
 
     private static final AttributeKey<String> ATTRIBUTE_KEY = AttributeKey.newInstance("testKey");
     private static final String ATTRIBUTE_VALUE = "Test";

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
@@ -28,7 +28,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class QuicStreamFrameTest {
+public class QuicStreamFrameTest extends AbstractQuicTest {
 
     @Test
     public void testCloseHalfClosureUnidirectional() throws Exception {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamHalfClosureTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamHalfClosureTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class QuicStreamHalfClosureTest {
+public class QuicStreamHalfClosureTest extends AbstractQuicTest {
 
     @Test
     public void testCloseHalfClosureUnidirectional() throws Exception {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamIdGeneratorTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamIdGeneratorTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class QuicStreamIdGeneratorTest {
+public class QuicStreamIdGeneratorTest extends AbstractQuicTest {
 
     @Test
     public void testServerStreamIds() {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
@@ -30,7 +30,7 @@ import java.net.InetSocketAddress;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class QuicStreamLimitTest {
+public class QuicStreamLimitTest extends AbstractQuicTest {
 
     @Test
     public void testStreamLimitEnforcedWhenCreatingViaClientBidirectional() throws Throwable {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class QuicStreamTypeTest {
+public class QuicStreamTypeTest extends AbstractQuicTest {
 
     @Test
     public void testUnidirectionalCreatedByClient() throws Exception {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicWritableTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicWritableTest.java
@@ -17,7 +17,6 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -31,7 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class QuicWritableTest {
+public class QuicWritableTest extends AbstractQuicTest {
 
     @Test
     public void testCorrectlyHandleWritabilityReadRequestedInReadComplete() throws Throwable {


### PR DESCRIPTION
Motivation:

We should enforce some sort of timeout in unit tests so we fail at some point

Modifications:

- Add AbstractQuicTest which defines a global timeout and let all tests extend it
- Also ensure that we can load the native library

Result:

Tests will fail after some timeout