### PR TITLE
Override the flush() and read() methods to return the correct Channel…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -28,6 +28,12 @@ import io.netty.util.concurrent.Promise;
  */
 public interface QuicChannel extends Channel {
 
+    @Override
+    QuicChannel read();
+
+    @Override
+    QuicChannel flush();
+
     /**
      * Returns the configuration of this channel.
      */

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
@@ -15,6 +15,7 @@
  */
 package io.netty.incubator.codec.quic;
 
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPromise;
@@ -89,6 +90,12 @@ public interface QuicStreamChannel extends DuplexChannel {
 
     @Override
     QuicChannel parent();
+
+    @Override
+    QuicStreamChannel read();
+
+    @Override
+    QuicStreamChannel flush();
 
     @Override
     QuicStreamChannelConfig config();

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -322,6 +322,18 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     @Override
+    public QuicChannel flush() {
+        super.flush();
+        return this;
+    }
+
+    @Override
+    public QuicChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
     public Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler,
                                                   Promise<QuicStreamChannel> promise) {
         if (eventLoop().inEventLoop()) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -360,6 +360,18 @@ final class QuicheQuicStreamChannel extends AbstractChannel implements QuicStrea
     }
 
     @Override
+    public QuicStreamChannel flush() {
+        super.flush();
+        return this;
+    }
+
+    @Override
+    public QuicStreamChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
     public QuicStreamChannelConfig config() {
         return config;
     }


### PR DESCRIPTION
… subtype

Motivation:

We should override the flush / read method so we return the correct sub-type for method chaining.

Modifications:

Add missing overrides and implementations

Result:

Be able to correctly method chain