### PR TITLE
Add clone() method to codec builders

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
@@ -32,6 +32,15 @@ public final class QuicClientCodecBuilder extends QuicCodecBuilder<QuicClientCod
         super(false);
     }
 
+    private QuicClientCodecBuilder(QuicCodecBuilder<QuicClientCodecBuilder> builder) {
+        super(builder);
+    }
+
+    @Override
+    public QuicClientCodecBuilder clone() {
+        return new QuicClientCodecBuilder(this);
+    }
+
     @Override
     protected ChannelHandler build(QuicheConfig config,
                                    Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider,

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -49,9 +49,33 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     private QuicCongestionControlAlgorithm congestionControlAlgorithm;
     private int localConnIdLength = Quiche.QUICHE_MAX_CONN_ID_LEN;
     private Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider;
+
     QuicCodecBuilder(boolean server) {
         Quic.ensureAvailability();
         this.server = server;
+    }
+
+    QuicCodecBuilder(QuicCodecBuilder<B> builder) {
+        Quic.ensureAvailability();
+        this.server = builder.server;
+        this.grease = builder.grease;
+        this.earlyData = builder.earlyData;
+        this.maxIdleTimeout = builder.maxIdleTimeout;
+        this.maxRecvUdpPayloadSize = builder.maxRecvUdpPayloadSize;
+        this.maxSendUdpPayloadSize = builder.maxSendUdpPayloadSize;
+        this.initialMaxData = builder.initialMaxData;
+        this.initialMaxStreamDataBidiLocal = builder.initialMaxStreamDataBidiLocal;
+        this.initialMaxStreamDataBidiRemote = builder.initialMaxStreamDataBidiRemote;
+        this.initialMaxStreamDataUni = builder.initialMaxStreamDataUni;
+        this.initialMaxStreamsBidi = builder.initialMaxStreamsBidi;
+        this.initialMaxStreamsUni = builder.initialMaxStreamsUni;
+        this.ackDelayExponent = builder.ackDelayExponent;
+        this.maxAckDelay = builder.maxAckDelay;
+        this.disableActiveMigration = builder.disableActiveMigration;
+        this.enableHystart = builder.enableHystart;
+        this.congestionControlAlgorithm = builder.congestionControlAlgorithm;
+        this.localConnIdLength = builder.localConnIdLength;
+        this.sslEngineProvider = builder.sslEngineProvider;
     }
 
     /**
@@ -389,6 +413,13 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
             throw cause;
         }
     }
+
+    /**
+     * Clone the builder
+     *
+     * @return the new instance that is a clone if this instance.
+     */
+    public abstract B clone();
 
     /**
      * Builds the QUIC codec.

--- a/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -48,6 +48,23 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
         super(true);
     }
 
+    private QuicServerCodecBuilder(QuicServerCodecBuilder builder) {
+        super(builder);
+        options.putAll(builder.options);
+        attrs.putAll(builder.attrs);
+        streamOptions.putAll(builder.streamOptions);
+        streamAttrs.putAll(builder.streamAttrs);
+        handler = builder.handler;
+        streamHandler = builder.streamHandler;
+        connectionIdAddressGenerator = builder.connectionIdAddressGenerator;
+        tokenHandler = builder.tokenHandler;
+    }
+
+    @Override
+    public QuicServerCodecBuilder clone() {
+        return new QuicServerCodecBuilder(this);
+    }
+
     /**
      * Allow to specify a {@link ChannelOption} which is used for the {@link QuicChannel} instances once they got
      * created. Use a value of {@code null} to remove a previous set {@link ChannelOption}.


### PR DESCRIPTION
Motivation:

It is useful to be able to clone the codec builder.

Modifications:

Add clone method for both codec builders

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/150