### PR TITLE
    Ensure we never leak direct memory by adding finalize

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.util.ReferenceCounted;
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.ResourceLeakDetectorFactory;
+import io.netty.util.ResourceLeakTracker;
+
+final class QuicheQuicConnection {
+    private static final ResourceLeakDetector<QuicheQuicConnection> LEAK_DETECTOR =
+            ResourceLeakDetectorFactory.instance().newResourceLeakDetector(QuicheQuicConnection.class);
+    private long connection;
+    private final ReferenceCounted refCnt;
+    private final ResourceLeakTracker<QuicheQuicConnection> tracker;
+
+    QuicheQuicConnection(long connection, ReferenceCounted refCnt) {
+        this.connection = connection;
+        this.refCnt = refCnt;
+        tracker = LEAK_DETECTOR.track(this);
+    }
+
+    // This should not need to be synchronized as it will either be called from the EventLoop thread or
+    // the finalizer (in which case there can't be concurrent access here).
+    void free() {
+        if (connection != -1) {
+            try {
+                Quiche.quiche_conn_free(connection);
+                refCnt.release();
+                if (tracker != null) {
+                    tracker.close(this);
+                }
+            } finally {
+                connection = -1;
+            }
+        }
+    }
+
+    long address() {
+        assert connection != -1;
+        return connection;
+    }
+
+    boolean isClosed() {
+        assert connection != -1;
+        return Quiche.quiche_conn_is_closed(connection);
+    }
+
+    // Let's override finalize() as we want to ensure we never leak memory even if the user will miss to close
+    // Channel that uses this connection and just let it get GC'ed
+    @Override
+    protected void finalize() throws Throwable {
+        try {
+            free();
+        } finally {
+            super.finalize();
+        }
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -210,15 +210,16 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         }
 
         QuicheQuicSslEngine quicSslEngine = (QuicheQuicSslEngine) engine;
-        conn = Quiche.quiche_conn_new_with_tls(scidAddr, scidLen, ocidAddr, ocidLen,
-                config.nativeAddress(), quicSslEngine.createNative(), true);
-        if (conn < 0) {
+        QuicheQuicConnection connection = quicSslEngine.createConnection(ssl ->
+                Quiche.quiche_conn_new_with_tls(scidAddr, scidLen, ocidAddr, ocidLen,
+                        config.nativeAddress(), ssl, true));
+        if (connection  == null) {
             channel.unsafe().closeForcibly();
             LOGGER.debug("quiche_accept failed");
             return null;
         }
 
-        channel.attach(conn, quicSslEngine);
+        channel.attach(connection);
 
         putChannel(channel);
         ctx.channel().eventLoop().register(channel);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.LongFunction;
 
 final class QuicheQuicSslEngine extends QuicSslEngine {
     private final QuicheQuicSslContext ctx;
@@ -49,7 +50,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
     private List<SNIServerName> sniHostNames;
     private boolean handshakeFinished;
     private String applicationProtocol;
-    private final String tlsHostName;
+    final String tlsHostName;
 
     QuicheQuicSslEngine(QuicheQuicSslContext ctx, String peerHost, int peerPort) {
         this.ctx = ctx;
@@ -65,8 +66,8 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
         }
     }
 
-    long createNative() {
-        return ctx.newSSL(this, tlsHostName);
+    QuicheQuicConnection createConnection(LongFunction<Long> connectionCreator) {
+        return ctx.createConnection(connectionCreator, this);
     }
 
     void setLocalCertificateChain(Certificate[] localCertificateChain) {


### PR DESCRIPTION
Motivation:

We should ensure we never leak memory by fallback free ressourced via finalize if the user did not explict close things.

Modifications:

- Add finalize() in QuicheConfig
- Add extra class which holds the native connection and also add finalize() here
- Add leak detection as well

Result:

Never leak direct memory used by quiche