### PR TITLE
Allow to use KeyManagerFactory / TrustmanagerFactory

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -39,3 +39,11 @@ This product is statically linked against Quiche.
     * license/LICENSE.quiche.txt (BSD2)
   * HOMEPAGE:
     * https://github.com/cloudflare/quiche
+
+
+This product is statically linked against boringssl.
+
+  * LICENSE (Combination ISC and OpenSSL license)
+    * license/LICENSE.boringssl.txt (Combination ISC and OpenSSL license)
+  * HOMEPAGE:
+    * https://boringssl.googlesource.com/boringssl/

--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -76,5 +76,8 @@ COPY ./pom.xml $SOURCE_DIR/pom.xml
 WORKDIR $SOURCE_DIR
 RUN /bin/bash -c 'source $HOME/.bashrc && mvn dependency:go-offline surefire:test -ntp'
 
+# Pre-build boringssl
+RUN /bin/bash -c 'source $HOME/.bashrc && mvn antrun:run@build-boringssl -DquicheCheckoutDir=$SOURCE_DIR/boringssl'
+
 # Pre-build quiche
 RUN /bin/bash -c 'source $HOME/.bashrc && mvn antrun:run@build-quiche -DquicheCheckoutDir=$SOURCE_DIR/quiche'

--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -19,12 +19,12 @@ services:
 
   build:
     <<: *common
-    command: /bin/bash -cl "mvn clean package -DquicheCheckoutDir=/root/source/quiche"
+    command: /bin/bash -cl "mvn clean package -DboringsslSourceDir=/root/source/boringssl -DquicheCheckoutDir=/root/source/quiche"
 
 
   build-leak:
     <<: *common
-    command: /bin/bash -cl "mvn -Pleak clean package -DquicheCheckoutDir=/root/source/quiche"
+    command: /bin/bash -cl "mvn -Pleak clean package -DboringsslSourceDir=/root/source/boringssl -DquicheCheckoutDir=/root/source/quiche"
 
 
   build-clean:
@@ -33,7 +33,7 @@ services:
 
   deploy:
     <<: *common
-    command: /bin/bash -cl "mvn clean deploy -DskipTests=true -DquicheCheckoutDir=/root/source/quiche"
+    command: /bin/bash -cl "mvn clean deploy -DskipTests=true -DboringsslSourceDir=/root/source/boringssl -DquicheCheckoutDir=/root/source/quiche"
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg

--- a/license/LICENSE.boringssl.txt
+++ b/license/LICENSE.boringssl.txt
@@ -1,0 +1,221 @@
+BoringSSL is a fork of OpenSSL. As such, large parts of it fall under OpenSSL
+licensing. Files that are completely new have a Google copyright and an ISC
+license. This license is reproduced at the bottom of this file.
+Contributors to BoringSSL are required to follow the CLA rules for Chromium:
+https://cla.developers.google.com/clas
+Files in third_party/ have their own licenses, as described therein. The MIT
+license, for third_party/fiat, which, unlike other third_party directories, is
+compiled into non-test libraries, is included below.
+The OpenSSL toolkit stays under a dual license, i.e. both the conditions of the
+OpenSSL License and the original SSLeay license apply to the toolkit. See below
+for the actual license texts. Actually both licenses are BSD-style Open Source
+licenses. In case of any license issues related to OpenSSL please contact
+openssl-core@openssl.org.
+The following are Google-internal bug numbers where explicit permission from
+some authors is recorded for use of their work. (This is purely for our own
+record keeping.)
+  27287199
+  27287880
+  27287883
+  OpenSSL License
+  ---------------
+/* ====================================================================
+ * Copyright (c) 1998-2011 The OpenSSL Project.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer. 
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. All advertising materials mentioning features or use of this
+ *    software must display the following acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+ *
+ * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For written permission, please contact
+ *    openssl-core@openssl.org.
+ *
+ * 5. Products derived from this software may not be called "OpenSSL"
+ *    nor may "OpenSSL" appear in their names without prior written
+ *    permission of the OpenSSL Project.
+ *
+ * 6. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+ * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This product includes cryptographic software written by Eric Young
+ * (eay@cryptsoft.com).  This product includes software written by Tim
+ * Hudson (tjh@cryptsoft.com).
+ *
+ */
+ Original SSLeay License
+ -----------------------
+/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+ * All rights reserved.
+ *
+ * This package is an SSL implementation written
+ * by Eric Young (eay@cryptsoft.com).
+ * The implementation was written so as to conform with Netscapes SSL.
+ * 
+ * This library is free for commercial and non-commercial use as long as
+ * the following conditions are aheared to.  The following conditions
+ * apply to all code found in this distribution, be it the RC4, RSA,
+ * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+ * included with this distribution is covered by the same copyright terms
+ * except that the holder is Tim Hudson (tjh@cryptsoft.com).
+ * 
+ * Copyright remains Eric Young's, and as such any Copyright notices in
+ * the code are not to be removed.
+ * If this package is used in a product, Eric Young should be given attribution
+ * as the author of the parts of the library used.
+ * This can be in the form of a textual message at program startup or
+ * in documentation (online or textual) provided with the package.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *    "This product includes cryptographic software written by
+ *     Eric Young (eay@cryptsoft.com)"
+ *    The word 'cryptographic' can be left out if the rouines from the library
+ *    being used are not cryptographic related :-).
+ * 4. If you include any Windows specific code (or a derivative thereof) from 
+ *    the apps directory (application code) you must include an acknowledgement:
+ *    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
+ * 
+ * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * 
+ * The licence and distribution terms for any publically available version or
+ * derivative of this code cannot be changed.  i.e. this code cannot simply be
+ * copied and put under another distribution licence
+ * [including the GNU Public Licence.]
+ */
+ISC license used for completely new code in BoringSSL:
+/* Copyright (c) 2015, Google Inc.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+ * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+The code in third_party/fiat carries the MIT license:
+Copyright (c) 2015-2016 the fiat-crypto authors (see
+https://github.com/mit-plv/fiat-crypto/blob/master/AUTHORS).
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+Licenses for support code
+-------------------------
+Parts of the TLS test suite are under the Go license. This code is not included
+in BoringSSL (i.e. libcrypto and libssl) when compiled, however, so
+distributing code linked against BoringSSL does not trigger this license:
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+BoringSSL uses the Chromium test infrastructure to run a continuous build,
+trybots etc. The scripts which manage this, and the script for generating build
+metadata, are under the Chromium license. Distributing code linked against
+BoringSSL does not trigger this license.
+Copyright 2015 The Chromium Authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pom.xml
+++ b/pom.xml
@@ -69,18 +69,25 @@
     <javaModuleName>io.netty.incubator.codec.quic</javaModuleName>
     <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
     <skipTests>false</skipTests>
-    <netty.version>4.1.58.Final</netty.version>
+    <netty.version>4.1.59.Final-SNAPSHOT</netty.version>
     <netty.build.version>28</netty.build.version>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <jniLibName>netty_quiche_${os.detected.name}_${os.detected.arch}</jniLibName>
     <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/</jniUtilIncludeDir>
+    <boringsslBranch>chromium-stable</boringsslBranch>
+    <boringsslHome>${boringsslSourceDir}/build</boringsslHome>
+    <boringsslSourceDir>${project.build.directory}/boringssl</boringsslSourceDir>
+    <!--
+      See https://boringssl.googlesource.com/boringssl/+/refs/heads/chromium-stable for the latest commit
+    -->
+    <boringsslCommitSha>3743aafdacff2f7b083615a043a37101f740fa53</boringsslCommitSha>
     <quicheCheckoutDir>${project.build.directory}/quiche</quicheCheckoutDir>
     <quicheBuildDir>${quicheCheckoutDir}/target/release</quicheBuildDir>
     <quicheBranch>master</quicheBranch>
     <quicheCommitSha>5403e54c40caf70f096a2a08c50c9d71c149da6f</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
-    <cflags>-Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3 -I${quicheCheckoutDir}/include</cflags>
-    <ldflags>-L${quicheBuildDir} -lquiche</ldflags>
+    <cflags>-Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3 -I${quicheCheckoutDir}/include -I${boringsslSourceDir}/include</cflags>
+    <ldflags>-L${quicheBuildDir} -lquiche -L${boringsslHome}/ssl -L${boringsslHome}/crypto -L${boringsslHome}/decrepit -ldecrepit -lssl -lcrypto</ldflags>
     <extraLdflags />
     <extraConfigureArg />
     <!-- We need 10.12 as minimum to compile quiche and use it.
@@ -199,6 +206,104 @@
         </dependency>
       </dependencies>
       <executions>
+
+        <!-- Build the BoringSSL static libs -->
+        <execution>
+          <id>build-boringssl</id>
+          <phase>generate-sources</phase>
+          <goals>
+            <goal>run</goal>
+          </goals>
+          <configuration>
+            <target>
+              <!-- Add the ant tasks from ant-contrib -->
+              <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+              <property environment="env" />
+              <if>
+                <available file="${boringsslHome}" />
+                <then>
+                  <echo message="BoringSSL was already build, skipping the build step." />
+                </then>
+                <else>
+                  <if>
+                    <available file="${boringsslSourceDir}" />
+                    <then>
+                      <echo message="BoringSSL was already cloned, skipping the clone step." />
+                    </then>
+                    <else>
+                      <echo message="Clone BoringSSL" />
+
+                      <exec executable="git" failonerror="true" dir="${project.build.directory}" resolveexecutable="true">
+                        <arg value="clone" />
+                        <arg value="--branch" />
+                        <arg value="${boringsslBranch}" />
+                        <arg value="https://boringssl.googlesource.com/boringssl" />
+                        <arg value="${boringsslSourceDir}" />
+                      </exec>
+                    </else>
+                  </if>
+
+                  <echo message="Building BoringSSL" />
+
+                  <!-- Use the known SHA of the commit -->
+                  <exec executable="git" failonerror="true" dir="${boringsslSourceDir}" resolveexecutable="true">
+                    <arg value="checkout" />
+                    <arg value="${boringsslCommitSha}" />
+                  </exec>
+
+                  <mkdir dir="${boringsslHome}" />
+                  <if>
+                    <equals arg1="${os.detected.name}" arg2="linux" />
+                    <then>
+                      <!-- On *nix, add ASM flags to disable executable stack -->
+                      <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
+                      <property name="cmakeCFlags" value="-O3 -fno-omit-frame-pointer -DOPENSSL_C11_ATOMIC" />
+                      <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
+                      <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -DOPENSSL_C11_ATOMIC -Wno-error=maybe-uninitialized -Wno-error=shadow -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
+                    </then>
+                    <else>
+                      <!-- On *nix, add ASM flags to disable executable stack -->
+                      <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
+                      <property name="cmakeCFlags" value="-O3 -fno-omit-frame-pointer -DOPENSSL_C11_ATOMIC" />
+                      <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -DOPENSSL_C11_ATOMIC -Wno-error=range-loop-analysis" />
+                    </else>
+                  </if>
+                  <exec executable="cmake" failonerror="true" dir="${boringsslHome}" resolveexecutable="true">
+                    <env key="MACOSX_DEPLOYMENT_TARGET" value="${macosxDeploymentTarget}" />
+                    <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
+                    <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                    <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
+                    <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
+                    <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                    <arg value="-GNinja" />
+                    <arg value="${boringsslSourceDir}" />
+                  </exec>
+                  <if>
+                    <!-- may be called ninja-build or ninja -->
+                    <!-- See https://github.com/netty/netty-tcnative/issues/475 -->
+                    <available file="ninja-build" filepath="${env.PATH}" />
+                    <then>
+                      <exec executable="ninja-build" failonerror="true" dir="${boringsslHome}" resolveexecutable="true" />
+                    </then>
+                    <else>
+                      <exec executable="ninja" failonerror="true" dir="${boringsslHome}" resolveexecutable="true" />
+                    </else>
+                  </if>
+                  <exec executable="ln" failonerror="true" dir="${boringsslHome}" resolveexecutable="true">
+                    <arg value="-s" />
+                    <arg value="ssl/libssl.a" />
+                    <arg value="." />
+                  </exec>
+                  <exec executable="ln" failonerror="true" dir="${boringsslHome}" resolveexecutable="true">
+                    <arg value="-s" />
+                    <arg value="crypto/libcrypto.a" />
+                    <arg value="." />
+                  </exec>
+                </else>
+              </if>
+            </target>
+          </configuration>
+        </execution>
         <!-- Build the Quiche static lib -->
         <execution>
           <id>build-quiche</id>
@@ -252,8 +357,9 @@
                         <arg value="ffi" />
                         <arg value="--release" />
                         <env key="MACOSX_DEPLOYMENT_TARGET" value="${macosxDeploymentTarget}" />
-                        <env key="CFLAGS" value="-O3 -fno-omit-frame-pointer -DOPENSSL_C11_ATOMIC" />
+                        <env key="CFLAGS" value="-O3 -fno-omit-frame-pointer" />
                         <env key="CXXFLAGS" value="-O3 -fno-omit-frame-pointer" />
+                        <env key="QUICHE_BSSL_PATH" value="${boringsslSourceDir}/"/>
                       </exec>
 
                       <!-- delete the shared library as otherwise we may link against it and not against the static
@@ -418,6 +524,10 @@
             <instructions>
               <Export-Package>${project.groupId}.*</Export-Package>
               <Bundle-NativeCode>${bundleNativeCode}</Bundle-NativeCode>
+              <BoringSSL-Revision>${boringsslCommitSha}</BoringSSL-Revision>
+              <BoringSSL-Branch>${boringsslBranch}</BoringSSL-Branch>
+              <Quiche-Revision>${quicheCommitSha}</Quiche-Revision>
+              <Quiche-Branch>${quicheBranch}</Quiche-Branch>
             </instructions>
           </configuration>
         </execution>
@@ -589,6 +699,11 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
       <version>${netty.version}</version>
     </dependency>
     <dependency>

--- a/src/main/c/netty_quic.h
+++ b/src/main/c/netty_quic.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef NETTY_QUIC_H_
+#define NETTY_QUIC_H_
+
+jint quic_get_java_env(JNIEnv **env);
+
+
+#endif /* NETTY_QUIC_H_ */

