### PR TITLE
Add script to finish release

### DIFF
--- a/scripts/finish_release.sh
+++ b/scripts/finish_release.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Expected staging profile id and tag, login into oss.sonatype.org to retrieve it"
+    exit 1
+fi
+
+OS=$(uname)
+
+if [ "$OS" != "Darwin" ]; then
+    echo "Needs to be executed on macOS"
+    exit 1
+fi
+
+BRANCH=$(git branch --show-current)
+
+git fetch
+git checkout "$2"
+
+export JAVA_HOME="$JAVA8_HOME"
+
+./mvnw -Psonatype-oss-release clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
+
+git checkout "$BRANCH"


### PR DESCRIPTION
Motivation:

After the release workflow was done we need to run some extra commands.

Modifications:

Add a script to run

Result:

Easier to do a release