### PR TITLE
Re-enable CRYPTO_BUFFER_POOL usage

### DIFF
--- a/src/main/c/netty_quic_boringssl.c
+++ b/src/main/c/netty_quic_boringssl.c
@@ -546,8 +546,8 @@ static jlong netty_boringssl_SSLContext_new0(JNIEnv* env, jclass clazz, jboolean
     SSL_CTX_set_ex_data(ctx, certificateCallbackIdx, certificateCallbackRef);
     SSL_CTX_set_cert_cb(ctx, quic_certificate_cb, certificateCallbackRef);
 
-    // Disable the usage of the pool for now.
-    //SSL_CTX_set_ex_data(ctx, crypto_buffer_pool_idx, CRYPTO_BUFFER_POOL_new());
+    // Use a pool for our certificates so we can share these across connections.
+    SSL_CTX_set_ex_data(ctx, crypto_buffer_pool_idx, CRYPTO_BUFFER_POOL_new());
 
     STACK_OF(CRYPTO_BUFFER) *names = arrayToStack(env, subjectNames, NULL);
     if (names != NULL) {


### PR DESCRIPTION
Motivation:

Now that we fixed the free'ing of native resources in all cases we can re-enable the CRYPTO_BUFFER_POOL.
The free'ing of native resources was fixed by https://github.com/netty/netty-incubator-codec-quic/pull/191.

Modifications:

Re-enable CRYPTO_BUFFER_POOL

Result:

Share memory