--- a/src/main/c/netty_quic_boringssl.c
+++ b/src/main/c/netty_quic_boringssl.c
@@ -1,0 +1,814 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#include <jni.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <openssl/ssl.h>
+
+#include "netty_jni_util.h"
+#include "netty_quic.h"
+#include "netty_quic_boringssl.h"
+
+// Add define if NETTY_BUILD_STATIC is defined so it is picked up in netty_jni_util.c
+#ifdef NETTY_BUILD_STATIC
+#define NETTY_JNI_UTIL_BUILD_STATIC
+#endif
+
+#define STATICALLY_CLASSNAME "io/netty/incubator/codec/quic/BoringSSLNativeStaticallyReferencedJniMethods"
+#define CLASSNAME "io/netty/incubator/codec/quic/BoringSSL"
+
+static jclass verifyCallbackClass = NULL;
+static jmethodID verifyCallbackMethod = NULL;
+
+static jclass certificateCallbackClass = NULL;
+static jmethodID certificateCallbackMethod = NULL;
+
+static jclass handshakeCompleteCallbackClass = NULL;
+static jmethodID handshakeCompleteCallbackMethod = NULL;
+
+static jclass byteArrayClass = NULL;
+static jclass stringClass = NULL;
+
+static int handshakeCompleteCallbackIdx = -1;
+static int verifyCallbackIdx = -1;
+static int certificateCallbackIdx = -1;
+static int alpn_data_idx = -1;
+static int crypto_buffer_pool_idx = -1;
+
+static jint netty_boringssl_ssl_verify_none(JNIEnv* env, jclass clazz) {
+    return SSL_VERIFY_NONE;
+}
+
+static jint netty_boringssl_ssl_verify_fail_if_no_peer_cert(JNIEnv* env, jclass clazz) {
+    return SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+}
+
+static jint netty_boringssl_ssl_verify_peer(JNIEnv* env, jclass clazz) {
+    return SSL_VERIFY_PEER;
+}
+
+static jint netty_boringssl_x509_v_ok(JNIEnv* env, jclass clazz) {
+    return X509_V_OK;
+}
+
+static jint netty_boringssl_x509_v_err_cert_has_expired(JNIEnv* env, jclass clazz) {
+    return X509_V_ERR_CERT_HAS_EXPIRED;
+}
+
+static jint netty_boringssl_x509_v_err_cert_not_yet_valid(JNIEnv* env, jclass clazz) {
+    return X509_V_ERR_CERT_NOT_YET_VALID;
+}
+
+static jint netty_boringssl_x509_v_err_cert_revoked(JNIEnv* env, jclass clazz) {
+    return X509_V_ERR_CERT_REVOKED;
+}
+
+static jint netty_boringssl_x509_v_err_unspecified(JNIEnv* env, jclass clazz) {
+    return X509_V_ERR_UNSPECIFIED;
+}
+
+static STACK_OF(CRYPTO_BUFFER)* arrayToStack(JNIEnv* env, jobjectArray array, CRYPTO_BUFFER_POOL* pool) {
+    if (array == NULL) {
+        return NULL;
+    }
+    STACK_OF(CRYPTO_BUFFER) *stack = sk_CRYPTO_BUFFER_new_null();
+    int arrayLen = (*env)->GetArrayLength(env, array);
+    for (int i = 0; i < arrayLen; i++) {
+        jbyteArray bytes = (*env)->GetObjectArrayElement(env, array, i);
+        int data_len = (*env)->GetArrayLength(env, bytes);
+        uint8_t* data = (uint8_t*) (*env)->GetByteArrayElements(env, bytes, 0);
+        CRYPTO_BUFFER *buffer = CRYPTO_BUFFER_new(data, data_len, pool);
+        if (buffer == NULL || sk_CRYPTO_BUFFER_push(stack, buffer) <= 0) {
+            goto cleanup;
+        }
+    }
+    return stack;
+cleanup:
+    sk_CRYPTO_BUFFER_pop_free(stack, CRYPTO_BUFFER_free);
+    return NULL;
+}
+
+static jobjectArray stackToArray(JNIEnv *e, const STACK_OF(CRYPTO_BUFFER)* stack, int offset) {
+    if (stack == NULL) {
+        return NULL;
+    }
+    const int len = sk_CRYPTO_BUFFER_num(stack) - offset;
+    if (len <= 0) {
+        return NULL;
+    }
+    // Create the byte[][] array that holds all the certs
+    jbyteArray array = (*e)->NewObjectArray(e, len, byteArrayClass, NULL);
+    if (array == NULL) {
+        return NULL;
+    }
+
+    for(int i = 0; i < len; i++) {
+        CRYPTO_BUFFER* value = sk_CRYPTO_BUFFER_value(stack, i + offset);
+        int length = CRYPTO_BUFFER_len(value);
+
+        if (length <= 0) {
+            return NULL;
+        }
+
+        jbyteArray bArray = (*e)->NewByteArray(e, length);
+        if (bArray == NULL) {
+            return NULL;
+        }
+        (*e)->SetByteArrayRegion(e, bArray, 0, length, (jbyte*) CRYPTO_BUFFER_data(value));
+        (*e)->SetObjectArrayElement(e, array, i, bArray);
+        // Delete the local reference as we not know how long the chain is and local references are otherwise
+        // only freed once jni method returns.
+        (*e)->DeleteLocalRef(e, bArray);
+        bArray = NULL;
+    }
+    return array;
+}
+
+
+enum ssl_verify_result_t quic_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert) {
+    enum ssl_verify_result_t ret = ssl_verify_invalid;
+    jint result = X509_V_ERR_UNSPECIFIED;
+    JNIEnv *e = NULL;
+
+    SSL_CTX* ctx = SSL_get_SSL_CTX(ssl);
+    if (ctx == NULL) {
+        goto complete;
+    }
+
+    if (quic_get_java_env(&e) != JNI_OK) {
+        goto complete;
+    }
+
+    jobject verifyCallback = SSL_CTX_get_ex_data(ctx, verifyCallbackIdx);
+    if (verifyCallback == NULL) {
+        goto complete;
+    }
+
+    const STACK_OF(CRYPTO_BUFFER) *chain = SSL_get0_peer_certificates(ssl);
+    if (chain == NULL) {
+        goto complete;
+    }
+
+    // Create the byte[][] array that holds all the certs
+    jobjectArray array = stackToArray(e, chain, 0);
+    if (array == NULL) {
+        goto complete;
+    }
+
+    const char* authentication_method = NULL;
+    STACK_OF(SSL_CIPHER) *ciphers = SSL_get_ciphers(ssl);
+    if (ciphers == NULL || sk_SSL_CIPHER_num(ciphers) <= 0) {
+         // No cipher available so return UNKNOWN.
+         authentication_method = "UNKNOWN";
+    } else {
+         authentication_method = SSL_CIPHER_get_kx_name(sk_SSL_CIPHER_value(ciphers, 0));
+         if (authentication_method == NULL) {
+              authentication_method = "UNKNOWN";
+         }
+    }
+
+    jstring authMethodString = (*e)->NewStringUTF(e, authentication_method);
+    if (authMethodString == NULL) {
+        goto complete;
+    }
+
+    // Execute the java callback
+    result = (*e)->CallIntMethod(e, verifyCallback, verifyCallbackMethod, (jlong)ssl, array, authMethodString);
+
+    if ((*e)->ExceptionCheck(e) == JNI_TRUE) {
+        (*e)->ExceptionClear(e);
+        result = X509_V_ERR_UNSPECIFIED;
+        goto complete;
+    }
+
+    int len = (*e)->GetArrayLength(e, array);
+    // If we failed to verify for an unknown reason (currently this happens if we can't find a common root) then we should
+    // fail with the same status as recommended in the OpenSSL docs https://www.openssl.org/docs/man1.0.2/ssl/SSL_set_verify.html
+    if (result == X509_V_ERR_UNSPECIFIED && len < sk_CRYPTO_BUFFER_num(chain)) {
+        result = X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY;
+    }
+complete:
+    if (result == X509_V_OK) {
+        ret = ssl_verify_ok;
+    } else {
+        ret = ssl_verify_invalid;
+        *out_alert = SSL_alert_from_verify_result(result);
+    }
+    return ret;
+}
+
+static jbyteArray keyTypes(JNIEnv* e, SSL* ssl) {
+    jbyte* ctype_bytes = NULL;
+    int ctype_num = SSL_get0_certificate_types(ssl, (const uint8_t **) &ctype_bytes);
+    if (ctype_num <= 0) {
+        // No idea what we should use... Let the caller handle it.
+        return NULL;
+    }
+    jbyteArray types = (*e)->NewByteArray(e, ctype_num);
+    if (types == NULL) {
+        return NULL;
+    }
+    (*e)->SetByteArrayRegion(e, types, 0, ctype_num, ctype_bytes);
+    return types;
+}
+
+// See https://www.openssl.org/docs/man1.0.2/man3/SSL_set_cert_cb.html for return values.
+static int quic_certificate_cb(SSL* ssl, void* arg) {
+    JNIEnv *e = NULL;
+    CRYPTO_BUFFER** certs = NULL;
+    jlong* elements = NULL;
+    int ret = 0;
+    int free = 0;
+
+    if (quic_get_java_env(&e) != JNI_OK) {
+        goto done;
+    }
+
+    jobjectArray authMethods = NULL;
+    jobjectArray issuers = NULL;
+    jbyteArray types = NULL;
+    if (SSL_is_server(ssl) == 1) {
+        const STACK_OF(SSL_CIPHER) *ciphers = SSL_get_ciphers(ssl);
+        int len = sk_SSL_CIPHER_num(ciphers);
+        authMethods = (*e)->NewObjectArray(e, len, stringClass, NULL);
+        if (authMethods == NULL) {
+            goto done;
+        }
+
+        for (int i = 0; i < len; i++) {
+            jstring methodString = (*e)->NewStringUTF(e, SSL_CIPHER_get_kx_name(sk_SSL_CIPHER_value(ciphers, i)));
+            if (methodString == NULL) {
+                // Out of memory
+                goto done;
+            }
+            (*e)->SetObjectArrayElement(e, authMethods, i, methodString);
+        }
+
+        // TODO: Consider filling these somehow.
+        types = NULL;
+        issuers = NULL;
+    } else {
+        authMethods = NULL;
+        types = keyTypes(e, ssl);
+        issuers = stackToArray(e, SSL_get0_server_requested_CAs(ssl), 0);
+    }
+
+    // Execute the java callback
+    jlongArray result = (*e)->CallObjectMethod(e, arg, certificateCallbackMethod, (jlong) ssl, types, issuers, authMethods);
+
+    // Check if java threw an exception and if so signal back that we should not continue with the handshake.
+    if ((*e)->ExceptionCheck(e) == JNI_TRUE) {
+        (*e)->ExceptionClear(e);
+        goto done;
+    }
+    if (result == NULL) {
+        goto done;
+    }
+
+    int arrayLen = (*e)->GetArrayLength(e, result);
+    if (arrayLen != 3) {
+        goto done;
+    }
+
+    elements = (*e)->GetLongArrayElements(e, result, NULL);
+    EVP_PKEY* pkey = (EVP_PKEY *) elements[0];
+    const STACK_OF(CRYPTO_BUFFER) *cchain = (STACK_OF(CRYPTO_BUFFER) *) elements[1];
+    free = elements[2];
+
+    int numCerts = sk_CRYPTO_BUFFER_num(cchain);
+    if (numCerts == 0) {
+        goto done;
+    }
+    certs = OPENSSL_malloc(sizeof(CRYPTO_BUFFER*) * numCerts);
+
+    if (certs == NULL) {
+        goto done;
+    }
+
+    for (int i = 0; i < numCerts; i++) {
+        certs[i] = sk_CRYPTO_BUFFER_value(cchain, i);
+    }
+
+    if (SSL_set_chain_and_key(ssl, certs, numCerts, pkey, NULL) > 0) {
+        ret = 1;
+    }
+done:
+    if (elements != NULL) {
+        (*e)->ReleaseLongArrayElements(e, result, elements, 0);
+    }
+    OPENSSL_free(certs);
+    if (free == 1) {
+        EVP_PKEY_free(pkey);
+        sk_CRYPTO_BUFFER_pop_free((STACK_OF(CRYPTO_BUFFER) *) cchain, CRYPTO_BUFFER_free);
+    }
+    return ret;
+}
+
+struct alpn_data {
+    unsigned char* proto_data;
+    int proto_len;
+} typedef alpn_data;
+
+int BoringSSL_callback_alpn_select_proto(SSL* ssl, const unsigned char **out, unsigned char *outlen,
+        const unsigned char *in, unsigned int inlen, void *arg) {
+    unsigned int i = 0;
+    unsigned char target_proto_len;
+    unsigned char *p = NULL;
+    const unsigned char *end = NULL;
+    unsigned char *proto = NULL;
+    unsigned char proto_len;
+    alpn_data* data = (alpn_data*) arg;
+    int supported_protos_len = data->proto_len;
+    unsigned char* supported_protos = data->proto_data;
+    while (i < supported_protos_len) {
+        target_proto_len = *supported_protos;
+        ++supported_protos;
+
+        p = (unsigned char*) in;
+        end = p + inlen;
+
+        while (p < end) {
+            proto_len = *p;
+            proto = ++p;
+
+            if (proto + proto_len <= end && target_proto_len == proto_len &&
+                    memcmp(supported_protos, proto, proto_len) == 0) {
+
+                // We found a match, so set the output and return with OK!
+                *out = proto;
+                *outlen = proto_len;
+
+                return SSL_TLSEXT_ERR_OK;
+            }
+            // Move on to the next protocol.
+            p += proto_len;
+        }
+
+        // increment len and pointers.
+        i += target_proto_len;
+        supported_protos += target_proto_len;
+    }
+    return SSL_TLSEXT_ERR_NOACK;
+}
+
+static jbyteArray netty_boringssl_SSL_getSessionId(JNIEnv* env, const SSL* ssl_) {
+    SSL_SESSION *session = SSL_get_session(ssl_);
+    if (session == NULL) {
+        return NULL;
+    }
+
+    unsigned int len = 0;
+    const unsigned char *session_id = SSL_SESSION_get_id(session, &len);
+    if (len == 0 || session_id == NULL) {
+        return NULL;
+    }
+
+    jbyteArray bArray = (*env)->NewByteArray(env, len);
+    if (bArray == NULL) {
+        return NULL;
+    }
+    (*env)->SetByteArrayRegion(env, bArray, 0, len, (jbyte*) session_id);
+    return bArray;
+}
+
+
+static jstring netty_boringssl_SSL_getCipher(JNIEnv* env, const SSL* ssl) {
+    const char* cipher = SSL_get_cipher(ssl);
+    if (cipher == NULL) {
+        return NULL;
+    }
+    return (*env)->NewStringUTF(env, cipher);
+}
+
+static jstring netty_boringssl_SSL_getVersion(JNIEnv* env, const SSL* ssl) {
+    const char* version = SSL_get_version(ssl);
+    if (version == NULL) {
+        return NULL;
+    }
+    return (*env)->NewStringUTF(env, version);
+}
+
+static jobjectArray netty_boringssl_SSL_getPeerCertChain(JNIEnv* env, const SSL* ssl_) {
+    // Get a stack of all certs in the chain.
+    const STACK_OF(CRYPTO_BUFFER) *chain = SSL_get0_peer_certificates(ssl_);
+    if (chain == NULL) {
+        return NULL;
+    }
+    int offset = SSL_is_server(ssl_) == 1 ? 1 : 0;
+    return stackToArray(env, chain, offset);
+}
+
+static jbyteArray netty_boringssl_SSL_getPeerCertificate(JNIEnv* env, const SSL* ssl_) {
+    // Get a stack of all certs in the chain, the first is the leaf.
+    const STACK_OF(CRYPTO_BUFFER) *certs = SSL_get0_peer_certificates(ssl_);
+    if (certs == NULL || sk_CRYPTO_BUFFER_num(certs) <= 0) {
+        return NULL;
+    }
+    const CRYPTO_BUFFER *leafCert = sk_CRYPTO_BUFFER_value(certs, 0);
+    int length = CRYPTO_BUFFER_len(leafCert);
+
+    jbyteArray bArray = (*env)->NewByteArray(env, length);
+    if (bArray == NULL) {
+        return NULL;
+    }
+    (*env)->SetByteArrayRegion(env, bArray, 0, length, (jbyte*) CRYPTO_BUFFER_data(leafCert));
+    return bArray;
+}
+
+
+static jlong netty_boringssl_SSL_getTime(JNIEnv* env, const SSL* ssl_) {
+    SSL_SESSION *session = SSL_get_session(ssl_);
+    if (session == NULL) {
+        // BoringSSL does not protect against a NULL session. OpenSSL
+        // returns 0 if the session is NULL, so do that here.
+        return 0;
+    }
+
+    return SSL_get_time(session);
+}
+
+static jlong netty_boringssl_SSL_getTimeout(JNIEnv* env, const SSL* ssl_) {
+    SSL_SESSION *session = SSL_get_session(ssl_);
+    if (session == NULL) {
+        // BoringSSL does not protect against a NULL session. OpenSSL
+        // returns 0 if the session is NULL, so do that here.
+        return 0;
+    }
+
+    return SSL_get_timeout(session);
+}
+
+static jbyteArray netty_boringssl_SSL_getAlpnSelected(JNIEnv* env, const SSL* ssl_) {
+    const unsigned char *proto = NULL;
+    unsigned int proto_len = 0;
+
+    SSL_get0_alpn_selected(ssl_, &proto, &proto_len);
+    if (proto == NULL) {
+        return NULL;
+    }
+    jbyteArray bytes = (*env)->NewByteArray(env, proto_len);
+    if (bytes == NULL) {
+        return NULL;
+    }
+    (*env)->SetByteArrayRegion(env, bytes, 0, proto_len, (jbyte *)proto);
+    return bytes;
+}
+
+void quic_SSL_info_callback(const SSL *ssl, int type, int value) {
+    if (type == SSL_CB_HANDSHAKE_DONE) {
+        SSL_CTX* ctx = SSL_get_SSL_CTX(ssl);
+        if (ctx == NULL) {
+            return;
+        }
+
+        JNIEnv* e = NULL;
+        if (quic_get_java_env(&e) != JNI_OK) {
+            return;
+        }
+
+        jobject handshakeCompleteCallback = SSL_CTX_get_ex_data(ctx, handshakeCompleteCallbackIdx);
+        if (handshakeCompleteCallback == NULL) {
+            return;
+        }
+
+        jbyteArray session_id = netty_boringssl_SSL_getSessionId(e, ssl);
+        jstring cipher = netty_boringssl_SSL_getCipher(e, ssl);
+        jstring version = netty_boringssl_SSL_getVersion(e, ssl);
+        jbyteArray peerCert = netty_boringssl_SSL_getPeerCertificate(e, ssl);
+        jobjectArray certChain = netty_boringssl_SSL_getPeerCertChain(e, ssl);
+        jlong creationTime = netty_boringssl_SSL_getTime(e, ssl);
+        jlong timeout = netty_boringssl_SSL_getTimeout(e, ssl);
+        jbyteArray alpnSelected = netty_boringssl_SSL_getAlpnSelected(e, ssl);
+
+        // Execute the java callback
+        (*e)->CallVoidMethod(e, handshakeCompleteCallback, handshakeCompleteCallbackMethod,
+                 (jlong) ssl, session_id, cipher, version, peerCert, certChain, creationTime, timeout, alpnSelected);
+    }
+}
+static jlong netty_boringssl_SSLContext_new0(JNIEnv* env, jclass clazz, jboolean server, jbyteArray alpn_protos, jobject handshakeCompleteCallback, jobject certificateCallback, jobject verifyCallback, int verifyMode, jobjectArray subjectNames) {
+    jobject handshakeCompleteCallbackRef = NULL;
+    jobject certificateCallbackRef = NULL;
+    jobject verifyCallbackRef = NULL;
+
+    if ((handshakeCompleteCallbackRef = (*env)->NewGlobalRef(env, handshakeCompleteCallback)) == NULL) {
+        goto error;
+    }
+
+    if ((certificateCallbackRef = (*env)->NewGlobalRef(env, certificateCallback)) == NULL) {
+        goto error;
+    }
+
+    if ((verifyCallbackRef = (*env)->NewGlobalRef(env, verifyCallback)) == NULL) {
+        goto error;
+    }
+
+    SSL_CTX *ctx = SSL_CTX_new(TLS_with_buffers_method());
+    // When using BoringSSL we want to use CRYPTO_BUFFER to reduce memory usage and minimize overhead as we do not need
+    // X509* at all and just need the raw bytes of the certificates to construct our Java X509Certificate.
+    //
+    // See https://github.com/google/boringssl/blob/chromium-stable/PORTING.md#crypto_buffer
+    SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
+    SSL_CTX_set_max_proto_version(ctx, TLS1_3_VERSION);
+
+    // Automatically release buffers
+    SSL_CTX_set_mode(ctx, SSL_MODE_RELEASE_BUFFERS);
+
+    // Set callback which will inform when handshake is done
+    SSL_CTX_set_ex_data(ctx, handshakeCompleteCallbackIdx, handshakeCompleteCallbackRef);
+    SSL_CTX_set_info_callback(ctx, quic_SSL_info_callback);
+
+    // So we can access this in quic_SSL_cert_custom_verify
+    SSL_CTX_set_ex_data(ctx, verifyCallbackIdx, verifyCallbackRef);
+    SSL_CTX_set_custom_verify(ctx, verifyMode, quic_SSL_cert_custom_verify);
+
+    SSL_CTX_set_ex_data(ctx, certificateCallbackIdx, certificateCallbackRef);
+    SSL_CTX_set_cert_cb(ctx, quic_certificate_cb, certificateCallbackRef);
+
+    SSL_CTX_set_ex_data(ctx, crypto_buffer_pool_idx, CRYPTO_BUFFER_POOL_new());
+
+    STACK_OF(CRYPTO_BUFFER) *names = arrayToStack(env, subjectNames, NULL);
+    if (names != NULL) {
+        SSL_CTX_set0_client_CAs(ctx, names);
+    }
+
+    if (alpn_protos != NULL) {
+        int alpn_length = (*env)->GetArrayLength(env, alpn_protos);
+        alpn_data* alpn = (alpn_data*) OPENSSL_malloc(sizeof(alpn_data));
+        if (alpn != NULL) {
+            // Fill the alpn_data struct
+            alpn->proto_data = OPENSSL_malloc(alpn_length);
+            alpn->proto_len = alpn_length;
+            (*env)->GetByteArrayRegion(env, alpn_protos, 0, alpn_length, (jbyte*) alpn->proto_data);
+
+            SSL_CTX_set_ex_data(ctx, alpn_data_idx, alpn);
+            if (server == JNI_TRUE) {
+                SSL_CTX_set_alpn_select_cb(ctx, BoringSSL_callback_alpn_select_proto, (void*) alpn);
+            } else {
+                SSL_CTX_set_alpn_protos(ctx, alpn->proto_data, alpn->proto_len);
+            }
+        }
+    }
+    return (jlong) ctx;
+error:
+    if (handshakeCompleteCallbackRef != NULL) {
+        (*env)->DeleteGlobalRef(env, handshakeCompleteCallbackRef);
+    }
+    if (certificateCallbackRef != NULL) {
+        (*env)->DeleteGlobalRef(env, certificateCallbackRef);
+    }
+    if (certificateCallbackRef != NULL) {
+        (*env)->DeleteGlobalRef(env, certificateCallbackRef);
+    }
+    return -1;
+}
+
+static void netty_boringssl_SSLContext_free(JNIEnv* env, jclass clazz, long ctx) {
+    SSL_CTX* ssl_ctx = (SSL_CTX*) ctx;
+
+    jobject handshakeCompleteCallbackRef = SSL_CTX_get_ex_data(ssl_ctx, handshakeCompleteCallbackIdx);
+    if (handshakeCompleteCallbackRef != NULL) {
+        (*env)->DeleteGlobalRef(env, handshakeCompleteCallbackRef);
+    }
+    jobject verifyCallbackRef = SSL_CTX_get_ex_data(ssl_ctx, verifyCallbackIdx);
+    if (verifyCallbackRef != NULL) {
+        (*env)->DeleteLocalRef(env, verifyCallbackRef);
+    }
+    jobject certificateCallbackRef = SSL_CTX_get_ex_data(ssl_ctx, certificateCallbackIdx);
+    if (certificateCallbackRef != NULL) {
+        (*env)->DeleteLocalRef(env, certificateCallbackRef);
+    }
+
+    alpn_data* data = SSL_CTX_get_ex_data(ssl_ctx, alpn_data_idx);
+    OPENSSL_free(data);
+
+    CRYPTO_BUFFER_POOL* pool = SSL_CTX_get_ex_data(ssl_ctx, crypto_buffer_pool_idx);
+    if (pool != NULL) {
+        CRYPTO_BUFFER_POOL_free(pool);
+    }
+    SSL_CTX_free(ssl_ctx);
+}
+
+static jlong netty_boringssl_SSLContext_setSessionCacheTimeout(JNIEnv* env, jclass clazz, jlong ctx, jlong timeout){
+    return SSL_CTX_set_timeout((SSL_CTX*) ctx, timeout);
+}
+
+static jlong netty_boringssl_SSLContext_setSessionCacheSize(JNIEnv* env, jclass clazz, jlong ctx, jlong size) {
+    if (size >= 0) {
+        SSL_CTX* ssl_ctx = (SSL_CTX*) ctx;
+        // Caching only works on the server side for now.
+        SSL_CTX_set_session_cache_mode(ssl_ctx, SSL_SESS_CACHE_SERVER);
+        return SSL_CTX_sess_set_cache_size(ssl_ctx, size);
+    }
+
+    return 0;
+}
+
+jlong netty_boringssl_SSL_new0(JNIEnv* env, jclass clazz, jlong ctx, jboolean server, jstring hostname) {
+    SSL* ssl = SSL_new((SSL_CTX*) ctx);
+
+    if (ssl == NULL) {
+        return -1;
+    }
+
+    if (server == JNI_TRUE) {
+        SSL_set_accept_state(ssl);
+    } else {
+        SSL_set_connect_state(ssl);
+        if (hostname != NULL) {
+            const char *charHostname = (*env)->GetStringUTFChars(env, hostname, 0);
+            SSL_set_tlsext_host_name(ssl, charHostname);
+            (*env)->ReleaseStringUTFChars(env, hostname, charHostname);
+        }
+    }
+
+    return (jlong) ssl;
+}
+
+void netty_boringssl_SSL_free(JNIEnv* env, jclass clazz, jlong ssl) {
+    SSL_free((SSL *) ssl);
+}
+
+int netty_boringssl_password_callback(char *buf, int bufsiz, int verify, void *cb) {
+    char *password = (char *) cb;
+    if (password == NULL) {
+        return 0;
+    }
+    strncpy(buf, password, bufsiz);
+    return (int) strlen(buf);
+}
+
+jlong netty_boringssl_EVP_PKEY_parse(JNIEnv* env, jclass clazz, jbyteArray array, jstring password) {
+    int dataLen = (*env)->GetArrayLength(env, array);
+    char* data = (char*) (*env)->GetByteArrayElements(env, array, 0);
+    BIO* bio = BIO_new_mem_buf(data, dataLen);
+
+    const char *charPass;
+    if (password == NULL) {
+        charPass = NULL;
+    } else {
+        charPass = (*env)->GetStringUTFChars(env, password, 0);
+    }
+
+    EVP_PKEY *key = PEM_read_bio_PrivateKey(bio, NULL,
+                    (pem_password_cb *)netty_boringssl_password_callback,
+                    (void *)charPass);
+    BIO_free(bio);
+    if (charPass != NULL) {
+        (*env)->ReleaseStringUTFChars(env, password, charPass);
+    }
+    if (key == NULL) {
+        return -1;
+    }
+    return (jlong) key;
+}
+
+void netty_boringssl_EVP_PKEY_free(JNIEnv* env, jclass clazz, jlong privateKey) {
+    EVP_PKEY_free((EVP_PKEY*) privateKey); // Safe to call with NULL as well.
+}
+
+jlong netty_boringssl_CRYPTO_BUFFER_stack_new(JNIEnv* env, jclass clazz, jlong ssl, jobjectArray x509Chain){
+    CRYPTO_BUFFER_POOL* pool = NULL;
+    SSL_CTX* ctx = SSL_get_SSL_CTX((SSL*) ssl);
+    if (ctx != NULL) {
+        pool = SSL_CTX_get_ex_data(ctx, crypto_buffer_pool_idx);
+    }
+    STACK_OF(CRYPTO_BUFFER) *chain = arrayToStack(env, x509Chain, pool);
+    if (chain == NULL) {
+        return 0;
+    }
+    return (jlong) chain;
+
+}
+
+void netty_boringssl_CRYPTO_BUFFER_stack_free(JNIEnv* env, jclass clazz, jlong chain) {
+    sk_CRYPTO_BUFFER_pop_free((STACK_OF(CRYPTO_BUFFER) *) chain, CRYPTO_BUFFER_free);
+}
+
+// JNI Registered Methods End
+
+// JNI Method Registration Table Begin
+static const JNINativeMethod statically_referenced_fixed_method_table[] = {
+  { "ssl_verify_none", "()I", (void *) netty_boringssl_ssl_verify_none },
+  { "ssl_verify_fail_if_no_peer_cert", "()I", (void *) netty_boringssl_ssl_verify_fail_if_no_peer_cert },
+  { "ssl_verify_peer", "()I", (void *) netty_boringssl_ssl_verify_peer },
+  { "x509_v_ok", "()I", (void *) netty_boringssl_x509_v_ok },
+  { "x509_v_err_cert_has_expired", "()I", (void *) netty_boringssl_x509_v_err_cert_has_expired },
+  { "x509_v_err_cert_not_yet_valid", "()I", (void *) netty_boringssl_x509_v_err_cert_not_yet_valid },
+  { "x509_v_err_cert_revoked", "()I", (void *) netty_boringssl_x509_v_err_cert_revoked },
+  { "x509_v_err_unspecified", "()I", (void *) netty_boringssl_x509_v_err_unspecified }
+};
+
+static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
+static const JNINativeMethod fixed_method_table[] = {
+  { "SSLContext_new0", "(Z[BLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;I[[B)J", (void *) netty_boringssl_SSLContext_new0 },
+  { "SSLContext_free", "(J)V", (void *) netty_boringssl_SSLContext_free },
+  { "SSLContext_setSessionCacheTimeout", "(JJ)J", (void *) netty_boringssl_SSLContext_setSessionCacheTimeout },
+  { "SSLContext_setSessionCacheSize", "(JJ)J", (void *) netty_boringssl_SSLContext_setSessionCacheSize },
+  { "SSL_new0", "(JZLjava/lang/String;)J", (void *) netty_boringssl_SSL_new0 },
+  { "SSL_free", "(J)V", (void *) netty_boringssl_SSL_free },
+  { "EVP_PKEY_parse", "([BLjava/lang/String;)J", (void *) netty_boringssl_EVP_PKEY_parse },
+  { "EVP_PKEY_free", "(J)V", (void *) netty_boringssl_EVP_PKEY_free },
+  { "CRYPTO_BUFFER_stack_new", "(J[[B)J", (void *) netty_boringssl_CRYPTO_BUFFER_stack_new },
+  { "CRYPTO_BUFFER_stack_free", "(J)V", (void *) netty_boringssl_CRYPTO_BUFFER_stack_free }
+};
+
+static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);
+
+// JNI Method Registration Table End
+
+jint netty_boringssl_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
+    int ret = JNI_ERR;
+    int staticallyRegistered = 0;
+    int nativeRegistered = 0;
+    char* name = NULL;
+
+    // We must register the statically referenced methods first!
+    if (netty_jni_util_register_natives(env,
+            packagePrefix,
+            STATICALLY_CLASSNAME,
+            statically_referenced_fixed_method_table,
+            statically_referenced_fixed_method_table_size) != 0) {
+        goto done;
+    }
+    staticallyRegistered = 1;
+
+    if (netty_jni_util_register_natives(env,
+            packagePrefix,
+            CLASSNAME,
+            fixed_method_table,
+            fixed_method_table_size) != 0) {
+        goto done;
+    }
+    nativeRegistered = 1;
+    // Initialize this module
+
+
+    NETTY_JNI_UTIL_LOAD_CLASS(env, byteArrayClass, "[B", done);
+    NETTY_JNI_UTIL_LOAD_CLASS(env, stringClass, "Ljava/lang/String;", done);
+
+    NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLCertificateCallback", name, done);
+    NETTY_JNI_UTIL_LOAD_CLASS(env, certificateCallbackClass, name, done);
+    NETTY_JNI_UTIL_GET_METHOD(env, certificateCallbackClass, certificateCallbackMethod, "handle", "(J[B[[B[Ljava/lang/String;)[J", done);
+    free((void*) packagePrefix);
+    packagePrefix = NULL;
+
+
+    NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLCertificateVerifyCallback", name, done);
+    NETTY_JNI_UTIL_LOAD_CLASS(env, verifyCallbackClass, name, done);
+    NETTY_JNI_UTIL_GET_METHOD(env, verifyCallbackClass, verifyCallbackMethod, "verify", "(J[[BLjava/lang/String;)I", done);
+
+
+    NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLHandshakeCompleteCallback", name, done);
+    NETTY_JNI_UTIL_LOAD_CLASS(env, handshakeCompleteCallbackClass, name, done);
+    NETTY_JNI_UTIL_GET_METHOD(env, handshakeCompleteCallbackClass, handshakeCompleteCallbackMethod, "handshakeComplete", "(J[BLjava/lang/String;Ljava/lang/String;[B[[BJJ[B)V", done);
+
+    verifyCallbackIdx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+    certificateCallbackIdx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+    handshakeCompleteCallbackIdx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+    alpn_data_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+    crypto_buffer_pool_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+    ret = NETTY_JNI_UTIL_JNI_VERSION;
+done:
+    if (ret == JNI_ERR) {
+        if (staticallyRegistered == 1) {
+            netty_jni_util_unregister_natives(env, packagePrefix, STATICALLY_CLASSNAME);
+        }
+        if (nativeRegistered == 1) {
+            netty_jni_util_unregister_natives(env, packagePrefix, CLASSNAME);
+        }
+
+        NETTY_JNI_UTIL_UNLOAD_CLASS(env, byteArrayClass);
+        NETTY_JNI_UTIL_UNLOAD_CLASS(env, stringClass);
+        NETTY_JNI_UTIL_UNLOAD_CLASS(env, certificateCallbackClass);
+        NETTY_JNI_UTIL_UNLOAD_CLASS(env, verifyCallbackClass);
+        NETTY_JNI_UTIL_UNLOAD_CLASS(env, handshakeCompleteCallbackClass);
+
+    }
+    return ret;
+}
+
+void netty_boringssl_JNI_OnUnload(JNIEnv* env, const char* packagePrefix) {
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, byteArrayClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, certificateCallbackClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, verifyCallbackClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, handshakeCompleteCallbackClass);
+
+
+    netty_jni_util_unregister_natives(env, packagePrefix, STATICALLY_CLASSNAME);
+    netty_jni_util_unregister_natives(env, packagePrefix, CLASSNAME);
+}

