### PR TITLE
Also enable ffi on linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,8 @@
                     <else>
                       <exec executable="cargo" failonerror="true" dir="${quicheCheckoutDir}" resolveexecutable="true">
                         <arg value="build" />
+                        <arg value="--features" />
+                        <arg value="ffi" />
                         <arg value="--release" />
                         <env key="CFLAGS" value="-O3 -fno-omit-frame-pointer -DOPENSSL_C11_ATOMIC" />
                         <env key="CXXFLAGS" value="-O3 -fno-omit-frame-pointer" />


### PR DESCRIPTION
Motivation:

dd211ef47dfcd38d9023e588d5877f0c9f937aa5 changed the version of quiche we compile against and correctly used --features ffi for macOS. Unfortunally we missed to do the same for linux

Modifications:

Add --features ffi on linux as well when building

Result:

No more "undefined symbol" errors on linux