### PR TITLE
Allow to update the stream priority

### DIFF
--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -207,6 +207,10 @@ static jlong netty_quiche_connect(JNIEnv* env, jclass clazz, jstring server_name
     return (jlong) conn;
 }
 
+static jint netty_quiche_conn_stream_priority(JNIEnv* env, jclass clazz, jlong conn, jlong stream_id, jbyte urgency, jboolean incremental) {
+    return (jint) quiche_conn_stream_priority((quiche_conn *) conn, (uint64_t) stream_id,  (uint8_t) urgency, incremental == JNI_TRUE ? true : false);
+}
+
 static jint netty_quiche_conn_stream_recv(JNIEnv* env, jclass clazz, jlong conn, jlong stream_id, jlong out, int buf_len, jlong finAddr) {
     return (jint) quiche_conn_stream_recv((quiche_conn *) conn, (uint64_t) stream_id,  (uint8_t *) out, (size_t) buf_len, (bool *) finAddr);
 }
@@ -513,6 +517,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_send", "(JJI)I", (void *) netty_quiche_conn_send },
   { "quiche_conn_free", "(J)V", (void *) netty_quiche_conn_free },
   { "quiche_connect", "(Ljava/lang/String;JIJ)J", (void *) netty_quiche_connect },
+  { "quiche_conn_stream_priority", "(JJBZ)I", (void *) netty_quiche_conn_stream_priority },
   { "quiche_conn_stream_recv", "(JJJIJ)I", (void *) netty_quiche_conn_stream_recv },
   { "quiche_conn_stream_send", "(JJJIZ)I", (void *) netty_quiche_conn_stream_send },
   { "quiche_conn_stream_shutdown", "(JJIJ)I", (void *) netty_quiche_conn_stream_shutdown },

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
@@ -17,6 +17,7 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.socket.DuplexChannel;
 
 /**
@@ -56,6 +57,35 @@ public interface QuicStreamChannel extends DuplexChannel {
      * @return the stream id of this {@link QuicStreamChannel}.
      */
     long streamId();
+
+    /**
+     * The {@link QuicStreamPriority} if explicit set for the stream via {@link #updatePriority(QuicStreamPriority)} or
+     * {@link #updatePriority(QuicStreamPriority, ChannelPromise)}. Otherwise {@code null}.
+     *
+     * @return the priority if any was set.
+     */
+    QuicStreamPriority priority();
+
+    /**
+     * Update the priority of the stream. A stream's priority determines the order in which stream data is sent
+     * on the wire (streams with lower priority are sent first).
+     *
+     * @param priority  the priority.
+     * @return          future that is notified once the operation completes.
+     */
+    default ChannelFuture updatePriority(QuicStreamPriority priority) {
+        return updatePriority(priority, newPromise());
+    }
+
+    /**
+     * Update the priority of the stream. A stream's priority determines the order in which stream data is sent
+     * on the wire (streams with lower priority are sent first).
+     *
+     * @param priority  the priority.
+     * @param promise   notified once operations completes.
+     * @return          future that is notified once the operation completes.
+     */
+    ChannelFuture updatePriority(QuicStreamPriority priority, ChannelPromise promise);
 
     @Override
     QuicChannel parent();

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamPriority.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamPriority.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.util.internal.ObjectUtil;
+
+import java.util.Objects;
+
+/**
+ * The priority of a {@link QuicStreamChannel}.
+ */
+public final class QuicStreamPriority {
+
+    private final int urgency;
+    private final boolean incremental;
+
+    /**
+     * Create a new instance
+     *
+     * @param urgency       the urgency of the stream.
+     * @param incremental   {@code true} if incremental.
+     */
+    public QuicStreamPriority(int urgency, boolean incremental) {
+        this.urgency = ObjectUtil.checkInRange(urgency, 0, Byte.MAX_VALUE, "urgency");
+        this.incremental = incremental;
+    }
+
+    /**
+     * The urgency of the stream. Smaller number means more urgent and so data will be send earlier.
+     *
+     * @return  the urgency.
+     */
+    public int urgency() {
+        return urgency;
+    }
+
+    /**
+     * {@code true} if incremental, {@code false} otherwise.
+     *
+     * @return  if incremental.
+     */
+    public boolean isIncremental() {
+        return incremental;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        QuicStreamPriority that = (QuicStreamPriority) o;
+        return urgency == that.urgency && incremental == that.incremental;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(urgency, incremental);
+    }
+
+    @Override
+    public String toString() {
+        return "QuicStreamPriority{" +
+                "urgency=" + urgency +
+                ", incremental=" + incremental +
+                '}';
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -16,7 +16,6 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.internal.NativeLibraryLoader;
@@ -236,6 +235,14 @@ final class Quiche {
     static native long quiche_connect(String server_name, long scidAddr, int scidLen, long configAddr);
 
     /**
+     * See
+     * <a href="https://github.com/cloudflare/quiche/blob/
+     * 35e38d987c1e53ef2bd5f23b754c50162b5adac8/include/quiche.h#L278">quiche_conn_stream_priority</a>.
+     */
+    static native int quiche_conn_stream_priority(
+            long connAddr, long streamId, byte urgency, boolean incremental);
+
+    /**
      * See <a href="https://github.com/cloudflare/quiche/blob/
      * 35e38d987c1e53ef2bd5f23b754c50162b5adac8/include/quiche.h#L312">quiche_conn_trace_id</a>.
      */
@@ -245,6 +252,7 @@ final class Quiche {
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L258">quiche_conn_stream_recv</a>.
      */
     static native int quiche_conn_stream_recv(long connAddr, long streamId, long outAddr, int bufLen, long finAddr);
+
     /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L262">quiche_conn_stream_send</a>.
      */

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -580,6 +580,11 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         streams.clear();
     }
 
+    void streamPriority(long streamId, byte priority, boolean incremental) throws Exception {
+       Quiche.throwIfError(Quiche.quiche_conn_stream_priority(connectionAddressChecked(), streamId,
+               priority, incremental));
+    }
+
     void streamClosed(long streamId) {
         streams.remove(streamId);
     }


### PR DESCRIPTION
Motivation:

We should allow to update the stream priority as this is also supported by quiche.

Modifications:

Add new methods and implementation that allows to update the stream priority.

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/13