### PR TITLE
Use copy when closing connections in handlerRemoved

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -82,7 +82,9 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) {
-        for (QuicheQuicChannel ch: connections.values()) {
+        // Use a copy of the array as closing the channel may cause an unwritable event that could also
+        // remove channels.
+        for (QuicheQuicChannel ch:  connections.values().toArray(new QuicheQuicChannel[0])) {
             ch.forceClose();
         }
         connections.clear();


### PR DESCRIPTION
Motivation:

We need to act on a copy of the values as forceClose() may also remove from the map.

Modifications:

Make a copy of the values and iterate over these.

Result:

No more assert error