### PR TITLE
Ensure we create a real copy of the attributes and options when boots…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/Quic.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quic.java
@@ -22,6 +22,8 @@ import io.netty.util.AttributeKey;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public final class Quic {
@@ -77,12 +79,12 @@ public final class Quic {
         return UNAVAILABILITY_CAUSE;
     }
 
-    static Map.Entry<ChannelOption<?>, Object>[] optionsArray(Map<ChannelOption<?>, Object> opts) {
-        return opts.entrySet().toArray(EMPTY_OPTION_ARRAY);
+    static Map.Entry<ChannelOption<?>, Object>[] toOptionsArray(Map<ChannelOption<?>, Object> opts) {
+        return new HashMap<>(opts).entrySet().toArray(EMPTY_OPTION_ARRAY);
     }
 
-    static Map.Entry<AttributeKey<?>, Object>[] attributesArray(Map<AttributeKey<?>, Object> attributes) {
-        return attributes.entrySet().toArray(EMPTY_ATTRIBUTE_ARRAY);
+    static Map.Entry<AttributeKey<?>, Object>[] toAttributesArray(Map<AttributeKey<?>, Object> attributes) {
+        return new LinkedHashMap<>(attributes).entrySet().toArray(EMPTY_ATTRIBUTE_ARRAY);
     }
 
     private static void setAttributes(Channel channel, Map.Entry<AttributeKey<?>, Object>[] attrs) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
@@ -197,9 +197,9 @@ public final class QuicChannelBootstrap {
         }
         final QuicConnectionAddress address = connectionAddress;
         QuicChannel channel = QuicheQuicChannel.forClient(parent, (InetSocketAddress) remote,
-                streamHandler, Quic.optionsArray(streamOptions), Quic.attributesArray(streamAttrs));
+                streamHandler, Quic.toOptionsArray(streamOptions), Quic.toAttributesArray(streamAttrs));
 
-        Quic.setupChannel(channel, Quic.optionsArray(options), Quic.attributesArray(attrs), handler, logger);
+        Quic.setupChannel(channel, Quic.toOptionsArray(options), Quic.toAttributesArray(attrs), handler, logger);
         EventLoop eventLoop = parent.eventLoop();
         eventLoop.register(channel).addListener((ChannelFuture future) -> {
             Throwable cause = future.cause();

--- a/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -17,7 +17,6 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
-import io.netty.handler.ssl.SslContext;
 import io.netty.util.AttributeKey;
 import io.netty.util.internal.ObjectUtil;
 
@@ -178,7 +177,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
         ChannelHandler handler = this.handler;
         ChannelHandler streamHandler = this.streamHandler;
         return new QuicheQuicServerCodec(config, localConnIdLength, tokenHandler, generator, sslEngineProvider,
-                handler, Quic.optionsArray(options), Quic.attributesArray(attrs),
-                streamHandler, Quic.optionsArray(streamOptions), Quic.attributesArray(streamAttrs));
+                handler, Quic.toOptionsArray(options), Quic.toAttributesArray(attrs),
+                streamHandler, Quic.toOptionsArray(streamOptions), Quic.toAttributesArray(streamAttrs));
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelBootstrap.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelBootstrap.java
@@ -125,7 +125,7 @@ public final class QuicStreamChannelBootstrap {
         }
 
         return parent.createStream(type, new QuicStreamChannelBootstrapHandler(handler,
-                Quic.optionsArray(options), Quic.attributesArray(attrs)), promise);
+                Quic.toOptionsArray(options), Quic.toAttributesArray(attrs)), promise);
     }
 
     private static final class QuicStreamChannelBootstrapHandler extends ChannelInitializer<QuicStreamChannel> {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicTest.java
@@ -15,13 +15,48 @@
  */
 package io.netty.incubator.codec.quic;
 
+import io.netty.channel.ChannelOption;
+import io.netty.util.AttributeKey;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class QuicTest extends AbstractQuicTest {
 
     @Test
     public void test() {
         Quic.ensureAvailability();
-        System.err.println(Quiche.quiche_version());
+        assertNotNull(Quiche.quiche_version());
+    }
+
+    @Test
+    public void testToAttributesArrayDoesCopy() {
+        AttributeKey<String> key = AttributeKey.valueOf(UUID.randomUUID().toString());
+        String value = "testValue";
+        Map<AttributeKey<?>, Object> attributes = new HashMap<>();
+        attributes.put(key, value);
+        Map.Entry<AttributeKey<?>, Object>[] array = Quic.toAttributesArray(attributes);
+        assertEquals(1, array.length);
+        attributes.put(key, "newTestValue");
+        Map.Entry<AttributeKey<?>, Object> entry = array[0];
+        assertEquals(key, entry.getKey());
+        assertEquals(value, entry.getValue());
+    }
+
+    @Test
+    public void testToOptionsArrayDoesCopy() {
+        Map<ChannelOption<?>, Object> options = new HashMap<>();
+        options.put(ChannelOption.AUTO_READ, true);
+        Map.Entry<ChannelOption<?>, Object>[] array = Quic.toOptionsArray(options);
+        assertEquals(1, array.length);
+        options.put(ChannelOption.AUTO_READ, false);
+        Map.Entry<ChannelOption<?>, Object> entry = array[0];
+        assertEquals(ChannelOption.AUTO_READ, entry.getKey());
+        assertEquals(true, entry.getValue());
     }
 }


### PR DESCRIPTION
…trap the codec / channels

Motivation:

We need to ensure we copy the whole maps before we convert these to arrays of Entry as otherwise we may change the Entry itself later on.

Modifications:

- Make a real copy
- Add unit tests

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/152