### PR TITLE
Fail fast if config is invalid

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -412,7 +412,13 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      */
     public final ChannelHandler build() {
         validate();
-        return build(createConfig(), localConnIdLength);
+        QuicheConfig config = createConfig();
+        try {
+            return build(config, localConnIdLength);
+        } catch (Throwable cause) {
+            config.free();
+            throw cause;
+        }
     }
 
     /**

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
@@ -48,7 +48,7 @@ final class QuicheQuicClientCodec extends QuicheQuicCodec {
                         SocketAddress localAddress, ChannelPromise promise) {
         final QuicheQuicChannel channel;
         try {
-            channel = QuicheQuicChannel.handleConnect(remoteAddress, nativeConfig, localConnIdLength,
+            channel = QuicheQuicChannel.handleConnect(remoteAddress, config.nativeAddress(), localConnIdLength,
                     config.isDatagramSupported());
         } catch (Exception e) {
             promise.setFailure(e);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -47,7 +47,6 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
     protected final QuicheConfig config;
     protected final int localConnIdLength;
-    protected long nativeConfig;
 
     QuicheQuicCodec(QuicheConfig config, int localConnIdLength, int maxTokenLength) {
         this.config = config;
@@ -77,7 +76,6 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
                 }
             }
         };
-        nativeConfig = config.createNativeConfig();
     }
 
     @Override
@@ -92,9 +90,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
             needsFireChannelReadComplete.clear();
         } finally {
-            if (nativeConfig != 0) {
-                Quiche.quiche_config_free(nativeConfig);
-            }
+            config.free();
             if (headerParser != null) {
                 headerParser.close();
                 headerParser = null;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -170,10 +170,12 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
                     dcid.internalNioBuffer(dcid.readerIndex(), dcid.readableBytes()), localConnIdLength);
             connIdBuffer.writeBytes(key.duplicate());
             conn = Quiche.quiche_accept_no_token(
-                    Quiche.memoryAddress(connIdBuffer) + connIdBuffer.readerIndex(), localConnIdLength, nativeConfig);
+                    Quiche.memoryAddress(connIdBuffer) + connIdBuffer.readerIndex(), localConnIdLength,
+                    config.nativeAddress());
         } else {
             conn = Quiche.quiche_accept(Quiche.memoryAddress(dcid) + dcid.readerIndex(), localConnIdLength,
-                    Quiche.memoryAddress(token) + offset, token.readableBytes() - offset, nativeConfig);
+                    Quiche.memoryAddress(token) + offset, token.readableBytes() - offset,
+                    config.nativeAddress());
 
             // Now create the key to store the channel in the map.
             byte[] bytes = new byte[localConnIdLength];

--- a/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -218,13 +218,12 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         }
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testConnectWithoutBogusCertificate() throws Throwable {
-        Channel server = QuicTestUtils.newServer(
+        QuicTestUtils.newServer(
                 QuicTestUtils.newQuicServerBuilder().certificateChain("cert-does-not-exist.pem"),
                 InsecureQuicTokenHandler.INSTANCE,
                 new ChannelInboundHandlerAdapter(), new ChannelInboundHandlerAdapter());
-        assertNull(server.pipeline().get(QuicheQuicCodec.class));
     }
 
     private static final class BytesCountingHandler extends ChannelInboundHandlerAdapter {


### PR DESCRIPTION
Motivation:

We should fail as fast as possible when the config is incorrect. This makes it easier for the user to detect issues

Modifications:

- Create config as fast as possible and so fail fast
- Adjust unit test

Result:

Fail fast if config is incorrect