### PR TITLE
Add support for qlog

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -397,10 +397,7 @@
                     <equals arg1="${os.detected.name}" arg2="windows" />
                     <then>
                       <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                        <arg value="build" />
-                        <arg value="--features" />
-                        <arg value="ffi" />
-                        <arg value="--release" />
+                        <arg line='build --features "ffi qlog" --release' />
                         <arg value="${cargoTarget}" />
                         <!-- See https://github.com/cloudflare/quiche/blob/0.7.0/src/build.rs#L73 -->
                         <env key="DEBUG" value="true" />
@@ -410,10 +407,7 @@
                    </then>
                     <else>
                       <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                        <arg value="build" />
-                        <arg value="--features" />
-                        <arg value="ffi" />
-                        <arg value="--release" />
+                        <arg line='build --features "ffi qlog" --release' />
                         <env key="CFLAGS" value="${extraCflags}" />
                         <env key="CXXFLAGS" value="${extraCxxflags}" />
                         <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />

--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -134,6 +134,20 @@ static jboolean netty_quiche_version_is_supported(JNIEnv* env, jclass clazz, jin
     return quiche_version_is_supported(version) == true ? JNI_TRUE : JNI_FALSE;
 }
 
+static jboolean netty_quiche_conn_set_qlog_path(JNIEnv* env, jclass clazz, jlong conn, jstring path,
+                          jstring log_title, jstring log_desc) {
+    const char *nativePath = (*env)->GetStringUTFChars(env, path, 0);
+    const char *nativeLogTitle = (*env)->GetStringUTFChars(env, log_title, 0);
+    const char *nativeLogDesc = (*env)->GetStringUTFChars(env, log_desc, 0);
+    bool ret = quiche_conn_set_qlog_path((quiche_conn *) conn, nativePath,
+                          nativeLogTitle, nativeLogDesc);
+    (*env)->ReleaseStringUTFChars(env, path, nativePath);
+    (*env)->ReleaseStringUTFChars(env, log_title, nativeLogTitle);
+    (*env)->ReleaseStringUTFChars(env, log_desc, nativeLogDesc);
+
+    return ret == true ? JNI_TRUE : JNI_FALSE;
+}
+
 static jint netty_quiche_header_info(JNIEnv* env, jclass clazz, jlong buf, jint buf_len, jint dcil, jlong version,
                  jlong type, jlong scid, jlong scid_len, jlong dcid, jlong dcid_len, jlong token, jlong token_len) {
     return (jint) quiche_header_info((const uint8_t *) buf, (size_t) buf_len, (size_t) dcil,
@@ -452,6 +466,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_header_info", "(JIIJJJJJJJJ)I", (void *) netty_quiche_header_info },
   { "quiche_negotiate_version", "(JIJIJI)I", (void *) netty_quiche_negotiate_version },
   { "quiche_retry", "(JIJIJIJIIJI)I", (void *) netty_quiche_retry },
+  { "quiche_conn_set_qlog_path", "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z", (void *) netty_quiche_conn_set_qlog_path },
   { "quiche_conn_trace_id", "(J)[B", (void *) netty_quiche_conn_trace_id },
   { "quiche_conn_new_with_tls", "(JIJIJJZ)J", (void *) netty_quiche_conn_new_with_tls },
   { "quiche_conn_recv", "(JJI)I", (void *) netty_quiche_conn_recv },

--- a/src/main/java/io/netty/incubator/codec/quic/QLogConfiguration.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QLogConfiguration.java
@@ -17,26 +17,52 @@ package io.netty.incubator.codec.quic;
 
 import java.util.Objects;
 
+/**
+ * Configuration used for setup
+ * <a href="https://quiclog.github.io/internet-drafts/draft-marx-qlog-main-schema.html">qlog</a>.
+ */
 public final class QLogConfiguration {
 
     private final String path;
     private final String logTitle;
     private final String logDescription;
 
+    /**
+     * Create a new configuration.
+     *
+     * @param path              the path to the log file to use. This file must not exist yet.
+     * @param logTitle          the title to use when logging.
+     * @param logDescription    the description to use when logging.
+     */
     public QLogConfiguration(String path, String logTitle, String logDescription) {
         this.path = Objects.requireNonNull(path, "path");
         this.logTitle = Objects.requireNonNull(logTitle, "logTitle");
         this.logDescription = Objects.requireNonNull(logDescription, "logDescription");
     }
 
+    /**
+     * Return the path to the log file.
+     *
+     * @return the path.
+     */
     public String path() {
         return path;
     }
 
+    /**
+     * Return the title.
+     *
+     * @return the title.
+     */
     public String logTitle() {
         return logTitle;
     }
 
+    /**
+     * Return the description.
+     *
+     * @return the description.
+     */
     public String logDescription() {
         return logDescription;
     }

--- a/src/main/java/io/netty/incubator/codec/quic/QLogConfiguration.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QLogConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import java.util.Objects;
+
+public final class QLogConfiguration {
+
+    private final String path;
+    private final String logTitle;
+    private final String logDescription;
+
+    public QLogConfiguration(String path, String logTitle, String logDescription) {
+        this.path = Objects.requireNonNull(path, "path");
+        this.logTitle = Objects.requireNonNull(logTitle, "logTitle");
+        this.logDescription = Objects.requireNonNull(logDescription, "logDescription");
+    }
+
+    public String path() {
+        return path;
+    }
+
+    public String logTitle() {
+        return logTitle;
+    }
+
+    public String logDescription() {
+        return logDescription;
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelOption.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelOption.java
@@ -30,6 +30,12 @@ public final class QuicChannelOption<T> extends ChannelOption<T> {
     public static final ChannelOption<Boolean> READ_FRAMES =
             valueOf(QuicChannelOption.class, "READ_FRAMES");
 
+    /**
+     * Enable <a href="https://quiclog.github.io/internet-drafts/draft-marx-qlog-main-schema.html">qlog</a>
+     * for a {@link QuicChannel}.
+     */
+    public static final ChannelOption<QLogConfiguration> QLOG = valueOf(QuicChannelOption.class, "QLOG");
+
     @SuppressWarnings({ "deprecation" })
     private QuicChannelOption() {
         super(null);

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -217,6 +217,12 @@ final class Quiche {
                                                 long configAddr, long ssl, boolean isServer);
 
     /**
+     * See <a href="https://github.com/cloudflare/quiche/blob/master/include/quiche.h#L248">
+     *     quiche_conn_set_qlog_path</a>.
+     */
+    static native boolean quiche_conn_set_qlog_path(long connAddr, String path, String logTitle, String logDescription);
+
+    /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L249">quiche_conn_recv</a>.
      */
     static native int quiche_conn_recv(long connAddr, long bufAddr, int bufLen);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -114,7 +114,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private final long[] readableStreams = new long[128];
     private final LongObjectMap<QuicheQuicStreamChannel> streams = new LongObjectHashMap<>();
     private final Queue<Long> flushPendingQueue = new ArrayDeque<>();
-    private final QuicChannelConfig config;
+    private final DefaultQuicChannelConfig config;
     private final boolean server;
     private final QuicStreamIdGenerator idGenerator;
     private final ChannelHandler streamHandler;
@@ -183,6 +183,11 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
     void attach(QuicheQuicConnection connection) {
         this.connection = connection;
+        QLogConfiguration configuration = config.getQLogConfiguration();
+        if (configuration != null) {
+            Quiche.quiche_conn_set_qlog_path(connection.address(), configuration.path(),
+                    configuration.logTitle(), configuration.logDescription());
+        }
         byte[] traceId = Quiche.quiche_conn_trace_id(connection.address());
         if (traceId != null) {
             this.traceId = new String(traceId);
@@ -230,6 +235,11 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 this.traceId = new String(bytes);
             }
             this.connection = connection;
+            QLogConfiguration configuration = config.getQLogConfiguration();
+            if (configuration != null) {
+                Quiche.quiche_conn_set_qlog_path(connection.address(), configuration.path(),
+                        configuration.logTitle(), configuration.logDescription());
+            }
             this.supportsDatagram = supportsDatagram;
             key = connectId;
         } finally {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -219,7 +219,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
             return null;
         }
 
-        channel.attach(connection);
+        channel.attachQuicheConnection(connection);
 
         putChannel(channel);
         ctx.channel().eventLoop().register(channel);


### PR DESCRIPTION
Motivation:

qlog makes debugging easier, we should support it

Modifications:

- Add new QuicChannelOption.QLOG which allows to setup qlog support for a QuicChannel
- Add unit test

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/67