### PR TITLE
Return early if an unsupported QUIC version was detected

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -119,10 +119,10 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
             if (res < 0) {
                 out.release();
                 Quiche.throwIfError(res);
-                return null;
+            } else {
+                ctx.writeAndFlush(new DatagramPacket(out.writerIndex(outWriterIndex + res), sender));
             }
-
-            ctx.writeAndFlush(new DatagramPacket(out.writerIndex(outWriterIndex + res), sender));
+            return null;
         }
 
         final int offset;


### PR DESCRIPTION
Motivation:

We should return early if a unsupported QUIC version was detected and not create a QuicChannel in this case

Modifications:

Add missing return statement

Result:

Don't create QuicChannel for unsupported QUIC versions