### PR TITLE
Fix quicheCheckoutDir path

### DIFF
--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -19,7 +19,7 @@ services:
 
   build:
     <<: *common
-    command: /bin/bash -cl "mvn clean package -DquicheCheckoutDir=$HOME/source/quiche"
+    command: /bin/bash -cl "mvn clean package -DquicheCheckoutDir=/root/source/quiche"
 
   build-clean:
     <<: *common


### PR DESCRIPTION
Motivation:

How we constructed the path was incorrect.

Modifications:

Fix path.

Result:

Be able to re-use precompiled quiche