### PR TITLE
Don't use LeakDetector when finalizer is used

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
@@ -16,21 +16,14 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.util.ReferenceCounted;
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakDetectorFactory;
-import io.netty.util.ResourceLeakTracker;
 
 final class QuicheQuicConnection {
-    private static final ResourceLeakDetector<QuicheQuicConnection> LEAK_DETECTOR =
-            ResourceLeakDetectorFactory.instance().newResourceLeakDetector(QuicheQuicConnection.class);
-    private long connection;
     private final ReferenceCounted refCnt;
-    private final ResourceLeakTracker<QuicheQuicConnection> tracker;
+    private long connection;
 
     QuicheQuicConnection(long connection, ReferenceCounted refCnt) {
         this.connection = connection;
         this.refCnt = refCnt;
-        tracker = LEAK_DETECTOR.track(this);
     }
 
     // This should not need to be synchronized as it will either be called from the EventLoop thread or
@@ -40,9 +33,6 @@ final class QuicheQuicConnection {
             try {
                 Quiche.quiche_conn_free(connection);
                 refCnt.release();
-                if (tracker != null) {
-                    tracker.close(this);
-                }
             } finally {
                 connection = -1;
             }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
@@ -21,9 +21,6 @@ import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCounted;
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakDetectorFactory;
-import io.netty.util.ResourceLeakTracker;
 
 import javax.crypto.NoSuchPaddingException;
 import javax.net.ssl.KeyManager;
@@ -332,15 +329,10 @@ final class QuicheQuicSslContext extends QuicSslContext {
     }
 
     private static final class NativeSslContext extends AbstractReferenceCounted {
-        private static final ResourceLeakDetector<NativeSslContext> LEAK_DETECTOR =
-                ResourceLeakDetectorFactory.instance().newResourceLeakDetector(NativeSslContext.class);
-
         private final long ctx;
-        private final ResourceLeakTracker<NativeSslContext> tracker;
 
         NativeSslContext(long ctx) {
             this.ctx = ctx;
-            tracker = LEAK_DETECTOR.track(this);
         }
 
         long address() {
@@ -350,9 +342,6 @@ final class QuicheQuicSslContext extends QuicSslContext {
         @Override
         protected void deallocate() {
             BoringSSL.SSLContext_free(ctx);
-            if (tracker != null) {
-                tracker.close(this);
-            }
         }
 
         @Override


### PR DESCRIPTION
Motivation:

The LeakDector may show false positives when the finalizer is used as an object may be enqueued while its finalizer run

Modifications:

Remove usage of LeakDetector

Result:

No false positives