### PR TITLE
SEGV when QUIC configuration is invalid

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -91,7 +91,9 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
         needsFireChannelReadComplete.clear();
 
-        Quiche.quiche_config_free(nativeConfig);
+        if (nativeConfig != 0) {
+            Quiche.quiche_config_free(nativeConfig);
+        }
         if (headerParser != null) {
             headerParser.close();
             headerParser = null;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -79,8 +79,12 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) {
         super.handlerRemoved(ctx);
-        connIdBuffer.release();
-        mintTokenBuffer.release();
+        if (connIdBuffer != null) {
+            connIdBuffer.release();
+        }
+        if (mintTokenBuffer != null) {
+            mintTokenBuffer.release();
+        }
     }
 
     @Override

--- a/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -217,6 +217,16 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             channel.close().sync();
         }
     }
+
+    @Test
+    public void testConnectWithoutBogusCertificate() throws Throwable {
+        Channel server = QuicTestUtils.newServer(
+                QuicTestUtils.newQuicServerBuilder().certificateChain("cert-does-not-exist.pem"),
+                InsecureQuicTokenHandler.INSTANCE,
+                new ChannelInboundHandlerAdapter(), new ChannelInboundHandlerAdapter());
+        assertNull(server.pipeline().get(QuicheQuicCodec.class));
+    }
+
     private static final class BytesCountingHandler extends ChannelInboundHandlerAdapter {
         private final CountDownLatch latch;
         private final int numBytes;


### PR DESCRIPTION
Motivation:

When QuicheConfig.createNativeConfig() throws, for example if the server certificate and/or private key are invalid or missing, a SEGV later happens when QuicheQuicCodec frees the nativeConfig object.

Modifications:

Check if nativeConfig is zero before calling Quiche.quiche_config_free().

Result:

No more SEGV.