### PR TITLE
Update files related to docker to point to vault

### DIFF
--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -1,13 +1,13 @@
-ARG centos_version=6
-FROM centos:$centos_version
-# needed to do again after FROM due to docker limitation
-ARG centos_version
+FROM centos:6.10
 
 ENV SOURCE_DIR /root/source
 ENV CMAKE_VERSION_BASE 3.8
 ENV CMAKE_VERSION $CMAKE_VERSION_BASE.2
 ENV NINJA_VERSION 1.7.2
 ENV GO_VERSION 1.9.3
+
+# Update as we need to use the vault now.
+RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever\//baseurl=http:\/\/vault.centos.org\/6.10\//g' /etc/yum.repos.d/CentOS-Base.repo
 
 # We want to have git 2.x for the maven scm plugin
 RUN yum install -y http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,5 +7,5 @@ cd /path/to/source/
 ## centos 6 with java 8
 
 ```
-docker-compose -f docker/docker-compose.centos.yaml -f docker/docker-compose.centos-6.18.yaml run build
+docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build
 ```

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -6,7 +6,6 @@ services:
     image: netty-codec-quic-centos:centos-6-1.8
     build:
       args:
-        centos_version : "6"
         java_version : "adopt@1.8.0-272"
 
   build:

--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-quic-centos:default
     build:
       context: .
-      dockerfile: Dockerfile.centos
+      dockerfile: Dockerfile.centos6
 
   common: &common
     image: netty-codec-quic-centos:default


### PR DESCRIPTION
Motivation:

Centos6 is now in the vault as it is EOL. That said we still want to compile on it our releases

Modifications:

Update files to update repos to point to the vault

Result:

Be able to still use docker