### PR TITLE
Force the usage of ipv4 for yum

### DIFF
--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -10,6 +10,7 @@ ENV GO_VERSION 1.9.3
 # Update as we need to use the vault now.
 RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever\//baseurl=http:\/\/vault.centos.org\/6.10\//g' /etc/yum.repos.d/CentOS-Base.repo
 
+RUN echo 'ip_resolve=4' >> /etc/yum.conf
 # We want to have git 2.x for the maven scm plugin
 RUN yum install -y http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm
 


### PR DESCRIPTION
Motivation:

We did see failures often when yum tried to use ipv6, lets force it to use ipv4

Modifications:

Configure yum to use ipv4

Result:

Hopefully more stable builds