### PR TITLE
Fix buffer leak in QuicHeaderParser

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicHeaderParser.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicHeaderParser.java
@@ -63,6 +63,7 @@ public final class QuicHeaderParser implements AutoCloseable {
         if (!closed) {
             closed = true;
             versionBuffer.release();
+            typeBuffer.release();
             scidBuffer.release();
             scidLenBuffer.release();
             dcidBuffer.release();


### PR DESCRIPTION
Motivation:

We need to release all buffers that we allocate in QuicHeaderParser. We missed one:

```
10:15:07.968 [nioEventLoopGroup-2-21] ERROR io.netty.util.ResourceLeakDetector - LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
Recent access records:
Created at:
	io.netty.buffer.UnpooledByteBufAllocator.newDirectBuffer(UnpooledByteBufAllocator.java:96)
	io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:187)
	io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:178)
	io.netty.buffer.Unpooled.directBuffer(Unpooled.java:127)
	io.netty.incubator.codec.quic.Quiche.allocateNativeOrder(Quiche.java:540)
	io.netty.incubator.codec.quic.QuicHeaderParser.<init>(QuicHeaderParser.java:52)
	io.netty.incubator.codec.quic.QuicheQuicCodec.handlerAdded(QuicheQuicCodec.java:68)
	io.netty.channel.AbstractChannelHandlerContext.callHandlerAdded(AbstractChannelHandlerContext.java:938)
	io.netty.channel.DefaultChannelPipeline.callHandlerAdded0(DefaultChannelPipeline.java:609)
	io.netty.channel.DefaultChannelPipeline.access$100(DefaultChannelPipeline.java:46)
	io.netty.channel.DefaultChannelPipeline$PendingHandlerAddedTask.execute(DefaultChannelPipeline.java:1463)
	io.netty.channel.DefaultChannelPipeline.callHandlerAddedForAllHandlers(DefaultChannelPipeline.java:1115)
	io.netty.channel.DefaultChannelPipeline.invokeHandlerAddedIfNeeded(DefaultChannelPipeline.java:650)
	io.netty.channel.AbstractChannel$AbstractUnsafe.register0(AbstractChannel.java:502)
	io.netty.channel.AbstractChannel$AbstractUnsafe.access$200(AbstractChannel.java:417)
	io.netty.channel.AbstractChannel$AbstractUnsafe$1.run(AbstractChannel.java:474)
	io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)
	io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	java.base/java.lang.Thread.run(Thread.java:834)
```

Modifications:

Also release the typeBuffer

Result:

No more buffer leaks