### PR TITLE
Only compile ssl and crypto targets when building BoringSSL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,12 +285,16 @@
                     <!-- See https://github.com/netty/netty-tcnative/issues/475 -->
                     <available file="ninja-build" filepath="${env.PATH}" />
                     <then>
-                      <exec executable="ninja-build" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" />
+                      <property name="ninjaExecutable" value="ninja-build" />
                     </then>
                     <else>
-                      <exec executable="ninja" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" />
+                      <property name="ninjaExecutable" value="ninja" />
                     </else>
                   </if>
+                  <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" >
+                    <arg value="crypto" />
+                    <arg value="ssl" />
+                  </exec>
 
                   <!-- Only copy the libs and header files we need -->
                   <mkdir dir="${boringsslHomeDir}/build" />


### PR DESCRIPTION
Motivation:

We only need to build the ssl and crypto targets

Modifications:

- Add args to ninja to only build what we need

Result:

Faster builds