### PR TITLE
Always use the mvn installation of the image

### DIFF
--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -66,6 +66,7 @@ RUN echo 'PATH=$PATH:$HOME/.cargo/bin' >> ~/.bashrc
 
 WORKDIR /opt
 RUN curl https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar -xz
+RUN echo 'PATH=/opt/apache-maven-3.6.3/bin/:$PATH' >> ~/.bashrc
 
 # Prepare our own build
 ENV PATH /opt/apache-maven-3.6.3/bin/:$PATH

--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -23,13 +23,13 @@ services:
 
   build-clean:
     <<: *common
-    command: /bin/bash -cl "./mvnw clean package"
+    command: /bin/bash -cl "mvn clean package"
 
   shell:
     <<: *common
     environment:
-      - SANOTYPE_USER
-      - SANOTYPE_PASSWORD
+      - SONATYPE_USER
+      - SONATYPE_PASSWORD
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated


### PR DESCRIPTION
Motivation:

Let's use always the mvn installation which is part of the image to minimize things that needs to be fetched

Modifications:

Use mvn directly

Result:

Less downloads during build