### PR TITLE
Make use of quiche_conn_dgram_recv_front_len to better size recv buffers

### DIFF
--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -323,6 +323,10 @@ static jint netty_quiche_conn_dgram_max_writable_len(JNIEnv* env, jclass clazz, 
     return (jint) quiche_conn_dgram_max_writable_len((quiche_conn *) conn);
 }
 
+static jint netty_quiche_conn_dgram_recv_front_len(JNIEnv* env, jclass clazz, jlong conn) {
+    return (jint) quiche_conn_dgram_recv_front_len((quiche_conn*) conn);
+}
+
 static jint netty_quiche_conn_dgram_recv(JNIEnv* env, jclass clazz, jlong conn, jlong buf, jint buf_len) {
     return (jint) quiche_conn_dgram_recv((quiche_conn *) conn, (uint8_t *) buf, (size_t) buf_len);
 }
@@ -530,6 +534,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_stream_iter_free", "(J)V", (void *) netty_quiche_stream_iter_free },
   { "quiche_stream_iter_next", "(J[J)I", (void *) netty_quiche_stream_iter_next },
   { "quiche_conn_dgram_max_writable_len", "(J)I", (void* ) netty_quiche_conn_dgram_max_writable_len },
+  { "quiche_conn_dgram_recv_front_len", "(J)I", (void* ) netty_quiche_conn_dgram_recv_front_len },
   { "quiche_conn_dgram_recv", "(JJI)I", (void* ) netty_quiche_conn_dgram_recv },
   { "quiche_conn_dgram_send", "(JJI)I", (void* ) netty_quiche_conn_dgram_send },
   { "quiche_config_new", "(I)J", (void *) netty_quiche_config_new },

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -352,6 +352,14 @@ final class Quiche {
 
     /**
      * See
+     * <a href=https://github.com/cloudflare/quiche/blob/
+     * 9d0c677ef1411b24d720b5c8b73bcc94b5535c29/include/quiche.h#L381">
+     *     quiche_conn_dgram_recv_front_len</a>.
+     */
+    static native int quiche_conn_dgram_recv_front_len(long connAddr);
+
+    /**
+     * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L361">
      *     quiche_conn_dgram_recv</a>.
      */


### PR DESCRIPTION
Motivation:

We can make use of quiche_conn_dgram_recv_front_len now. This allows us to ensure we always allocate a buffer with the correct size.

Modifications:

- Add jni methods for quiche_conn_dgram_recv_front_len
- Use the return value to allocate a new buffer
- Remove code that handled resizing before as its not needed anymore

Result:

Allocate buffers with correct size for datagram and no need to resize