--- a/src/main/c/netty_quic_boringssl.h
+++ b/src/main/c/netty_quic_boringssl.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef NETTY_BORINGSSL_H_
+#define NETTY_BORINGSSL_H_
+
+// JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
+jint netty_boringssl_JNI_OnLoad(JNIEnv* env, const char* packagePrefix);
+void netty_boringssl_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix);
+
+#endif /* NETTY_BORINGSSL_H_ */

--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSL.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSL.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.handler.ssl.util.LazyX509Certificate;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.X509Certificate;
+
+final class BoringSSL {
+    private BoringSSL() { }
+
+    static final int SSL_VERIFY_NONE = BoringSSLNativeStaticallyReferencedJniMethods.ssl_verify_none();
+    static final int SSL_VERIFY_FAIL_IF_NO_PEER_CERT = BoringSSLNativeStaticallyReferencedJniMethods
+            .ssl_verify_fail_if_no_peer_cert();
+    static final int SSL_VERIFY_PEER = BoringSSLNativeStaticallyReferencedJniMethods.ssl_verify_peer();
+    static final int X509_V_OK = BoringSSLNativeStaticallyReferencedJniMethods.x509_v_ok();
+    static final int X509_V_ERR_CERT_HAS_EXPIRED =
+            BoringSSLNativeStaticallyReferencedJniMethods.x509_v_err_cert_has_expired();
+    static final int X509_V_ERR_CERT_NOT_YET_VALID =
+            BoringSSLNativeStaticallyReferencedJniMethods.x509_v_err_cert_not_yet_valid();
+    static final int X509_V_ERR_CERT_REVOKED = BoringSSLNativeStaticallyReferencedJniMethods.x509_v_err_cert_revoked();
+    static final int X509_V_ERR_UNSPECIFIED = BoringSSLNativeStaticallyReferencedJniMethods.x509_v_err_unspecified();
+
+    static long SSLContext_new(boolean server, String[] applicationProtocols,
+                               BoringSSLHandshakeCompleteCallback handshakeCompleteCallback,
+                               BoringSSLCertificateCallback certificateCallback,
+                               BoringSSLCertificateVerifyCallback verifyCallback,
+                               int verifyMode,
+                               byte[][] subjectNames) {
+        return SSLContext_new0(server, toWireFormat(applicationProtocols),
+                handshakeCompleteCallback,
+                certificateCallback, verifyCallback, verifyMode, subjectNames);
+    }
+
+    private static byte[] toWireFormat(String[] applicationProtocols) {
+        if (applicationProtocols == null) {
+            return null;
+        }
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            for (String p : applicationProtocols) {
+                byte[] bytes = p.getBytes(StandardCharsets.US_ASCII);
+                out.write(bytes.length);
+                out.write(bytes);
+            }
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static native long SSLContext_new0(boolean server,
+                                               byte[] applicationProtocols, Object handshakeCompleteCallback,
+                                               Object certificateCallback, Object verifyCallback, int verifyDepth,
+                                               byte[][] subjectNames);
+    static native long SSLContext_setSessionCacheSize(long context, long size);
+    static native long SSLContext_setSessionCacheTimeout(long context, long size);
+    static native void SSLContext_free(long context);
+    static long SSL_new(long context, boolean server, String hostname) {
+        return SSL_new0(context, server, tlsExtHostName(hostname));
+    }
+    static native long SSL_new0(long context, boolean server, String hostname);
+    static native void SSL_free(long ssl);
+    static native long EVP_PKEY_parse(byte[] bytes, String pass);
+    static native void EVP_PKEY_free(long key);
+
+    static native long CRYPTO_BUFFER_stack_new(long ssl, byte[][] bytes);
+    static native void CRYPTO_BUFFER_stack_free(long chain);
+
+    private static String tlsExtHostName(String hostname) {
+        if (hostname != null && hostname.endsWith(".")) {
+            // Strip trailing dot if included.
+            // See https://github.com/netty/netty-tcnative/issues/400
+            hostname = hostname.substring(0, hostname.length() - 1);
+        }
+        return hostname;
+    }
+
+    static X509Certificate[] certificates(byte[][] chain) {
+        X509Certificate[] peerCerts = new X509Certificate[chain.length];
+        for (int i = 0; i < peerCerts.length; i++) {
+            peerCerts[i] = new LazyX509Certificate(chain[i]);
+        }
+        return peerCerts;
+    }
+
+    static byte[][] subjectNames(X509Certificate[] certificates) {
+        byte[][] subjectNames = new byte[certificates.length][];
+        for (int i = 0; i < certificates.length; i++) {
+            subjectNames[i] = certificates[i].getSubjectX500Principal().getEncoded();
+        }
+        return subjectNames;
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallback.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallback.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+
+import io.netty.util.CharsetUtil;
+
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.X509ExtendedKeyManager;
+import javax.security.auth.x500.X500Principal;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+final class BoringSSLCertificateCallback {
+    private static final byte[] BEGIN_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----\n".getBytes(CharsetUtil.US_ASCII);
+    private static final byte[] END_PRIVATE_KEY = "\n-----END PRIVATE KEY-----\n".getBytes(CharsetUtil.US_ASCII);
+
+    /**
+     * The types contained in the {@code keyTypeBytes} array.
+     */
+    // Extracted from https://github.com/openssl/openssl/blob/master/include/openssl/tls1.h
+    private static final byte TLS_CT_RSA_SIGN = 1;
+    private static final byte TLS_CT_DSS_SIGN = 2;
+    private static final byte TLS_CT_RSA_FIXED_DH = 3;
+    private static final byte TLS_CT_DSS_FIXED_DH = 4;
+    private static final byte TLS_CT_ECDSA_SIGN = 64;
+    private static final byte TLS_CT_RSA_FIXED_ECDH = 65;
+    private static final byte TLS_CT_ECDSA_FIXED_ECDH = 66;
+
+    // Code in this class is inspired by code of conscrypts:
+    // - https://android.googlesource.com/platform/external/
+    //   conscrypt/+/master/src/main/java/org/conscrypt/OpenSSLEngineImpl.java
+    // - https://android.googlesource.com/platform/external/
+    //   conscrypt/+/master/src/main/java/org/conscrypt/SSLParametersImpl.java
+    //
+    static final String KEY_TYPE_RSA = "RSA";
+    static final String KEY_TYPE_DH_RSA = "DH_RSA";
+    static final String KEY_TYPE_EC = "EC";
+    static final String KEY_TYPE_EC_EC = "EC_EC";
+    static final String KEY_TYPE_EC_RSA = "EC_RSA";
+
+    // key type mappings for types.
+    private static final Map<String, String> KEY_TYPES = new HashMap<String, String>();
+    static {
+        KEY_TYPES.put("RSA", KEY_TYPE_RSA);
+        KEY_TYPES.put("DHE_RSA", KEY_TYPE_RSA);
+        KEY_TYPES.put("ECDHE_RSA", KEY_TYPE_RSA);
+        KEY_TYPES.put("ECDHE_ECDSA", KEY_TYPE_EC);
+        KEY_TYPES.put("ECDH_RSA", KEY_TYPE_EC_RSA);
+        KEY_TYPES.put("ECDH_ECDSA", KEY_TYPE_EC_EC);
+        KEY_TYPES.put("DH_RSA", KEY_TYPE_DH_RSA);
+    }
+
+    private static final Set<String> SUPPORTED_KEY_TYPES = Collections.unmodifiableSet(new LinkedHashSet<String>(
+            Arrays.asList(KEY_TYPE_RSA,
+                    KEY_TYPE_DH_RSA,
+                    KEY_TYPE_EC,
+                    KEY_TYPE_EC_RSA,
+                    KEY_TYPE_EC_EC)));
+
+    private final QuicheQuicSslEngineMap engineMap;
+    private final X509ExtendedKeyManager keyManager;
+    private final String password;
+
+    BoringSSLCertificateCallback(QuicheQuicSslEngineMap engineMap, X509ExtendedKeyManager keyManager, String password) {
+        this.engineMap = engineMap;
+        this.keyManager = keyManager;
+        this.password = password;
+    }
+
+    @SuppressWarnings("unused")
+    long[] handle(long ssl, byte[] keyTypeBytes, byte[][] asn1DerEncodedPrincipals, String[] authMethods) {
+        QuicheQuicSslEngine engine = engineMap.get(ssl);
+        if (engine == null) {
+            return null;
+        }
+
+        try {
+            if (keyManager == null) {
+                engineMap.remove(ssl);
+                return null;
+            }
+            if (engine.getUseClientMode()) {
+                final Set<String> keyTypesSet = supportedClientKeyTypes(keyTypeBytes);
+                final String[] keyTypes = keyTypesSet.toArray(new String[0]);
+                final X500Principal[] issuers;
+                if (asn1DerEncodedPrincipals == null) {
+                    issuers = null;
+                } else {
+                    issuers = new X500Principal[asn1DerEncodedPrincipals.length];
+                    for (int i = 0; i < asn1DerEncodedPrincipals.length; i++) {
+                        issuers[i] = new X500Principal(asn1DerEncodedPrincipals[i]);
+                    }
+                }
+                return removeMappingIfNeeded(ssl, selectKeyMaterialClientSide(ssl, engine, keyTypes, issuers));
+            } else {
+                // For now we just ignore the asn1DerEncodedPrincipals as this is kind of inline with what the
+                // OpenJDK SSLEngineImpl does.
+                return removeMappingIfNeeded(ssl, selectKeyMaterialServerSide(ssl, engine, authMethods));
+            }
+        } catch (SSLException e) {
+            engineMap.remove(ssl);
+            return null;
+        } catch (Throwable cause) {
+            engineMap.remove(ssl);
+            throw cause;
+        }
+    }
+
+    private long[] removeMappingIfNeeded(long ssl, long[] result) {
+        if (result == null) {
+            engineMap.remove(ssl);
+        }
+        return result;
+    }
+
+    private long[] selectKeyMaterialServerSide(long ssl, QuicheQuicSslEngine engine, String[] authMethods)
+            throws SSLException {
+        if (authMethods.length == 0) {
+            throw new SSLHandshakeException("Unable to find key material");
+        }
+
+        // authMethods may contain duplicates or may result in the same type
+        // but call chooseServerAlias(...) may be expensive. So let's ensure
+        // we filter out duplicates.
+        Set<String> typeSet = new HashSet<String>(KEY_TYPES.size());
+        for (String authMethod : authMethods) {
+            String type = KEY_TYPES.get(authMethod);
+            if (type != null && typeSet.add(type)) {
+                String alias = chooseServerAlias(engine, type);
+                if (alias != null) {
+                    return selectMaterial(ssl, engine, alias) ;
+                }
+            }
+        }
+        throw new SSLHandshakeException("Unable to find key material for auth method(s): "
+                + Arrays.toString(authMethods));
+    }
+
+    private long[] selectKeyMaterialClientSide(long ssl, QuicheQuicSslEngine engine, String[] keyTypes,
+                                               X500Principal[] issuer) {
+        String alias = chooseClientAlias(engine, keyTypes, issuer);
+        // Only try to set the keymaterial if we have a match. This is also consistent with what OpenJDK does:
+        // https://hg.openjdk.java.net/jdk/jdk11/file/76072a077ee1/
+        // src/java.base/share/classes/sun/security/ssl/CertificateRequest.java#l362
+        if (alias != null) {
+            return selectMaterial(ssl, engine, alias) ;
+        }
+        return null;
+    }
+
+    private long[] selectMaterial(long ssl, QuicheQuicSslEngine engine, String alias)  {
+        X509Certificate[] certificates = keyManager.getCertificateChain(alias);
+        if (certificates == null || certificates.length == 0) {
+            return null;
+        }
+        byte[][] certs = new byte[certificates.length][];
+
+        for (int i = 0; i < certificates.length; i++) {
+            try {
+                certs[i] = certificates[i].getEncoded();
+            } catch (CertificateEncodingException e) {
+                return null;
+            }
+        }
+
+        PrivateKey privateKey = keyManager.getPrivateKey(alias);
+        byte[] pemKey = toPemEncoded(privateKey);
+        if (pemKey == null) {
+            return null;
+        }
+        long key = BoringSSL.EVP_PKEY_parse(pemKey, password);
+        long chain = BoringSSL.CRYPTO_BUFFER_stack_new(ssl, certs);
+        engine.setLocalCertificateChain(certificates);
+
+        // Return and signal that the key and chain should be released as well.
+        return new long[] { key,  chain , 1 };
+    }
+
+    private static byte[] toPemEncoded(PrivateKey key) {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            out.write(BEGIN_PRIVATE_KEY);
+            out.write(Base64.getEncoder().encode(key.getEncoded()));
+            out.write(END_PRIVATE_KEY);
+            return out.toByteArray();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+    private String chooseClientAlias(QuicheQuicSslEngine engine,
+                                     String[] keyTypes, X500Principal[] issuer) {
+        return keyManager.chooseEngineClientAlias(keyTypes, issuer, engine);
+    }
+
+    private String chooseServerAlias(QuicheQuicSslEngine engine, String type) {
+        return keyManager.chooseEngineServerAlias(type, null, engine);
+    }
+
+    /**
+     * Gets the supported key types for client certificates.
+     *
+     * @param clientCertificateTypes {@code ClientCertificateType} values provided by the server.
+     *        See https://www.ietf.org/assignments/tls-parameters/tls-parameters.xml.
+     * @return supported key types that can be used in {@code X509KeyManager.chooseClientAlias} and
+     *         {@code X509ExtendedKeyManager.chooseEngineClientAlias}.
+     */
+    private static Set<String> supportedClientKeyTypes(byte[] clientCertificateTypes) {
+        if (clientCertificateTypes == null) {
+            // Try all of the supported key types.
+            return SUPPORTED_KEY_TYPES;
+        }
+        Set<String> result = new HashSet<String>(clientCertificateTypes.length);
+        for (byte keyTypeCode : clientCertificateTypes) {
+            String keyType = clientKeyType(keyTypeCode);
+            if (keyType == null) {
+                // Unsupported client key type -- ignore
+                continue;
+            }
+            result.add(keyType);
+        }
+        return result;
+    }
+
+    private static String clientKeyType(byte clientCertificateType) {
+        // See also https://www.ietf.org/assignments/tls-parameters/tls-parameters.xml
+        switch (clientCertificateType) {
+            case TLS_CT_RSA_SIGN:
+                return KEY_TYPE_RSA; // RFC rsa_sign
+            case TLS_CT_RSA_FIXED_DH:
+                return KEY_TYPE_DH_RSA; // RFC rsa_fixed_dh
+            case TLS_CT_ECDSA_SIGN:
+                return KEY_TYPE_EC; // RFC ecdsa_sign
+            case TLS_CT_RSA_FIXED_ECDH:
+                return KEY_TYPE_EC_RSA; // RFC rsa_fixed_ecdh
+            case TLS_CT_ECDSA_FIXED_ECDH:
+                return KEY_TYPE_EC_EC; // RFC ecdsa_fixed_ecdh
+            default:
+                return null;
+        }
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateVerifyCallback.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateVerifyCallback.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.handler.ssl.OpenSslCertificateException;
+
+import javax.net.ssl.X509ExtendedTrustManager;
+import java.security.cert.CertPathValidatorException;
+import java.security.cert.CertificateExpiredException;
+import java.security.cert.CertificateNotYetValidException;
+import java.security.cert.CertificateRevokedException;
+import java.security.cert.X509Certificate;
+
+final class BoringSSLCertificateVerifyCallback {
+
+    private final QuicheQuicSslEngineMap engineMap;
+    private final X509ExtendedTrustManager manager;
+
+    BoringSSLCertificateVerifyCallback(QuicheQuicSslEngineMap engineMap, X509ExtendedTrustManager manager) {
+        this.engineMap = engineMap;
+        this.manager = manager;
+    }
+
+    @SuppressWarnings("unused")
+    int verify(long ssl, byte[][] x509, String authAlgorithm) {
+        final QuicheQuicSslEngine engine = engineMap.get(ssl);
+        if (engine == null) {
+            // May be null if it was destroyed in the meantime.
+            return BoringSSL.X509_V_ERR_UNSPECIFIED;
+        }
+
+        if (manager == null) {
+            engineMap.remove(ssl);
+            return BoringSSL.X509_V_ERR_UNSPECIFIED;
+        }
+
+        X509Certificate[] peerCerts = BoringSSL.certificates(x509);
+        try {
+            if (engine.getUseClientMode()) {
+                manager.checkServerTrusted(peerCerts, authAlgorithm, engine);
+            } else {
+                manager.checkClientTrusted(peerCerts, authAlgorithm, engine);
+            }
+            return BoringSSL.X509_V_OK;
+        } catch (Throwable cause) {
+            engineMap.remove(ssl);
+            // Try to extract the correct error code that should be used.
+            if (cause instanceof OpenSslCertificateException) {
+                // This will never return a negative error code as its validated when constructing the
+                // OpenSslCertificateException.
+                return ((OpenSslCertificateException) cause).errorCode();
+            }
+            if (cause instanceof CertificateExpiredException) {
+                return BoringSSL.X509_V_ERR_CERT_HAS_EXPIRED;
+            }
+            if (cause instanceof CertificateNotYetValidException) {
+                return BoringSSL.X509_V_ERR_CERT_NOT_YET_VALID;
+            }
+            return translateToError(cause);
+        }
+    }
+
+    private static int translateToError(Throwable cause) {
+        if (cause instanceof CertificateRevokedException) {
+            return BoringSSL.X509_V_ERR_CERT_REVOKED;
+        }
+
+        // The X509TrustManagerImpl uses a Validator which wraps a CertPathValidatorException into
+        // an CertificateException. So we need to handle the wrapped CertPathValidatorException to be
+        // able to send the correct alert.
+        Throwable wrapped = cause.getCause();
+        while (wrapped != null) {
+            if (wrapped instanceof CertPathValidatorException) {
+                CertPathValidatorException ex = (CertPathValidatorException) wrapped;
+                CertPathValidatorException.Reason reason = ex.getReason();
+                if (reason == CertPathValidatorException.BasicReason.EXPIRED) {
+                    return BoringSSL.X509_V_ERR_CERT_HAS_EXPIRED;
+                }
+                if (reason == CertPathValidatorException.BasicReason.NOT_YET_VALID) {
+                    return BoringSSL.X509_V_ERR_CERT_NOT_YET_VALID;
+                }
+                if (reason == CertPathValidatorException.BasicReason.REVOKED) {
+                    return BoringSSL.X509_V_ERR_CERT_REVOKED;
+                }
+            }
+            wrapped = wrapped.getCause();
+        }
+        return BoringSSL.X509_V_ERR_UNSPECIFIED;
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSLHandshakeCompleteCallback.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSLHandshakeCompleteCallback.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+final class BoringSSLHandshakeCompleteCallback {
+
+    private final QuicheQuicSslEngineMap map;
+
+    BoringSSLHandshakeCompleteCallback(QuicheQuicSslEngineMap map) {
+        this.map = map;
+    }
+
+    @SuppressWarnings("unused")
+    void handshakeComplete(long ssl, byte[] id, String cipher, String protocol, byte[] peerCertificate,
+                           byte[][] peerCertificateChain, long creationTime, long timeout, byte[] applicationProtocol) {
+        QuicheQuicSslEngine engine = map.remove(ssl);
+        if (engine != null) {
+            engine.handshakeFinished(id, cipher, protocol, peerCertificate, peerCertificateChain, creationTime,
+                    timeout, applicationProtocol);
+        }
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSLNativeStaticallyReferencedJniMethods.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSLNativeStaticallyReferencedJniMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,22 +15,16 @@
  */
 package io.netty.incubator.codec.quic;
 
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
+final class BoringSSLNativeStaticallyReferencedJniMethods {
+    static native int ssl_verify_none();
+    static native int ssl_verify_peer();
+    static native int ssl_verify_fail_if_no_peer_cert();
 
-public abstract class AbstractQuicTest {
+    static native int x509_v_ok();
+    static native int x509_v_err_cert_has_expired();
+    static native int x509_v_err_cert_not_yet_valid();
+    static native int x509_v_err_cert_revoked();
+    static native int x509_v_err_unspecified();
 
-    private static final int TEST_GLOBAL_TIMEOUT_VALUE = Integer.getInteger(
-            "io.netty.incubator.codec.quic.defaultTestTimeout", 10);
-
-    @Rule
-    public final Timeout globalTimeout = Timeout.seconds(TEST_GLOBAL_TIMEOUT_VALUE);
-
-    @BeforeClass
-    public static void assumeTrue() {
-        Quic.ensureAvailability();
-       Assume.assumeTrue(Quic.isAvailable());
-    }
+    private BoringSSLNativeStaticallyReferencedJniMethods() { }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/DefaultQuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/DefaultQuicChannelConfig.java
@@ -30,12 +30,6 @@ import io.netty.channel.WriteBufferWaterMark;
  */
 final class DefaultQuicChannelConfig extends DefaultChannelConfig implements QuicChannelConfig {
 
-    /**
-     * Optional parameter to verify peer's certificate.
-     * See <a href="https://docs.rs/quiche/0.6.0/quiche/fn.connect.html">server_name</a>.
-     */
-    private volatile String peerCertServerName;
-
     DefaultQuicChannelConfig(Channel channel) {
         super(channel);
     }
@@ -43,29 +37,6 @@ final class DefaultQuicChannelConfig extends DefaultChannelConfig implements Qui
     @Override
     public Map<ChannelOption<?>, Object> getOptions() {
         return getOptions(super.getOptions(), QuicChannelOption.PEER_CERT_SERVER_NAME);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <T> T getOption(ChannelOption<T> option) {
-        if (option == QuicChannelOption.PEER_CERT_SERVER_NAME) {
-            return (T) String.valueOf(getPeerCertServerName());
-        }
-
-        return super.getOption(option);
-    }
-
-    @Override
-    public <T> boolean setOption(ChannelOption<T> option, T value) {
-        validate(option, value);
-
-        if (option == QuicChannelOption.PEER_CERT_SERVER_NAME) {
-            setPeerCertServerName((String) value);
-        } else {
-            return super.setOption(option, value);
-        }
-
-        return true;
     }
 
     @Override
@@ -132,17 +103,6 @@ final class DefaultQuicChannelConfig extends DefaultChannelConfig implements Qui
     @Override
     public QuicChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
         super.setMessageSizeEstimator(estimator);
-        return this;
-    }
-
-    @Override
-    public String getPeerCertServerName() {
-        return peerCertServerName;
-    }
-
-    @Override
-    public QuicChannelConfig setPeerCertServerName(String peerCertServerName) {
-        this.peerCertServerName = peerCertServerName;
         return this;
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -75,13 +75,6 @@ public interface QuicChannel extends Channel {
     }
 
     /**
-     * Returns the negotiated ALPN protocol or {@code null} if none has been negotiated.
-     *
-     * @return the application protocol or {@code null} if none has been negotiated.
-     */
-    byte[] applicationProtocol();
-
-    /**
      * Close the {@link QuicChannel}
      *
      * @param applicationClose  {@code true} if an application close should be used,

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelConfig.java
@@ -59,22 +59,4 @@ public interface QuicChannelConfig extends ChannelConfig {
 
     @Override
     QuicChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator);
-
-    /**
-     * Return the server name parameter used to verify peer's certificate.
-     *
-     * @return the server name parameter.
-     */
-    String getPeerCertServerName();
-
-    /**
-     * Set set server name for peer's certificate verification.
-     *
-     * <strong>Be aware this config setting can only be adjusted before the
-     * connection is established.</strong>
-     *
-     * @param peerCertServerName    the server name parameter.
-     * @return                      the instance itself.
-     */
-    QuicChannelConfig setPeerCertServerName(String peerCertServerName);
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
@@ -17,6 +17,8 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.channel.ChannelHandler;
 
+import java.util.function.Function;
+
 /**
  * {@link QuicCodecBuilder} that configures and builds a {@link ChannelHandler} that should be added to the
  * {@link io.netty.channel.ChannelPipeline} of a {@code QUIC} client.
@@ -26,10 +28,14 @@ public final class QuicClientCodecBuilder extends QuicCodecBuilder<QuicClientCod
     /**
      * Creates a new instance.
      */
-    public QuicClientCodecBuilder() { }
+    public QuicClientCodecBuilder() {
+        super(false);
+    }
 
     @Override
-    protected ChannelHandler build(QuicheConfig config, int localConnIdLength) {
-        return new QuicheQuicClientCodec(config, localConnIdLength);
+    protected ChannelHandler build(QuicheConfig config,
+                                   Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider,
+                                   int localConnIdLength) {
+        return new QuicheQuicClientCodec(config, sslEngineProvider, localConnIdLength);
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -17,12 +17,14 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
+import io.netty.handler.ssl.SslContext;
 import io.netty.util.AttributeKey;
 import io.netty.util.internal.ObjectUtil;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * {@link QuicCodecBuilder} that configures and builds a {@link ChannelHandler} that should be added to the
@@ -43,7 +45,9 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     /**
      * Creates a new instance.
      */
-    public QuicServerCodecBuilder() { }
+    public QuicServerCodecBuilder() {
+        super(true);
+    }
 
     /**
      * Allow to specify a {@link ChannelOption} which is used for the {@link QuicChannel} instances once they got
@@ -162,7 +166,9 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     }
 
     @Override
-    protected ChannelHandler build(QuicheConfig config, int localConnIdLength) {
+    protected ChannelHandler build(QuicheConfig config,
+                                   Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider,
+                                   int localConnIdLength) {
         validate();
         QuicTokenHandler tokenHandler = this.tokenHandler;
         QuicConnectionIdGenerator generator = connectionIdAddressGenerator;
@@ -171,7 +177,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
         }
         ChannelHandler handler = this.handler;
         ChannelHandler streamHandler = this.streamHandler;
-        return new QuicheQuicServerCodec(config, localConnIdLength, tokenHandler, generator,
+        return new QuicheQuicServerCodec(config, localConnIdLength, tokenHandler, generator, sslEngineProvider,
                 handler, Quic.optionsArray(options), Quic.attributesArray(attrs),
                 streamHandler, Quic.optionsArray(streamOptions), Quic.attributesArray(streamAttrs));
     }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicSslContext.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicSslContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,22 +15,17 @@
  */
 package io.netty.incubator.codec.quic;
 
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.ssl.SslContext;
 
-public abstract class AbstractQuicTest {
+/**
+ * Special {@link SslContext} that can be used for {@code QUIC}.
+ */
+public abstract class QuicSslContext extends SslContext {
 
-    private static final int TEST_GLOBAL_TIMEOUT_VALUE = Integer.getInteger(
-            "io.netty.incubator.codec.quic.defaultTestTimeout", 10);
+    @Override
+    public abstract QuicSslEngine newEngine(ByteBufAllocator alloc);
 
-    @Rule
-    public final Timeout globalTimeout = Timeout.seconds(TEST_GLOBAL_TIMEOUT_VALUE);
-
-    @BeforeClass
-    public static void assumeTrue() {
-        Quic.ensureAvailability();
-       Assume.assumeTrue(Quic.isAvailable());
-    }
+    @Override
+    public abstract QuicSslEngine newEngine(ByteBufAllocator alloc, String peerHost, int peerPort);
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.incubator.codec.quic;
+
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.util.KeyManagerFactoryWrapper;
+import io.netty.handler.ssl.util.TrustManagerFactoryWrapper;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.File;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * Builder for configuring a new SslContext for creation.
+ */
+public final class QuicSslContextBuilder {
+
+    /**
+     * Creates a builder for new client-side {@link QuicSslContext} that can be used for {@code QUIC}.
+     */
+    public static QuicSslContextBuilder forClient() {
+        return new QuicSslContextBuilder(false);
+    }
+
+    /**
+     * Creates a builder for new server-side {@link QuicSslContext} that can be used for {@code QUIC}.
+     *
+     * @param keyFile a PKCS#8 private key file in PEM format
+     * @param keyPassword the password of the {@code keyFile}, or {@code null} if it's not
+     *     password-protected
+     * @param certChainFile an X.509 certificate chain file in PEM format
+     * @see #keyManager(File, String, File)
+     */
+    public static QuicSslContextBuilder forServer(
+            File keyFile, String keyPassword, File certChainFile) {
+        return new QuicSslContextBuilder(true).keyManager(keyFile, keyPassword, certChainFile);
+    }
+
+    /**
+     * Creates a builder for new server-side {@link QuicSslContext} that can be used for {@code QUIC}.
+     *
+     * @param key a PKCS#8 private key
+     * @param keyPassword the password of the {@code keyFile}, or {@code null} if it's not
+     *     password-protected
+     * @param certChain the X.509 certificate chain
+     * @see #keyManager(File, String, File)
+     */
+    public static QuicSslContextBuilder forServer(
+            PrivateKey key, String keyPassword, X509Certificate... certChain) {
+        return new QuicSslContextBuilder(true).keyManager(key, keyPassword, certChain);
+    }
+
+    /**
+     * Creates a builder for new server-side {@link QuicSslContext} that can be used for {@code QUIC}.
+     *
+     * @param keyManagerFactory non-{@code null} factory for server's private key
+     * @see #keyManager(KeyManagerFactory, String)
+     */
+    public static QuicSslContextBuilder forServer(KeyManagerFactory keyManagerFactory, String password) {
+        return new QuicSslContextBuilder(true).keyManager(keyManagerFactory, password);
+    }
+
+    /**
+     * Creates a builder for new server-side {@link QuicSslContext} with {@link KeyManager} that can be used for
+     * {@code QUIC}.
+     *
+     * @param keyManager non-{@code null} KeyManager for server's private key
+     * @param keyPassword the password of the {@code keyFile}, or {@code null} if it's not
+     *     password-protected
+     */
+    public static QuicSslContextBuilder forServer(KeyManager keyManager, String keyPassword) {
+        return new QuicSslContextBuilder(true).keyManager(keyManager, keyPassword);
+    }
+
+    private final boolean forServer;
+    private TrustManagerFactory trustManagerFactory;
+    private String keyPassword;
+    private KeyManagerFactory keyManagerFactory;
+    private long sessionCacheSize = 20480;
+    private long sessionTimeout = 300;
+    private ClientAuth clientAuth = ClientAuth.NONE;
+    private String[] applicationProtocols;
+
+    private QuicSslContextBuilder(boolean forServer) {
+        this.forServer = forServer;
+    }
+
+    /**
+     * Trusted certificates for verifying the remote endpoint's certificate. The file should
+     * contain an X.509 certificate collection in PEM format. {@code null} uses the system default.
+     */
+    public QuicSslContextBuilder trustManager(File trustCertCollectionFile) {
+        try {
+            return trustManager(QuicheQuicSslContext.toX509Certificates0(trustCertCollectionFile));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("File does not contain valid certificates: "
+                    + trustCertCollectionFile, e);
+        }
+    }
+
+    /**
+     * Trusted certificates for verifying the remote endpoint's certificate, {@code null} uses the system default.
+     */
+    public QuicSslContextBuilder trustManager(X509Certificate... trustCertCollection) {
+        try {
+            return trustManager(QuicheQuicSslContext.buildTrustManagerFactory0(trustCertCollection));
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Trusted manager for verifying the remote endpoint's certificate. {@code null} uses the system default.
+     */
+    public QuicSslContextBuilder trustManager(TrustManagerFactory trustManagerFactory) {
+        this.trustManagerFactory = trustManagerFactory;
+        return this;
+    }
+
+    /**
+     * A single trusted manager for verifying the remote endpoint's certificate.
+     * This is helpful when custom implementation of {@link TrustManager} is needed.
+     * Internally, a simple wrapper of {@link TrustManagerFactory} that only produces this
+     * specified {@link TrustManager} will be created, thus all the requirements specified in
+     * {@link #trustManager(TrustManagerFactory trustManagerFactory)} also apply here.
+     */
+    public QuicSslContextBuilder trustManager(TrustManager trustManager) {
+        return trustManager(new TrustManagerFactoryWrapper(trustManager));
+    }
+
+    /**
+     * Identifying certificate for this host. {@code keyCertChainFile} and {@code keyFile} may
+     * be {@code null} for client contexts, which disables mutual authentication.
+     *
+     * @param keyFile a PKCS#8 private key file in PEM format
+     * @param keyPassword the password of the {@code keyFile}, or {@code null} if it's not
+     *     password-protected
+     * @param keyCertChainFile an X.509 certificate chain file in PEM format
+     */
+    public QuicSslContextBuilder keyManager(File keyFile, String keyPassword, File keyCertChainFile) {
+        X509Certificate[] keyCertChain;
+        PrivateKey key;
+        try {
+            keyCertChain = QuicheQuicSslContext.toX509Certificates0(keyCertChainFile);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("File does not contain valid certificates: " + keyCertChainFile, e);
+        }
+        try {
+            key = QuicheQuicSslContext.toPrivateKey0(keyFile, keyPassword);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("File does not contain valid private key: " + keyFile, e);
+        }
+        return keyManager(key, keyPassword, keyCertChain);
+    }
+
+    /**
+     * Identifying certificate for this host. {@code keyCertChain} and {@code key} may
+     * be {@code null} for client contexts, which disables mutual authentication.
+     *
+     * @param key a PKCS#8 private key file
+     * @param keyPassword the password of the {@code key}, or {@code null} if it's not
+     *     password-protected
+     * @param certChain an X.509 certificate chain
+     */
+    public QuicSslContextBuilder keyManager(PrivateKey key, String keyPassword, X509Certificate... certChain) {
+        try {
+            java.security.KeyStore ks = java.security.KeyStore.getInstance(KeyStore.getDefaultType());
+            ks.load(null);
+            char[] pass = keyPassword == null ? null: keyPassword.toCharArray();
+            ks.setKeyEntry("alias", key, pass, certChain);
+            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(
+                    KeyManagerFactory.getDefaultAlgorithm());
+            keyManagerFactory.init(ks, pass);
+            return keyManager(keyManagerFactory, keyPassword);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Identifying manager for this host. {@code keyManagerFactory} may be {@code null} for
+     * client contexts, which disables mutual authentication.
+     */
+    public QuicSslContextBuilder keyManager(KeyManagerFactory keyManagerFactory, String keyPassword) {
+        this.keyPassword = keyPassword;
+        this.keyManagerFactory = keyManagerFactory;
+        return this;
+    }
+
+    /**
+     * A single key manager managing the identity information of this host.
+     * This is helpful when custom implementation of {@link KeyManager} is needed.
+     * Internally, a wrapper of {@link KeyManagerFactory} that only produces this specified
+     * {@link KeyManager} will be created, thus all the requirements specified in
+     * {@link #keyManager(KeyManagerFactory, String)} also apply here.
+     */
+    public QuicSslContextBuilder keyManager(KeyManager keyManager, String password) {
+        return keyManager(new KeyManagerFactoryWrapper(keyManager), password);
+    }
+
+    /**
+     * Application protocol negotiation configuration. {@code null} disables support.
+     */
+    public QuicSslContextBuilder applicationProtocols(String... applicationProtocols) {
+        this.applicationProtocols = applicationProtocols;
+        return this;
+    }
+
+    /**
+     * Set the size of the cache used for storing SSL session objects. {@code 0} to use the
+     * default value.
+     */
+    public QuicSslContextBuilder sessionCacheSize(long sessionCacheSize) {
+        this.sessionCacheSize = sessionCacheSize;
+        return this;
+    }
+
+    /**
+     * Set the timeout for the cached SSL session objects, in seconds. {@code 0} to use the
+     * default value.
+     */
+    public QuicSslContextBuilder sessionTimeout(long sessionTimeout) {
+        this.sessionTimeout = sessionTimeout;
+        return this;
+    }
+
+    /**
+     * Sets the client authentication mode.
+     */
+    public QuicSslContextBuilder clientAuth(ClientAuth clientAuth) {
+        this.clientAuth = checkNotNull(clientAuth, "clientAuth");
+        return this;
+    }
+
+    /**
+     * Create new {@link QuicSslContext} instance with configured settings that can be used for {@code QUIC}.
+     *
+     */
+    public QuicSslContext build() {
+        if (forServer) {
+            return new QuicheQuicSslContext(true, sessionCacheSize, sessionTimeout, clientAuth,
+                    trustManagerFactory, keyManagerFactory, keyPassword, applicationProtocols);
+        } else {
+            return new QuicheQuicSslContext(false, sessionCacheSize, sessionTimeout, clientAuth,
+                    trustManagerFactory, keyManagerFactory, keyPassword, applicationProtocols);
+        }
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicSslEngine.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicSslEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,22 +15,9 @@
  */
 package io.netty.incubator.codec.quic;
 
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
+import javax.net.ssl.SSLEngine;
 
-public abstract class AbstractQuicTest {
-
-    private static final int TEST_GLOBAL_TIMEOUT_VALUE = Integer.getInteger(
-            "io.netty.incubator.codec.quic.defaultTestTimeout", 10);
-
-    @Rule
-    public final Timeout globalTimeout = Timeout.seconds(TEST_GLOBAL_TIMEOUT_VALUE);
-
-    @BeforeClass
-    public static void assumeTrue() {
-        Quic.ensureAvailability();
-       Assume.assumeTrue(Quic.isAvailable());
-    }
-}
+/**
+ * An {@link SSLEngine} that can be used for QUIC.
+ */
+public abstract class QuicSslEngine extends SSLEngine { }

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -204,15 +204,10 @@ final class Quiche {
                                    int newScidLen, long tokenAddr, int tokenLen, int version, long outAddr, int outLen);
 
     /**
-     * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L206">quiche_accept</a>.
+     * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L229">quiche_conn_new_with_tls</a>.
      */
-    static native long quiche_accept(long scidAddr, int scidLen, long odcidAddr, int odcidLen, long configAddr);
-
-    /**
-     * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L206">quiche_accept</a> but
-     * used for accepting QUIC connections without token validation.
-     */
-    static native long quiche_accept_no_token(long scidAddr, int scidLen, long configAddr);
+    static native long quiche_conn_new_with_tls(long scidAddr, int scidLen, long odcidAddr, int odcidLen,
+                                                long configAddr, long ssl, boolean isServer);
 
     /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L249">quiche_conn_recv</a>.
@@ -230,6 +225,7 @@ final class Quiche {
     static native void quiche_conn_free(long connAddr);
 
     /**
+<<<<<<< HEAD
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L211">quiche_connect</a>.
      */
     static native long quiche_connect(String server_name, long scidAddr, int scidLen, long configAddr);
@@ -243,6 +239,8 @@ final class Quiche {
             long connAddr, long streamId, byte urgency, boolean incremental);
 
     /**
+=======
+>>>>>>> ccb1469... Allow to use KeyManagerFactory / TrustmanagerFactory
      * See <a href="https://github.com/cloudflare/quiche/blob/
      * 35e38d987c1e53ef2bd5f23b754c50162b5adac8/include/quiche.h#L312">quiche_conn_trace_id</a>.
      */
@@ -281,13 +279,6 @@ final class Quiche {
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L297">quiche_conn_close</a>.
      */
     static native int quiche_conn_close(long connAddr, boolean app, long err, long reasonAddr, int reasonLen);
-
-    /**
-     * See
-     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L301">
-     *     quiche_conn_application_proto</a>.
-     */
-    static native byte[] quiche_conn_application_proto(long connAddr);
 
     /**
      * See
@@ -388,27 +379,6 @@ final class Quiche {
 
     /**
      * See
-     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L118">
-     *     quiche_config_load_cert_chain_from_pem_file</a>.
-     */
-    static native int quiche_config_load_cert_chain_from_pem_file(long configAddr, String path);
-
-    /**
-     * See
-     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#122">
-     *     quiche_config_load_priv_key_from_pem_file</a>.
-     */
-    static native int quiche_config_load_priv_key_from_pem_file(long configAddr, String path);
-
-    /**
-     * See
-     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#126">
-     *     quiche_config_verify_peer</a>.
-     */
-    static native void quiche_config_verify_peer(long configAddr, boolean value);
-
-    /**
-     * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#129">
      *     quiche_config_grease</a>.
      */
@@ -420,13 +390,6 @@ final class Quiche {
      *     quiche_config_enable_early_data</a>.
      */
     static native void quiche_config_enable_early_data(long configAddr);
-
-    /**
-     * See
-     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#138">
-     *     quiche_config_set_application_protos</a>.
-     */
-    static native int quiche_config_set_application_protos(long configAddr, byte[] protos);
 
     /**
      * See

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
@@ -19,33 +19,20 @@ final class QuicheConfig {
     private final boolean isDatagramSupported;
     private final long config;
 
-    QuicheConfig(String certPath, String keyPath, Boolean verifyPeer, Boolean grease, boolean earlyData,
-                        byte[] protos, Long maxIdleTimeout, Long maxSendUdpPayloadSize, Long maxRecvUdpPayloadSize,
-                        Long initialMaxData, Long initialMaxStreamDataBidiLocal, Long initialMaxStreamDataBidiRemote,
+    QuicheConfig(Boolean grease, boolean earlyData, Long maxIdleTimeout, Long maxSendUdpPayloadSize,
+                        Long maxRecvUdpPayloadSize, Long initialMaxData,
+                        Long initialMaxStreamDataBidiLocal, Long initialMaxStreamDataBidiRemote,
                         Long initialMaxStreamDataUni, Long initialMaxStreamsBidi, Long initialMaxStreamsUni,
                         Long ackDelayExponent, Long maxAckDelay, Boolean disableActiveMigration, Boolean enableHystart,
                         QuicCongestionControlAlgorithm congestionControlAlgorithm,
                  Integer recvQueueLen, Integer sendQueueLen) {
-
         long config = Quiche.quiche_config_new(Quiche.QUICHE_PROTOCOL_VERSION);
         try {
-            if (certPath != null && Quiche.quiche_config_load_cert_chain_from_pem_file(config, certPath) != 0) {
-                throw new IllegalArgumentException("Unable to load certificate chain");
-            }
-            if (keyPath != null && Quiche.quiche_config_load_priv_key_from_pem_file(config, keyPath) != 0) {
-                throw new IllegalArgumentException("Unable to load private key");
-            }
-            if (verifyPeer != null) {
-                Quiche.quiche_config_verify_peer(config, verifyPeer);
-            }
             if (grease != null) {
                 Quiche.quiche_config_grease(config, grease);
             }
             if (earlyData) {
                 Quiche.quiche_config_enable_early_data(config);
-            }
-            if (protos != null) {
-                Quiche.quiche_config_set_application_protos(config, protos);
             }
             if (maxIdleTimeout != null) {
                 Quiche.quiche_config_set_max_idle_timeout(config, maxIdleTimeout);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.ssl.ApplicationProtocolNegotiator;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslHandler;
+
+import javax.crypto.NoSuchPaddingException;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedKeyManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import java.io.File;
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Executor;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+final class QuicheQuicSslContext extends QuicSslContext {
+    final long ctx;
+    final ClientAuth clientAuth;
+    private final boolean server;
+    @SuppressWarnings("deprecation")
+    private final ApplicationProtocolNegotiator apn;
+    private long sessionCacheSize;
+    private long sessionTimeout;
+    private final QuicheQuicSslSessionContext sessionCtx;
+    private final QuicheQuicSslEngineMap engineMap = new QuicheQuicSslEngineMap();
+
+    QuicheQuicSslContext(boolean server, long sessionTimeout, long sessionCacheSize,
+                         ClientAuth clientAuth, TrustManagerFactory trustManagerFactory,
+                         KeyManagerFactory keyManagerFactory, String password,
+                         String... applicationProtocols) {
+        Quic.ensureAvailability();
+        this.server = server;
+        this.clientAuth = server ? checkNotNull(clientAuth, "clientAuth") : ClientAuth.NONE;
+        final X509ExtendedTrustManager trustManager;
+        if (trustManagerFactory == null) {
+            try {
+                trustManagerFactory =
+                        TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                trustManagerFactory.init((KeyStore) null);
+                trustManager = chooseTrustManager(trustManagerFactory);
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+        } else {
+            trustManager = chooseTrustManager(trustManagerFactory);
+        }
+        final X509ExtendedKeyManager keyManager;
+        if (keyManagerFactory == null) {
+            if (server) {
+                throw new IllegalArgumentException("No KeyManagerFactory");
+            }
+            keyManager = null;
+        } else {
+            keyManager = chooseKeyManager(keyManagerFactory);
+        }
+        int verifyMode = server ? boringSSLVerifyModeForServer(this.clientAuth) : BoringSSL.SSL_VERIFY_PEER;
+        ctx = BoringSSL.SSLContext_new(server, applicationProtocols, new BoringSSLHandshakeCompleteCallback(engineMap),
+                new BoringSSLCertificateCallback(engineMap, keyManager, password),
+                new BoringSSLCertificateVerifyCallback(engineMap, trustManager),
+                verifyMode, BoringSSL.subjectNames(trustManager.getAcceptedIssuers()));
+        apn = new QuicheQuicApplicationProtocolNegotiator(applicationProtocols);
+        this.sessionCacheSize = BoringSSL.SSLContext_setSessionCacheSize(ctx, sessionCacheSize);
+        this.sessionTimeout = BoringSSL.SSLContext_setSessionCacheTimeout(ctx, sessionTimeout);
+        sessionCtx = new QuicheQuicSslSessionContext(this);
+    }
+
+    private X509ExtendedKeyManager chooseKeyManager(KeyManagerFactory keyManagerFactory) {
+        for (KeyManager manager: keyManagerFactory.getKeyManagers()) {
+            if (manager instanceof X509ExtendedKeyManager) {
+                return (X509ExtendedKeyManager) manager;
+            }
+        }
+        throw new IllegalArgumentException("No X509ExtendedKeyManager included");
+    }
+
+    private static X509ExtendedTrustManager chooseTrustManager(TrustManagerFactory trustManagerFactory) {
+        for (TrustManager manager: trustManagerFactory.getTrustManagers()) {
+            if (manager instanceof X509ExtendedTrustManager) {
+                return (X509ExtendedTrustManager) manager;
+            }
+        }
+        throw new IllegalArgumentException("No X509ExtendedTrustManager included");
+    }
+
+     static X509Certificate[] toX509Certificates0(File file) throws CertificateException {
+        return toX509Certificates(file);
+    }
+
+    static PrivateKey toPrivateKey0(File keyFile, String keyPassword) throws NoSuchAlgorithmException,
+            NoSuchPaddingException, InvalidKeySpecException,
+            InvalidAlgorithmParameterException,
+            KeyException, IOException {
+        return toPrivateKey(keyFile, keyPassword);
+    }
+
+    static TrustManagerFactory buildTrustManagerFactory0(
+            X509Certificate[] certCollection)
+            throws NoSuchAlgorithmException, CertificateException, KeyStoreException, IOException {
+        return buildTrustManagerFactory(certCollection, null, null);
+    }
+
+    private static int boringSSLVerifyModeForServer(ClientAuth mode) {
+        switch (mode) {
+            case NONE:
+                return BoringSSL.SSL_VERIFY_NONE;
+            case REQUIRE:
+                return BoringSSL.SSL_VERIFY_PEER | BoringSSL.SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+            case OPTIONAL:
+                return BoringSSL.SSL_VERIFY_PEER;
+            default:
+                throw new Error(mode.toString());
+        }
+    }
+
+    long newSSL(QuicheQuicSslEngine engine, String tlsHostName) {
+        long ssl = BoringSSL.SSL_new(ctx, isServer(), tlsHostName);
+        engineMap.put(ssl, engine);
+        return ssl;
+    }
+
+    @Override
+    public boolean isClient() {
+        return !server;
+    }
+
+    @Override
+    public List<String> cipherSuites() {
+        return Arrays.asList("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384");
+    }
+
+    @Override
+    public synchronized long sessionCacheSize() {
+        return sessionCacheSize;
+    }
+
+    @Override
+    public synchronized long sessionTimeout() {
+        return sessionTimeout;
+    }
+
+    @Override
+    public ApplicationProtocolNegotiator applicationProtocolNegotiator() {
+        return apn;
+    }
+
+    @Override
+    public QuicSslEngine newEngine(ByteBufAllocator alloc) {
+        return new QuicheQuicSslEngine(this, null, -1);
+    }
+
+    @Override
+    public QuicSslEngine newEngine(ByteBufAllocator alloc, String peerHost, int peerPort) {
+        return new QuicheQuicSslEngine(this, peerHost, peerPort);
+    }
+
+    @Override
+    public SSLSessionContext sessionContext() {
+        return sessionCtx;
+    }
+
+    @Override
+    protected SslHandler newHandler(ByteBufAllocator alloc, boolean startTls) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SslHandler newHandler(ByteBufAllocator alloc, Executor delegatedTaskExecutor) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected SslHandler newHandler(ByteBufAllocator alloc, boolean startTls, Executor executor) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort, boolean startTls) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort,
+                                 Executor delegatedTaskExecutor) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort,
+                                    boolean startTls, Executor delegatedTaskExecutor) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        super.finalize();
+        BoringSSL.SSLContext_free(ctx);
+    }
+
+    void setSessionTimeout(int seconds) throws IllegalArgumentException {
+        sessionTimeout = BoringSSL.SSLContext_setSessionCacheTimeout(ctx, seconds);
+    }
+
+    void setSessionCacheSize(int size) throws IllegalArgumentException {
+        sessionCacheSize = BoringSSL.SSLContext_setSessionCacheSize(ctx, size);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static final class QuicheQuicApplicationProtocolNegotiator implements ApplicationProtocolNegotiator {
+        private final List<String> protocols;
+
+        QuicheQuicApplicationProtocolNegotiator(String... protocols) {
+            if (protocols == null) {
+                this.protocols = Collections.emptyList();
+            } else {
+                this.protocols = Collections.unmodifiableList(Arrays.asList(protocols));
+            }
+        }
+
+        @Override
+        public List<String> protocols() {
+            return protocols;
+        }
+    }
+
+    private static final class QuicheQuicSslSessionContext implements SSLSessionContext {
+
+        private final QuicheQuicSslContext context;
+
+        QuicheQuicSslSessionContext(QuicheQuicSslContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public SSLSession getSession(byte[] sessionId) {
+            return null;
+        }
+
+        @Override
+        public Enumeration<byte[]> getIds() {
+            return new Enumeration<byte[]>() {
+                @Override
+                public boolean hasMoreElements() {
+                    return false;
+                }
+
+                @Override
+                public byte[] nextElement() {
+                    throw new NoSuchElementException();
+                }
+            };
+        }
+
+        @Override
+        public void setSessionTimeout(int seconds) throws IllegalArgumentException {
+            context.setSessionTimeout(seconds);
+        }
+
+        @Override
+        public int getSessionTimeout() {
+            return (int) context.sessionTimeout();
+        }
+
+        @Override
+        public void setSessionCacheSize(int size) throws IllegalArgumentException {
+            context.setSessionCacheSize(size);
+        }
+
+        @Override
+        public int getSessionCacheSize() {
+            return (int) context.sessionCacheSize();
+        }
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
@@ -1,0 +1,517 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.util.LazyJavaxX509Certificate;
+import io.netty.handler.ssl.util.LazyX509Certificate;
+import io.netty.util.NetUtil;
+import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ObjectUtil;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSessionBindingEvent;
+import javax.net.ssl.SSLSessionBindingListener;
+import javax.net.ssl.SSLSessionContext;
+import javax.security.cert.X509Certificate;
+import java.nio.ByteBuffer;
+import java.security.Principal;
+import java.security.cert.Certificate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+final class QuicheQuicSslEngine extends QuicSslEngine {
+    private final QuicheQuicSslContext ctx;
+    private final String peerHost;
+    private final int peerPort;
+    private final QuicheQuicSslSession session = new QuicheQuicSslSession();
+    private volatile Certificate[] localCertificateChain;
+    private List<SNIServerName> sniHostNames;
+    private boolean handshakeFinished;
+    private String applicationProtocol;
+    private final String tlsHostName;
+
+    QuicheQuicSslEngine(QuicheQuicSslContext ctx, String peerHost, int peerPort) {
+        this.ctx = ctx;
+        this.peerHost = peerHost;
+        this.peerPort = peerPort;
+        // Use SNI if peerHost was specified and a valid hostname
+        // See https://github.com/netty/netty/issues/4746
+        if (ctx.isClient() && isValidHostNameForSNI(peerHost)) {
+            tlsHostName = peerHost;
+            sniHostNames = Collections.singletonList(new SNIHostName(tlsHostName));
+        } else {
+            tlsHostName = null;
+        }
+    }
+
+    long createNative() {
+        return ctx.newSSL(this, tlsHostName);
+    }
+
+    void setLocalCertificateChain(Certificate[] localCertificateChain) {
+        this.localCertificateChain = localCertificateChain;
+    }
+
+    /**
+     * Validate that the given hostname can be used in SNI extension.
+     */
+    static boolean isValidHostNameForSNI(String hostname) {
+        return hostname != null &&
+                hostname.indexOf('.') > 0 &&
+                !hostname.endsWith(".") &&
+                !NetUtil.isValidIpV4Address(hostname) &&
+                !NetUtil.isValidIpV6Address(hostname);
+    }
+
+    @Override
+    public SSLParameters getSSLParameters() {
+        SSLParameters parameters = super.getSSLParameters();
+        parameters.setServerNames(sniHostNames);
+        return parameters;
+    }
+
+    // These method will override the method defined by Java 8u251 and later. As we may compile with an earlier
+    // java8 version we don't use @Override annotations here.
+    public synchronized String getApplicationProtocol() {
+        return applicationProtocol;
+    }
+
+    // These method will override the method defined by Java 8u251 and later. As we may compile with an earlier
+    // java8 version we don't use @Override annotations here.
+    public synchronized String getHandshakeApplicationProtocol() {
+        return applicationProtocol;
+    }
+
+    @Override
+    public SSLEngineResult wrap(ByteBuffer[] srcs, int offset, int length, ByteBuffer dst) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SSLEngineResult unwrap(ByteBuffer src, ByteBuffer[] dsts, int offset, int length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Runnable getDelegatedTask() {
+        return null;
+    }
+
+    @Override
+    public void closeInbound() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isInboundDone() {
+        return false;
+    }
+
+    @Override
+    public void closeOutbound() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isOutboundDone() {
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return ctx.cipherSuites().toArray(new String[0]);
+    }
+
+    @Override
+    public String[] getEnabledCipherSuites() {
+        return getSupportedCipherSuites();
+    }
+
+    @Override
+    public void setEnabledCipherSuites(String[] suites) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String[] getSupportedProtocols() {
+        // QUIC only supports TLSv1.3
+        return new String[] { "TLSv1.3" };
+    }
+
+    @Override
+    public String[] getEnabledProtocols() {
+        return getSupportedProtocols();
+    }
+
+    @Override
+    public void setEnabledProtocols(String[] protocols) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SSLSession getSession() {
+        return session;
+    }
+
+    @Override
+    public SSLSession getHandshakeSession() {
+        if (handshakeFinished) {
+            return null;
+        }
+        return session;
+    }
+
+    @Override
+    public void beginHandshake() {
+        // NOOP
+    }
+
+    @Override
+    public SSLEngineResult.HandshakeStatus getHandshakeStatus() {
+        if (handshakeFinished) {
+            return SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
+        }
+        return SSLEngineResult.HandshakeStatus.NEED_WRAP;
+    }
+
+    @Override
+    public void setUseClientMode(boolean clientMode) {
+        if (clientMode != ctx.isClient()) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Override
+    public boolean getUseClientMode() {
+        return ctx.isClient();
+    }
+
+    @Override
+    public void setNeedClientAuth(boolean b) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean getNeedClientAuth() {
+        return ctx.clientAuth == ClientAuth.REQUIRE;
+    }
+
+    @Override
+    public void setWantClientAuth(boolean b) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean getWantClientAuth() {
+        return ctx.clientAuth == ClientAuth.OPTIONAL;
+    }
+
+    @Override
+    public void setEnableSessionCreation(boolean flag) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean getEnableSessionCreation() {
+        return false;
+    }
+
+    synchronized void handshakeFinished(byte[] id, String cipher, String protocol, byte[] peerCertificate,
+                                        byte[][] peerCertificateChain,
+                                        long creationTime, long timeout,
+                                        byte[] applicationProtocol) {
+        if (applicationProtocol == null) {
+            this.applicationProtocol = null;
+        } else {
+            this.applicationProtocol = new String(applicationProtocol);
+        }
+        session.handshakeFinished(id, cipher, protocol, peerCertificate, peerCertificateChain, creationTime, timeout);
+        handshakeFinished = true;
+    }
+
+    private final class QuicheQuicSslSession implements SSLSession {
+        private X509Certificate[] x509PeerCerts;
+        private Certificate[] peerCerts;
+        private String protocol;
+        private String cipher;
+        private byte[] id;
+        private long creationTime;
+        private long timeout;
+
+        // lazy init for memory reasons
+        private Map<String, Object> values;
+
+        private boolean isEmpty(Object[] arr) {
+            return arr == null || arr.length == 0;
+        }
+        private boolean isEmpty(byte[] arr) {
+            return arr == null || arr.length == 0;
+        }
+
+        void handshakeFinished(byte[] id, String cipher, String protocol, byte[] peerCertificate,
+                               byte[][] peerCertificateChain, long creationTime, long timeout) {
+            synchronized (QuicheQuicSslEngine.this) {
+                initPeerCerts(peerCertificateChain, peerCertificate);
+                this.id = id;
+                this.cipher = cipher;
+                this.protocol = protocol;
+                this.creationTime = creationTime * 1000L;
+                this.timeout = timeout * 1000L;
+            }
+        }
+
+        /**
+         * Init peer certificates that can be obtained via {@link #getPeerCertificateChain()}
+         * and {@link #getPeerCertificates()}.
+         */
+        private void initPeerCerts(byte[][] chain, byte[] clientCert) {
+            // Return the full chain from the JNI layer.
+            if (getUseClientMode()) {
+                if (isEmpty(chain)) {
+                    peerCerts = EmptyArrays.EMPTY_CERTIFICATES;
+                    x509PeerCerts = EmptyArrays.EMPTY_JAVAX_X509_CERTIFICATES;
+                } else {
+                    peerCerts = new Certificate[chain.length];
+                    x509PeerCerts = new X509Certificate[chain.length];
+                    initCerts(chain, 0);
+                }
+            } else {
+                // if used on the server side SSL_get_peer_cert_chain(...) will not include the remote peer
+                // certificate. We use SSL_get_peer_certificate to get it in this case and add it to our
+                // array later.
+                //
+                // See https://www.openssl.org/docs/ssl/SSL_get_peer_cert_chain.html
+                if (isEmpty(clientCert)) {
+                    peerCerts = EmptyArrays.EMPTY_CERTIFICATES;
+                    x509PeerCerts = EmptyArrays.EMPTY_JAVAX_X509_CERTIFICATES;
+                } else {
+                    if (isEmpty(chain)) {
+                        peerCerts = new Certificate[] {new LazyX509Certificate(clientCert)};
+                        x509PeerCerts = new X509Certificate[] {new LazyJavaxX509Certificate(clientCert)};
+                    } else {
+                        peerCerts = new Certificate[chain.length + 1];
+                        x509PeerCerts = new X509Certificate[chain.length + 1];
+                        peerCerts[0] = new LazyX509Certificate(clientCert);
+                        x509PeerCerts[0] = new LazyJavaxX509Certificate(clientCert);
+                        initCerts(chain, 1);
+                    }
+                }
+            }
+        }
+
+        private void initCerts(byte[][] chain, int startPos) {
+            for (int i = 0; i < chain.length; i++) {
+                int certPos = startPos + i;
+                peerCerts[certPos] = new LazyX509Certificate(chain[i]);
+                x509PeerCerts[certPos] = new LazyJavaxX509Certificate(chain[i]);
+            }
+        }
+
+        @Override
+        public byte[] getId() {
+            synchronized (QuicheQuicSslSession.this) {
+                if (id == null) {
+                    return EmptyArrays.EMPTY_BYTES;
+                }
+                return id.clone();
+            }
+        }
+
+        @Override
+        public SSLSessionContext getSessionContext() {
+            return ctx.sessionContext();
+        }
+
+        @Override
+        public long getCreationTime() {
+            synchronized (QuicheQuicSslEngine.this) {
+                return creationTime;
+            }
+        }
+
+        @Override
+        public long getLastAccessedTime() {
+            return getCreationTime();
+        }
+
+        @Override
+        public void invalidate() {
+            // NOOP
+        }
+
+        @Override
+        public boolean isValid() {
+            synchronized (QuicheQuicSslEngine.this) {
+                return System.currentTimeMillis() - timeout < creationTime;
+            }
+        }
+
+        @Override
+        public void putValue(String name, Object value) {
+            ObjectUtil.checkNotNull(name, "name");
+            ObjectUtil.checkNotNull(value, "value");
+
+            final Object old;
+            synchronized (this) {
+                Map<String, Object> values = this.values;
+                if (values == null) {
+                    // Use size of 2 to keep the memory overhead small
+                    values = this.values = new HashMap<>(2);
+                }
+                old = values.put(name, value);
+            }
+
+            if (value instanceof SSLSessionBindingListener) {
+                // Use newSSLSessionBindingEvent so we alway use the wrapper if needed.
+                ((SSLSessionBindingListener) value).valueBound(newSSLSessionBindingEvent(name));
+            }
+            notifyUnbound(old, name);
+        }
+
+        @Override
+        public Object getValue(String name) {
+            ObjectUtil.checkNotNull(name, "name");
+            synchronized (this) {
+                if (values == null) {
+                    return null;
+                }
+                return values.get(name);
+            }
+        }
+
+        @Override
+        public void removeValue(String name) {
+            ObjectUtil.checkNotNull(name, "name");
+
+            final Object old;
+            synchronized (this) {
+                Map<String, Object> values = this.values;
+                if (values == null) {
+                    return;
+                }
+                old = values.remove(name);
+            }
+
+            notifyUnbound(old, name);
+        }
+
+        @Override
+        public String[] getValueNames() {
+            synchronized (this) {
+                Map<String, Object> values = this.values;
+                if (values == null || values.isEmpty()) {
+                    return EmptyArrays.EMPTY_STRINGS;
+                }
+                return values.keySet().toArray(new String[0]);
+            }
+        }
+
+        private SSLSessionBindingEvent newSSLSessionBindingEvent(String name) {
+            return new SSLSessionBindingEvent(session, name);
+        }
+
+        private void notifyUnbound(Object value, String name) {
+            if (value instanceof SSLSessionBindingListener) {
+                // Use newSSLSessionBindingEvent so we alway use the wrapper if needed.
+                ((SSLSessionBindingListener) value).valueUnbound(newSSLSessionBindingEvent(name));
+            }
+        }
+
+        @Override
+        public Certificate[] getPeerCertificates() throws SSLPeerUnverifiedException {
+            synchronized (QuicheQuicSslEngine.this) {
+                if (isEmpty(peerCerts)) {
+                    throw new SSLPeerUnverifiedException("peer not verified");
+                }
+                return peerCerts.clone();
+            }
+        }
+
+        @Override
+        public Certificate[] getLocalCertificates() {
+            Certificate[] localCerts = localCertificateChain;
+            if (localCerts == null) {
+                return null;
+            }
+            return localCerts.clone();
+        }
+
+        @Override
+        public X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException {
+            synchronized (QuicheQuicSslEngine.this) {
+                if (isEmpty(x509PeerCerts)) {
+                    throw new SSLPeerUnverifiedException("peer not verified");
+                }
+                return x509PeerCerts.clone();
+            }
+        }
+
+        @Override
+        public Principal getPeerPrincipal() throws SSLPeerUnverifiedException {
+            Certificate[] peer = getPeerCertificates();
+            // No need for null or length > 0 is needed as this is done in getPeerCertificates()
+            // already.
+            return ((java.security.cert.X509Certificate) peer[0]).getSubjectX500Principal();
+        }
+
+        @Override
+        public Principal getLocalPrincipal() {
+            Certificate[] local = localCertificateChain;
+            if (local == null || local.length == 0) {
+                return null;
+            }
+            return ((java.security.cert.X509Certificate) local[0]).getIssuerX500Principal();
+        }
+
+        @Override
+        public String getCipherSuite() {
+            return cipher;
+        }
+
+        @Override
+        public String getProtocol() {
+            return protocol;
+        }
+
+        @Override
+        public String getPeerHost() {
+            return peerHost;
+        }
+
+        @Override
+        public int getPeerPort() {
+            return peerPort;
+        }
+
+        @Override
+        public int getPacketBufferSize() {
+            return -1;
+        }
+
+        @Override
+        public int getApplicationBufferSize() {
+            return -1;
+        }
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngineMap.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngineMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,22 +15,23 @@
  */
 package io.netty.incubator.codec.quic;
 
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
 
-public abstract class AbstractQuicTest {
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
-    private static final int TEST_GLOBAL_TIMEOUT_VALUE = Integer.getInteger(
-            "io.netty.incubator.codec.quic.defaultTestTimeout", 10);
+final class QuicheQuicSslEngineMap {
 
-    @Rule
-    public final Timeout globalTimeout = Timeout.seconds(TEST_GLOBAL_TIMEOUT_VALUE);
+    private final ConcurrentMap<Long, QuicheQuicSslEngine> engines = new ConcurrentHashMap<>();
 
-    @BeforeClass
-    public static void assumeTrue() {
-        Quic.ensureAvailability();
-       Assume.assumeTrue(Quic.isAvailable());
+    QuicheQuicSslEngine get(long ssl) {
+        return engines.get(ssl);
+    }
+
+    QuicheQuicSslEngine remove(long ssl) {
+        return engines.remove(ssl);
+    }
+
+    void put(long ssl, QuicheQuicSslEngine engine) {
+        engines.put(ssl, engine);
     }
 }

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
@@ -16,7 +16,6 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.util.concurrent.Future;

--- a/src/test/java/io/netty/incubator/codec/quic/example/QuicClientExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/example/QuicClientExample.java
@@ -25,8 +25,11 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.incubator.codec.quic.QuicClientCodecBuilder;
+import io.netty.incubator.codec.quic.QuicSslContext;
+import io.netty.incubator.codec.quic.QuicSslContextBuilder;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.incubator.codec.quic.QuicStreamType;
 import io.netty.util.CharsetUtil;
@@ -40,15 +43,12 @@ public final class QuicClientExample {
     private QuicClientExample() { }
 
     public static void main(String[] args) throws Exception {
-        // We just want to support HTTP 0.9 as application protocol
-        byte[] proto = new byte[] {
-                0x08, 'h', 't', 't', 'p', '/', '0', '.', '9'
-        };
-
+        QuicSslContext context = QuicSslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).
+                applicationProtocols("http/0.9").build();
         NioEventLoopGroup group = new NioEventLoopGroup(1);
         try {
             ChannelHandler codec = new QuicClientCodecBuilder()
-                    .applicationProtocols(proto)
+                    .sslContext(context)
                     .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
                     .initialMaxData(10000000)
                     // As we don't want to support remote initiated streams just setup the limit for local initiated

--- a/src/test/java/io/netty/incubator/codec/quic/example/QuicServerExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/example/QuicServerExample.java
@@ -18,7 +18,6 @@ package io.netty.incubator.codec.quic.example;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -29,11 +28,14 @@ import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.incubator.codec.quic.InsecureQuicTokenHandler;
 import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.incubator.codec.quic.QuicServerCodecBuilder;
+import io.netty.incubator.codec.quic.QuicSslContext;
+import io.netty.incubator.codec.quic.QuicSslContextBuilder;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
@@ -44,16 +46,11 @@ public final class QuicServerExample {
     private QuicServerExample() { }
 
     public static void main(String[] args) throws Exception {
-        // We just want to support HTTP 0.9 as application protocol
-        byte[] proto = new byte[] {
-                0x08, 'h', 't', 't', 'p', '/', '0', '.', '9'
-        };
-
+        QuicSslContext context = QuicSslContextBuilder.forServer(
+                new File("./src/test/resources/cert.key"), null, new File("./src/test/resources/cert.crt"))
+                .applicationProtocols("http/0.9").build();
         NioEventLoopGroup group = new NioEventLoopGroup(1);
-        ChannelHandler codec = new QuicServerCodecBuilder()
-                .certificateChain("./src/test/resources/cert.crt")
-                .privateKey("./src/test/resources/cert.key")
-                .applicationProtocols(proto)
+        ChannelHandler codec = new QuicServerCodecBuilder().sslContext(context)
                 .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
                 // Configure some limits for the maximal number of streams (and the data) that we want to handle.
                 .initialMaxData(10000000)


### PR DESCRIPTION
Motivation:

People often want to use their own custom keymaterial selection / certificate validation. This was not possible as all of this was handled internally by quiche.

Modification:

- Allow to implement custom key material selection
- Allow to implement custom certificate validation
- Port over some code from netty-tcnative / netty
- Use our own vendored boringssl libraries when compiling

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/97