### PR TITLE
Fix pre-compilation step for BoringSSL

### DIFF
--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -77,7 +77,7 @@ WORKDIR $SOURCE_DIR
 RUN /bin/bash -c 'source $HOME/.bashrc && mvn dependency:go-offline surefire:test -ntp'
 
 # Pre-build boringssl
-RUN /bin/bash -c 'source $HOME/.bashrc && mvn antrun:run@build-boringssl -DquicheCheckoutDir=$SOURCE_DIR/boringssl'
+RUN /bin/bash -c 'source $HOME/.bashrc && mvn antrun:run@build-boringssl -DboringsslSourceDir=$SOURCE_DIR/boringssl'
 
 # Pre-build quiche
 RUN /bin/bash -c 'source $HOME/.bashrc && mvn antrun:run@build-quiche -DquicheCheckoutDir=$SOURCE_DIR/quiche'


### PR DESCRIPTION
Motivation:

Due some copy and paste error we didn't correctly re-use the precompiled version of BoringSSL

Modifications:

Fix variable name

Result:

Correctly pre-compile and use the pre-compiled version of BoringSSL