### PR TITLE
Remove QuicChannelOption that is not used anymore

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/DefaultQuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/DefaultQuicChannelConfig.java
@@ -15,11 +15,8 @@
  */
 package io.netty.incubator.codec.quic;
 
-import java.util.Map;
-
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
@@ -32,11 +29,6 @@ final class DefaultQuicChannelConfig extends DefaultChannelConfig implements Qui
 
     DefaultQuicChannelConfig(Channel channel) {
         super(channel);
-    }
-
-    @Override
-    public Map<ChannelOption<?>, Object> getOptions() {
-        return getOptions(super.getOptions(), QuicChannelOption.PEER_CERT_SERVER_NAME);
     }
 
     @Override

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelOption.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelOption.java
@@ -23,13 +23,6 @@ import io.netty.channel.ChannelOption;
 public final class QuicChannelOption<T> extends ChannelOption<T> {
 
     /**
-     * Optional parameter to verify peer's certificate.
-     * See <a href="https://docs.rs/quiche/0.6.0/quiche/fn.connect.html">server_name</a>.
-     */
-    public static final ChannelOption<String> PEER_CERT_SERVER_NAME =
-        valueOf(QuicChannelOption.class, "PEER_CERT_SERVER_NAME");
-
-    /**
      * If set to {@code true} the {@link QuicStreamChannel} will read {@link QuicStreamFrame}s and fire it through
      * the pipeline, if {@code false} it will read {@link io.netty.buffer.ByteBuf} and translate the FIN flag to
      * events.


### PR DESCRIPTION
Motivation:

Peer verification is now configured as part of the QuicSslContextBuilder. Remove the unused QuicChannelOption.

Modifications:

- Remove unused QuicChannelOption

Result:

Code cleanup