### PR TITLE
Support setup QLOG to log into a directory

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QLogConfiguration.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QLogConfiguration.java
@@ -30,7 +30,8 @@ public final class QLogConfiguration {
     /**
      * Create a new configuration.
      *
-     * @param path              the path to the log file to use. This file must not exist yet.
+     * @param path              the path to the log file to use. This file must not exist yet. If the path is a
+     *                          directory the filename will be generated
      * @param logTitle          the title to use when logging.
      * @param logDescription    the description to use when logging.
      */


### PR DESCRIPTION
Motivation:

Especially on the server side it is easier to just configure a dir where the qlog files will be placed as we will accept a lot of connections

Modifications:

- Allow to configure QLOG to log to a specific dir and auto-generate the filenames
- Add unit test

Result:

Easier to configure QLOG on the server side