### PR TITLE
Add more details to SSLHandshakeException

### DIFF
--- a/src/main/c/netty_quic_boringssl.c
+++ b/src/main/c/netty_quic_boringssl.c
@@ -32,6 +32,8 @@
 #define STATICALLY_CLASSNAME "io/netty/incubator/codec/quic/BoringSSLNativeStaticallyReferencedJniMethods"
 #define CLASSNAME "io/netty/incubator/codec/quic/BoringSSL"
 
+#define ERR_LEN 256
+
 static jclass verifyCallbackClass = NULL;
 static jmethodID verifyCallbackMethod = NULL;
 
@@ -699,6 +701,17 @@ void netty_boringssl_CRYPTO_BUFFER_stack_free(JNIEnv* env, jclass clazz, jlong c
     sk_CRYPTO_BUFFER_pop_free((STACK_OF(CRYPTO_BUFFER) *) chain, CRYPTO_BUFFER_free);
 }
 
+jstring netty_boringssl_ERR_last_error(JNIEnv* env, jclass clazz) {
+    char buf[ERR_LEN];
+    unsigned long err = ERR_get_error();
+    if (err == 0) {
+        return NULL;
+    }
+    ERR_error_string_n(err, buf, ERR_LEN);
+    return (*env)->NewStringUTF(env, buf);
+}
+
+
 // JNI Registered Methods End
 
 // JNI Method Registration Table Begin
@@ -724,7 +737,8 @@ static const JNINativeMethod fixed_method_table[] = {
   { "EVP_PKEY_parse", "([BLjava/lang/String;)J", (void *) netty_boringssl_EVP_PKEY_parse },
   { "EVP_PKEY_free", "(J)V", (void *) netty_boringssl_EVP_PKEY_free },
   { "CRYPTO_BUFFER_stack_new", "(J[[B)J", (void *) netty_boringssl_CRYPTO_BUFFER_stack_new },
-  { "CRYPTO_BUFFER_stack_free", "(J)V", (void *) netty_boringssl_CRYPTO_BUFFER_stack_free }
+  { "CRYPTO_BUFFER_stack_free", "(J)V", (void *) netty_boringssl_CRYPTO_BUFFER_stack_free },
+  { "ERR_last_error", "()Ljava/lang/String;", (void *) netty_boringssl_ERR_last_error }
 };
 
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);

--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSL.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSL.java
@@ -82,6 +82,8 @@ final class BoringSSL {
     static native long CRYPTO_BUFFER_stack_new(long ssl, byte[][] bytes);
     static native void CRYPTO_BUFFER_stack_free(long chain);
 
+    static native String ERR_last_error();
+
     private static String tlsExtHostName(String hostname) {
         if (hostname != null && hostname.endsWith(".")) {
             // Strip trailing dot if included.


### PR DESCRIPTION
Motivation:

At the moment we dont provide a lot of details in the SSLHandshakeException which makes it hard to understand why a handshake fails.

Modifications:

- Add native method which will peek into the error queue and provide more details if possible
- Use these details when constructing the exception message

Result:

Easier to debug SSLHandshakeException causes