### PR TITLE
Add QuicStreamLimitChangedEvent that will be fired once we can create…

### DIFF
--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -214,6 +214,14 @@ static void netty_quiche_conn_free(JNIEnv* env, jclass clazz, jlong conn) {
     quiche_conn_free((quiche_conn *) conn);
 }
 
+static jlong netty_quiche_conn_peer_streams_left_bidi(JNIEnv* env, jclass clazz, jlong conn) {
+    return (jlong) quiche_conn_peer_streams_left_bidi((quiche_conn *) conn);
+}
+
+static jlong netty_quiche_conn_peer_streams_left_uni(JNIEnv* env, jclass clazz, jlong conn) {
+    return (jlong) quiche_conn_peer_streams_left_uni((quiche_conn *) conn);
+}
+
 static jint netty_quiche_conn_stream_priority(JNIEnv* env, jclass clazz, jlong conn, jlong stream_id, jbyte urgency, jboolean incremental) {
     return (jint) quiche_conn_stream_priority((quiche_conn *) conn, (uint64_t) stream_id,  (uint8_t) urgency, incremental == JNI_TRUE ? true : false);
 }
@@ -472,6 +480,8 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_recv", "(JJI)I", (void *) netty_quiche_conn_recv },
   { "quiche_conn_send", "(JJI)I", (void *) netty_quiche_conn_send },
   { "quiche_conn_free", "(J)V", (void *) netty_quiche_conn_free },
