### PR TITLE
Configuration of early data belongs to the QuicSslContextBuilder

### DIFF
--- a/src/main/c/netty_quic_boringssl.c
+++ b/src/main/c/netty_quic_boringssl.c
@@ -620,6 +620,10 @@ static jlong netty_boringssl_SSLContext_setSessionCacheSize(JNIEnv* env, jclass 
     return 0;
 }
 
+static void netty_boringssl_SSLContext_set_early_data_enabled(JNIEnv* env, jclass clazz, jlong ctx, jboolean enabled){
+    SSL_CTX_set_early_data_enabled((SSL_CTX*) ctx, enabled == JNI_TRUE ? 1 : 0);
+}
+
 jlong netty_boringssl_SSL_new0(JNIEnv* env, jclass clazz, jlong ctx, jboolean server, jstring hostname) {
     SSL* ssl = SSL_new((SSL_CTX*) ctx);
 
@@ -732,6 +736,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "SSLContext_free", "(J)V", (void *) netty_boringssl_SSLContext_free },
   { "SSLContext_setSessionCacheTimeout", "(JJ)J", (void *) netty_boringssl_SSLContext_setSessionCacheTimeout },
   { "SSLContext_setSessionCacheSize", "(JJ)J", (void *) netty_boringssl_SSLContext_setSessionCacheSize },
+  { "SSLContext_set_early_data_enabled", "(JZ)V", (void *) netty_boringssl_SSLContext_set_early_data_enabled },
   { "SSL_new0", "(JZLjava/lang/String;)J", (void *) netty_boringssl_SSL_new0 },
   { "SSL_free", "(J)V", (void *) netty_boringssl_SSL_free },
   { "EVP_PKEY_parse", "([BLjava/lang/String;)J", (void *) netty_boringssl_EVP_PKEY_parse },

--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -324,10 +324,6 @@ static void netty_quiche_config_grease(JNIEnv* env, jclass clazz, jlong config, 
     quiche_config_grease((quiche_config*) config, value == JNI_TRUE ? true : false);
 }
 
-static void netty_quiche_config_enable_early_data(JNIEnv* env, jclass clazz, jlong config) {
-    quiche_config_enable_early_data((quiche_config*) config);
-}
-
 static void netty_quiche_config_set_max_idle_timeout(JNIEnv* env, jclass clazz, jlong config, jlong value) {
     quiche_config_set_max_idle_timeout((quiche_config*) config, (uint64_t) value);
 }
@@ -479,7 +475,6 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_config_new", "(I)J", (void *) netty_quiche_config_new },
   { "quiche_config_enable_dgram", "(JZII)V", (void *) netty_quiche_config_enable_dgram },
   { "quiche_config_grease", "(JZ)V", (void *) netty_quiche_config_grease },
-  { "quiche_config_enable_early_data", "(J)V", (void *) netty_quiche_config_enable_early_data },
   { "quiche_config_set_max_idle_timeout", "(JJ)V", (void *) netty_quiche_config_set_max_idle_timeout },
   { "quiche_config_set_max_recv_udp_payload_size", "(JJ)V", (void *) netty_quiche_config_set_max_recv_udp_payload_size },
   { "quiche_config_set_max_send_udp_payload_size", "(JJ)V", (void *) netty_quiche_config_set_max_send_udp_payload_size },

--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSL.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSL.java
@@ -68,6 +68,7 @@ final class BoringSSL {
                                                byte[] applicationProtocols, Object handshakeCompleteCallback,
                                                Object certificateCallback, Object verifyCallback, int verifyDepth,
                                                byte[][] subjectNames);
+    static native void SSLContext_set_early_data_enabled(long context, boolean enabled);
     static native long SSLContext_setSessionCacheSize(long context, long size);
     static native long SSLContext_setSessionCacheTimeout(long context, long size);
     static native void SSLContext_free(long context);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -32,7 +32,6 @@ import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     private final boolean server;
     private Boolean grease;
-    private boolean earlyData;
     private Long maxIdleTimeout;
     private Long maxRecvUdpPayloadSize;
     private Long maxSendUdpPayloadSize;
@@ -59,7 +58,6 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
         Quic.ensureAvailability();
         this.server = builder.server;
         this.grease = builder.grease;
-        this.earlyData = builder.earlyData;
         this.maxIdleTimeout = builder.maxIdleTimeout;
         this.maxRecvUdpPayloadSize = builder.maxRecvUdpPayloadSize;
         this.maxSendUdpPayloadSize = builder.maxSendUdpPayloadSize;
@@ -112,17 +110,6 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      */
     public final B grease(boolean enable) {
         grease = enable;
-        return self();
-    }
-
-    /**
-     * Enable the support of early data.
-     *
-     * @param enable {@code true} if enabled, {@code false} otherwise
-     * @return the instance itself.
-     */
-    public final B earlyData(boolean enable) {
-        earlyData = enable;
         return self();
     }
 
