### PR TITLE
Make copy of the values to prevent assert error

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -561,7 +561,9 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     private void closeStreams() {
-        for (QuicheQuicStreamChannel stream: streams.values()) {
+        // Make a copy to ensure we not run into a situation when we change the underlying iterator from
+        // another method and so run in an assert error.
+        for (QuicheQuicStreamChannel stream: streams.values().toArray(new QuicheQuicStreamChannel[0])) {
             stream.unsafe().close(voidPromise());
         }
         streams.clear();

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -82,21 +82,23 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) {
-        // Use a copy of the array as closing the channel may cause an unwritable event that could also
-        // remove channels.
-        for (QuicheQuicChannel ch:  connections.values().toArray(new QuicheQuicChannel[0])) {
-            ch.forceClose();
-        }
-        connections.clear();
+        try {
+            // Use a copy of the array as closing the channel may cause an unwritable event that could also
+            // remove channels.
+            for (QuicheQuicChannel ch : connections.values().toArray(new QuicheQuicChannel[0])) {
+                ch.forceClose();
+            }
+            connections.clear();
 
-        needsFireChannelReadComplete.clear();
-
-        if (nativeConfig != 0) {
-            Quiche.quiche_config_free(nativeConfig);
-        }
-        if (headerParser != null) {
-            headerParser.close();
-            headerParser = null;
+            needsFireChannelReadComplete.clear();
+        } finally {
+            if (nativeConfig != 0) {
+                Quiche.quiche_config_free(nativeConfig);
+            }
+            if (headerParser != null) {
+                headerParser.close();
+                headerParser = null;
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

We need to make a copy of the values to ensure we not modify the iterator concurrently. Beside this we should also call free in a finally block.

Modifications:

- Make a copy of the values
- Use try finally

Result:

No more assert failures possible