+  { "quiche_conn_peer_streams_left_bidi", "(J)J", (void *) netty_quiche_conn_peer_streams_left_bidi },
+  { "quiche_conn_peer_streams_left_uni", "(J)J", (void *) netty_quiche_conn_peer_streams_left_uni },
   { "quiche_conn_stream_priority", "(JJBZ)I", (void *) netty_quiche_conn_stream_priority },
   { "quiche_conn_stream_recv", "(JJJIJ)I", (void *) netty_quiche_conn_stream_recv },
   { "quiche_conn_stream_send", "(JJJIZ)I", (void *) netty_quiche_conn_stream_send },

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -41,6 +41,15 @@ public interface QuicChannel extends Channel {
     QuicChannelConfig config();
 
     /**
+     * Returns the number of streams that can be created before stream creation will fail
+     * with {@link QuicError#STREAM_LIMIT} error.
+     *
+     * @param type the stream type.
+     * @return the number of streams left.
+     */
+    long peerAllowedStreams(QuicStreamType type);
+
+    /**
      * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Future} once done.
      * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} automatically.

--- a/src/main/java/io/netty/incubator/codec/quic/QuicEvent.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -17,7 +17,7 @@ package io.netty.incubator.codec.quic;
 
 /**
  * Marker interface for events that will be passed through the {@link io.netty.channel.ChannelPipeline} via
- * {@link io.netty.channel.ChannelPipeline#fireUserEventTriggered(Object)} to notify the user about supported
- * QUIC extensions by the remote peer.
+ * {@link io.netty.channel.ChannelPipeline#fireUserEventTriggered(Object)} to notify the user about {@code QUIC}
+ * specific events.
  */
-public interface QuicExtensionEvent extends QuicEvent { }
+public interface QuicEvent { }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamLimitChangedEvent.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamLimitChangedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,8 +16,11 @@
 package io.netty.incubator.codec.quic;
 
 /**
- * Marker interface for events that will be passed through the {@link io.netty.channel.ChannelPipeline} via
- * {@link io.netty.channel.ChannelPipeline#fireUserEventTriggered(Object)} to notify the user about supported
- * QUIC extensions by the remote peer.
+ * Event fired once the stream limit of a {@link QuicChannel} changes.
  */
-public interface QuicExtensionEvent extends QuicEvent { }
+public final class QuicStreamLimitChangedEvent implements QuicEvent {
+
+    static final QuicStreamLimitChangedEvent INSTANCE = new QuicStreamLimitChangedEvent();
+
+    private QuicStreamLimitChangedEvent() { }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -238,6 +238,18 @@ final class Quiche {
     static native void quiche_conn_free(long connAddr);
 
     /**
+     * See <a href="https://github.com/cloudflare/quiche/blob/0.7.0/include/quiche.h#L330">
+     *     quiche_conn_peer_streams_left_bidi</a>.
+     */
+    static native long quiche_conn_peer_streams_left_bidi(long connAddr);
+
+    /**
+     * See <a href="https://github.com/cloudflare/quiche/blob/0.7.0/include/quiche.h#L334">
+     *     quiche_conn_peer_streams_left_uni</a>.
+     */
+    static native long quiche_conn_peer_streams_left_uni(long connAddr);
+
+    /**
      * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.7.0/include/quiche.h#L275">quiche_conn_stream_priority</a>.
      */

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -55,6 +55,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.function.Function;
 
 /**
@@ -148,6 +149,14 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private volatile int state;
     private volatile String traceId;
 
+    private static final AtomicLongFieldUpdater<QuicheQuicChannel> UNI_STREAMS_LEFT_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(QuicheQuicChannel.class, "uniStreamsLeft");
+    private volatile long uniStreamsLeft;
+
+    private static final AtomicLongFieldUpdater<QuicheQuicChannel> BIDI_STREAMS_LEFT_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(QuicheQuicChannel.class, "bidiStreamsLeft");
+    private volatile long bidiStreamsLeft;
+
     private QuicheQuicChannel(Channel parent, boolean server, ByteBuffer key,
                       InetSocketAddress remote, boolean supportsDatagram, ChannelHandler streamHandler,
                               Map.Entry<ChannelOption<?>, Object>[] streamOptionsArray,
@@ -179,6 +188,18 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                                        Map.Entry<AttributeKey<?>, Object>[] streamAttrsArray) {
         return new QuicheQuicChannel(parent, true, key, remote, supportsDatagram,
                 streamHandler, streamOptionsArray, streamAttrsArray);
+    }
+
+    @Override
+    public long peerAllowedStreams(QuicStreamType type) {
+        switch (type) {
+            case BIDIRECTIONAL:
+                return bidiStreamsLeft;
+            case UNIDIRECTIONAL:
+                return uniStreamsLeft;
+            default:
+                return 0;
+        }
     }
 
     void attachQuicheConnection(QuicheQuicConnection connection) {
@@ -976,6 +997,11 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 promise.setFailure(e);
                 return;
             }
+            if (type == QuicStreamType.UNIDIRECTIONAL) {
+                UNI_STREAMS_LEFT_UPDATER.decrementAndGet(QuicheQuicChannel.this);
+            } else {
+                BIDI_STREAMS_LEFT_UPDATER.decrementAndGet(QuicheQuicChannel.this);
+            }
             QuicheQuicStreamChannel streamChannel = addNewStreamChannel(streamId);
             if (handler != null) {
                 streamChannel.pipeline().addLast(handler);
@@ -1091,6 +1117,18 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
                         if (Quiche.quiche_conn_is_established(connAddr) ||
                                 Quiche.quiche_conn_is_in_early_data(connAddr)) {
+                            long uniLeftOld = uniStreamsLeft;
+                            long bidiLeftOld = bidiStreamsLeft;
+                            // Only fetch new stream info when we used all our credits
+                            if (uniLeftOld == 0 || bidiLeftOld == 0) {
+                                long uniLeft = Quiche.quiche_conn_peer_streams_left_uni(connAddr);
+                                long bidiLeft = Quiche.quiche_conn_peer_streams_left_bidi(connAddr);
+                                uniStreamsLeft = uniLeft;
+                                bidiStreamsLeft = bidiLeft;
+                                if (uniLeftOld != uniLeft || bidiLeftOld != bidiLeft) {
+                                    pipeline().fireUserEventTriggered(QuicStreamLimitChangedEvent.INSTANCE);
+                                }
+                            }
 
                             if (handleWritableStreams()) {
                                 // Some data was produced, let's flush.


### PR DESCRIPTION
… more streams again

Motivation:

At the moment we have no way to know when we can create more streams again (or how many streams we are allowed to create in general).

Modifications:

- Add QuicStreamLimitChangedEvent that will be fired once we received an update for stream credits
- Add method that allow to get info about how many streams we can create
- Add unit test

Result:

Be able to know how many streams can be created at a given time