### PR TITLE
Let's split up some work in different workflows (#44)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,44 @@
+name: Build project
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  schedule:
+    - cron: '30 7 * * 1'  # At 07:30 on Monday, every Monday.
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build-linux-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Enable caching of Docker layers
+      - uses: satackey/action-docker-layer-caching@v0.0.8
+        continue-on-error: true
+        with:
+          key: build-linux-x86_64-docker-cache-{hash}
+          restore-keys: |
+            build-linux-x86_64-docker-cache-
+
+      - name: Build docker image
+        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
+
+      - name: Build project without leak detection
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build
+
+      - name: Build project with leak detection
+        if: ${{ github.event_name == 'pull_request' }}
+        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build-leak
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: target
+          path: target/ # or path/to/artifact

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -1,9 +1,7 @@
-name: Build project
+name: Deploy project
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
     branches: [ main ]
 
   schedule:
@@ -13,16 +11,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  deploy-linux-x86_64:
     runs-on: ubuntu-latest
     steps:
-      # http://man7.org/linux/man-pages/man1/date.1.html
-      - name: Create Cache Key
-        id: cache-key
-        run: |
-          echo "::set-output name=key::$(/bin/date -u "+%Y%U")"
-        shell: bash
-
       - uses: s4u/maven-settings-action@v2.2.0
         with:
           servers: |
@@ -38,20 +29,14 @@ jobs:
       - uses: satackey/action-docker-layer-caching@v0.0.8
         continue-on-error: true
         with:
-          key: docker-cache-${{ steps.cache-key.outputs.key }}-{hash}
+          key: deploy-linux-x86_64-docker-cache-{hash}
           restore-keys: |
-            docker-cache-${{ steps.cache-key.outputs.key }}-
+            deploy-linux-x86_64-docker-cache-
 
-      - name: Build project without leak detection
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build
-
-      - name: Build project with leak detection
-        if: ${{ github.event_name == 'pull_request' }}
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build-leak
+      - name: Build docker image
+        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
 
       - name: Deploy project snapshot to sonatype
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run deploy
 
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Motivation:

We should split up work to different workflows as it also make it easier to run the seperatly and also makes it easier to control things

Modifications:

Split build and deploy to different workflows

Result:

Easier to configure jobs