### PR TITLE
Update to latest netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
     <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
     <skipTests>false</skipTests>
-    <netty.version>4.1.59.Final-SNAPSHOT</netty.version>
+    <netty.version>4.1.59.Final</netty.version>
     <netty.build.version>28</netty.build.version>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <jniLibName>netty_quiche_${os.detected.name}_${os.detected.arch}</jniLibName>


### PR DESCRIPTION
Motivation:

A new netty version was released, we can remove our SNAPSHOT dependency.

Modifications:

Update to 4.1.59.Final

Result:

Don't depend on a snapshot version