### PR TITLE
Publish test results after PR run

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-linux-x86_64:
     runs-on: ubuntu-latest
-    name: linux-x86_64 build
+    name: linux-x86_64
     steps:
       - uses: actions/checkout@v2
 
@@ -34,13 +34,6 @@ jobs:
       - name: Checking for test failures
         run: ./.github/scripts/check_build_result.sh build.output
 
-      - name: Upload Test Results
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-results-pr-linux-x86_64
-          path: '**/target/surefire-reports/TEST-*.xml'
-
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
@@ -49,7 +42,7 @@ jobs:
 
   build-windows:
     runs-on: windows-2016
-    name: windows-x86_64 build
+    name: windows-x86_64
     steps:
       - uses: actions/checkout@v2
 
@@ -92,13 +85,6 @@ jobs:
 
       - name: Build project
         run: mvn --file pom.xml clean package
-
-      - name: Upload Test Results
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-results-pr-windows-x86_64
-          path: '**/target/surefire-reports/TEST-*.xml'
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-linux-x86_64:
     runs-on: ubuntu-latest
-    name: linux-x86_64
+    name: linux-x86_64 build
     steps:
       - uses: actions/checkout@v2
 
@@ -34,6 +34,13 @@ jobs:
       - name: Checking for test failures
         run: ./.github/scripts/check_build_result.sh build.output
 
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-pr-linux-x86_64
+          path: '**/target/surefire-reports/TEST-*.xml'
+
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
@@ -42,7 +49,7 @@ jobs:
 
   build-windows:
     runs-on: windows-2016
-    name: windows-x86_64
+    name: windows-x86_64 build
     steps:
       - uses: actions/checkout@v2
 
@@ -85,6 +92,13 @@ jobs:
 
       - name: Build project
         run: mvn --file pom.xml clean package
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-pr-windows-x86_64
+          path: '**/target/surefire-reports/TEST-*.xml'
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}

--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -1,0 +1,44 @@
+name: PR Reports
+on:
+  workflow_run:
+    workflows: [ "Build PR" ]
+    types:
+      - completed
+jobs:
+  tests-linux-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Artifacts
+        uses: dawidd6/action-download-artifact@v2.11.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          # File location set in ci-pr.yml and must be coordinated.
+          name: test-results-pr-linux-x86_64
+      - name: Publish Test Report
+        uses: scacap/action-surefire-report@v1.0.7
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: '**/target/surefire-reports/TEST-*.xml'
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          check_name: linux-x86_64 test results
+
+  tests-windows-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Artifacts
+        uses: dawidd6/action-download-artifact@v2.11.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          # File location set in ci-pr.yml and must be coordinated.
+          name: test-results-pr-windows-x86_64
+      - name: Publish Test Report
+        uses: scacap/action-surefire-report@v1.0.7
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: '**/target/surefire-reports/TEST-*.xml'
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          check_name: windows-x86_64 test results

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-linux-x86_64:
     runs-on: ubuntu-latest
-    name: linux-x86_64
+    name: linux-x86_64 build
     steps:
       - uses: actions/checkout@v2
 
@@ -34,6 +34,13 @@ jobs:
       - name: Checking for detected leak
         run: ./.github/scripts/check_leak.sh build-leak.output
 
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-pr-linux-x86_64
+          path: '**/target/surefire-reports/TEST-*.xml'
+
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
@@ -42,7 +49,7 @@ jobs:
 
   build-pr-windows:
     runs-on: windows-2016
-    name: windows-x86_64
+    name: windows-x86_64 build
     steps:
       - uses: actions/checkout@v2
 
@@ -85,6 +92,13 @@ jobs:
 
       - name: Build project
         run: mvn --file pom.xml clean package
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-pr-windows-x86_64
+          path: '**/target/surefire-reports/TEST-*.xml'
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}


### PR DESCRIPTION
Motivation:

To make it easier to understand why a build failed let us publish the rest results

Modifications:

Use a new workflow to be able to publish the test reports

Result:

Easier to understand why a PR did fail