### PR TITLE
Rebuild docker image before execute project build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,10 @@ jobs:
           restore-keys: |
             docker-cache-${{ steps.cache-key.outputs.key }}-
 
-      - name: Run docker-compose
+      - name: Build docker image
+        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
+
+      - name: Execute project build
         run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build
 
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Motivation:

To ensure we pick up changes we need to rebuild the image before we run the build

Modifications:

Add extra step which rebuilds image

Result:

Image always up to date