### PR TITLE
Use byte[].length when encode protocols to wireformat

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -155,8 +155,8 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     public final B applicationProtocols(String... protocols) {
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             for (String p : protocols) {
-                out.write(p.length());
                 byte[] bytes = p.getBytes(StandardCharsets.US_ASCII);
+                out.write(bytes.length);
                 out.write(bytes);
             }
             this.protos = out.toByteArray();


### PR DESCRIPTION
Motivation:

While it not makes any difference we should better use byte[].length when convert the protocols to wireformat as it is more future proof and in theory more correct.

Modifications:

Replace String.length() with byte[].length

Result:

More correct code