@@ -380,7 +367,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     }
 
     private QuicheConfig createConfig() {
-        return new QuicheConfig(grease, earlyData,
+        return new QuicheConfig(grease,
                 maxIdleTimeout, maxSendUdpPayloadSize, maxRecvUdpPayloadSize, initialMaxData,
                 initialMaxStreamDataBidiLocal, initialMaxStreamDataBidiRemote,
                 initialMaxStreamDataUni, initialMaxStreamsBidi, initialMaxStreamsUni,

--- a/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
@@ -101,9 +101,18 @@ public final class QuicSslContextBuilder {
     private long sessionTimeout = 300;
     private ClientAuth clientAuth = ClientAuth.NONE;
     private String[] applicationProtocols;
+    private Boolean earlyData;
 
     private QuicSslContextBuilder(boolean forServer) {
         this.forServer = forServer;
+    }
+
+    /**
+     * Enable / disable the usage of early data.
+     */
+    public QuicSslContextBuilder earlyData(boolean enabled) {
+        this.earlyData = enabled;
+        return this;
     }
 
     /**
@@ -260,10 +269,10 @@ public final class QuicSslContextBuilder {
     public QuicSslContext build() {
         if (forServer) {
             return new QuicheQuicSslContext(true, sessionCacheSize, sessionTimeout, clientAuth,
-                    trustManagerFactory, keyManagerFactory, keyPassword, applicationProtocols);
+                    trustManagerFactory, keyManagerFactory, keyPassword, earlyData, applicationProtocols);
         } else {
             return new QuicheQuicSslContext(false, sessionCacheSize, sessionTimeout, clientAuth,
-                    trustManagerFactory, keyManagerFactory, keyPassword, applicationProtocols);
+                    trustManagerFactory, keyManagerFactory, keyPassword, earlyData, applicationProtocols);
         }
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -376,13 +376,6 @@ final class Quiche {
 
     /**
      * See
-     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#135">
-     *     quiche_config_enable_early_data</a>.
-     */
-    static native void quiche_config_enable_early_data(long configAddr);
-
-    /**
-     * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#143">
      *     quiche_config_set_max_idle_timeout</a>.
      */

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
@@ -19,7 +19,7 @@ final class QuicheConfig {
     private final boolean isDatagramSupported;
     private final long config;
 
-    QuicheConfig(Boolean grease, boolean earlyData, Long maxIdleTimeout, Long maxSendUdpPayloadSize,
+    QuicheConfig(Boolean grease, Long maxIdleTimeout, Long maxSendUdpPayloadSize,
                         Long maxRecvUdpPayloadSize, Long initialMaxData,
                         Long initialMaxStreamDataBidiLocal, Long initialMaxStreamDataBidiRemote,
                         Long initialMaxStreamDataUni, Long initialMaxStreamsBidi, Long initialMaxStreamsUni,
@@ -30,9 +30,6 @@ final class QuicheConfig {
         try {
             if (grease != null) {
                 Quiche.quiche_config_grease(config, grease);
-            }
-            if (earlyData) {
-                Quiche.quiche_config_enable_early_data(config);
             }
             if (maxIdleTimeout != null) {
                 Quiche.quiche_config_set_max_idle_timeout(config, maxIdleTimeout);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
@@ -63,6 +63,7 @@ final class QuicheQuicSslContext extends QuicSslContext {
     QuicheQuicSslContext(boolean server, long sessionTimeout, long sessionCacheSize,
                          ClientAuth clientAuth, TrustManagerFactory trustManagerFactory,
                          KeyManagerFactory keyManagerFactory, String password,
+                         Boolean earlyData,
                          String... applicationProtocols) {
         Quic.ensureAvailability();
         this.server = server;
@@ -97,6 +98,9 @@ final class QuicheQuicSslContext extends QuicSslContext {
         apn = new QuicheQuicApplicationProtocolNegotiator(applicationProtocols);
         this.sessionCacheSize = BoringSSL.SSLContext_setSessionCacheSize(ctx, sessionCacheSize);
         this.sessionTimeout = BoringSSL.SSLContext_setSessionCacheTimeout(ctx, sessionTimeout);
+        if (earlyData != null) {
+            BoringSSL.SSLContext_set_early_data_enabled(ctx, earlyData);
+        }
         sessionCtx = new QuicheQuicSslSessionContext(this);
     }
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
@@ -84,8 +84,7 @@ final class QuicTestUtils {
                 .initialMaxStreamsBidirectional(100)
                 .initialMaxStreamsUnidirectional(100)
                 .initialMaxStreamDataUnidirectional(1000000)
-                .activeMigration(false)
-                .earlyData(true);
+                .activeMigration(false);
     }
 
     static QuicServerCodecBuilder newQuicServerBuilder() {


### PR DESCRIPTION
Motivation:

We should move the configuration of early data to the QuicSslContextBuilder

Modifications:

Move the early data configuration to the ssl context builder

Result:

Early data works