### PR TITLE
Make use of quiche_conn_trace_id(....)

### DIFF
--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -160,6 +160,22 @@ static jlong netty_quiche_accept_no_token(JNIEnv* env, jclass clazz, jlong scid,
                                  (quiche_config *) config);
 }
 
+static jbyteArray netty_quiche_conn_trace_id(JNIEnv* env, jclass clazz, jlong conn) {
+    const uint8_t *trace_id = NULL;
+    size_t trace_id_len = 0;
+
+    quiche_conn_trace_id((quiche_conn *) conn, &trace_id, &trace_id_len);
+    if (trace_id == NULL || trace_id_len == 0) {
+        return NULL;
+    }
+     jbyteArray array = (*env)->NewByteArray(env, trace_id_len);
+     if (array == NULL) {
+        return NULL;
+     }
+     (*env)->SetByteArrayRegion(env,array, 0, trace_id_len, (jbyte*) trace_id);
+     return array;
+}
+
 static jint netty_quiche_conn_recv(JNIEnv* env, jclass clazz, jlong conn, jlong buf, jint buf_len) {
     return (jint) quiche_conn_recv((quiche_conn *) conn, (uint8_t *) buf, (size_t) buf_len);
 }
@@ -492,6 +508,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_retry", "(JIJIJIJIIJI)I", (void *) netty_quiche_retry },
   { "quiche_accept", "(JIJIJ)J", (void *) netty_quiche_accept },
   { "quiche_accept_no_token", "(JIJ)J", (void *) netty_quiche_accept_no_token },
+  { "quiche_conn_trace_id", "(J)[B", (void *) netty_quiche_conn_trace_id },
   { "quiche_conn_recv", "(JJI)I", (void *) netty_quiche_conn_recv },
   { "quiche_conn_send", "(JJI)I", (void *) netty_quiche_conn_send },
   { "quiche_conn_free", "(J)V", (void *) netty_quiche_conn_free },

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -236,6 +236,12 @@ final class Quiche {
     static native long quiche_connect(String server_name, long scidAddr, int scidLen, long configAddr);
 
     /**
+     * See <a href="https://github.com/cloudflare/quiche/blob/
+     * 35e38d987c1e53ef2bd5f23b754c50162b5adac8/include/quiche.h#L312">quiche_conn_trace_id</a>.
+     */
+    static native byte[] quiche_conn_trace_id(long connAddr);
+
+    /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L258">quiche_conn_stream_recv</a>.
      */
     static native int quiche_conn_stream_recv(long connAddr, long streamId, long outAddr, int bufLen, long finAddr);
@@ -587,12 +593,6 @@ final class Quiche {
         } else {
             promise.setSuccess();
         }
-    }
-
-    static String traceId(long connAddr, ByteBuf buffer) {
-        // We just do the same as quiche does for the traceid but we should use Connection:trace_id() once it is exposed
-        // in the c API.
-        return ByteBufUtil.hexDump(buffer);
     }
 
     private Quiche() { }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -188,7 +188,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         }
 
         QuicheQuicChannel channel = QuicheQuicChannel.forServer(
-                ctx.channel(), key, conn, Quiche.traceId(conn, dcid), sender, config.isDatagramSupported(),
+                ctx.channel(), key, conn, Quiche.quiche_conn_trace_id(conn), sender, config.isDatagramSupported(),
                 streamHandler, streamOptionsArray, streamAttrsArray);
         Quic.setupChannel(channel, optionsArray, attrsArray, handler, LOGGER);
         putChannel(channel);


### PR DESCRIPTION
Motivation:

We should directly use quiche_conn_trace_id now that it is exposed.

Modifications:

Remove our custom implementation and just use the C API of quiche

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/12