### PR TITLE
use --no-default-features when compiling quiche

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,7 @@
                     <then>
                       <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
                         <arg value="build" />
+                        <arg value="--no-default-features" />
                         <arg value="--features" />
                         <arg value="ffi" />
                         <arg value="--release" />
@@ -366,10 +367,11 @@
                     <else>
                       <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
                         <arg value="build" />
+                        <arg value="--no-default-features" />
                         <arg value="--features" />
                         <arg value="ffi" />
                         <arg value="--release" />
-                        <env key="CFLAGS" value="-O3 -fno-omit-frame-pointer -DOPENSSL_C11_ATOMIC" />
+                        <env key="CFLAGS" value="-O3 -fno-omit-frame-pointer" />
                         <env key="CXXFLAGS" value="-O3 -fno-omit-frame-pointer" />
                       </exec>
                     </else>


### PR DESCRIPTION
Motivation:

Let's use --no-default-features when compiling quiche to ensure we only enable what we really want. Thats also what quiche is doing in their nginx patch.

Modifications:

- Add --no-default-features
- Remove flags that are not needed anymore as we compile boringssl by ourselves

Result:

Build cleanup