### PR TITLE
Rename package-private implementations

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -117,7 +117,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private final long[] readableStreams = new long[128];
     private final LongObjectMap<QuicheQuicStreamChannel> streams = new LongObjectHashMap<>();
     private final Queue<Long> flushPendingQueue = new ArrayDeque<>();
-    private final DefaultQuicChannelConfig config;
+    private final QuicheQuicChannelConfig config;
     private final boolean server;
     private final QuicStreamIdGenerator idGenerator;
     private final ChannelHandler streamHandler;
@@ -164,7 +164,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                               Map.Entry<ChannelOption<?>, Object>[] streamOptionsArray,
                               Map.Entry<AttributeKey<?>, Object>[] streamAttrsArray) {
         super(parent);
-        config = new DefaultQuicChannelConfig(this);
+        config = new QuicheQuicChannelConfig(this);
         this.server = server;
         this.idGenerator = new QuicStreamIdGenerator(server);
         this.key = key;
@@ -1443,8 +1443,8 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             return null;
         }
 
-        final DefaultQuicConnectionStats connStats =
-            new DefaultQuicConnectionStats(stats[0], stats[1], stats[2], stats[3], stats[4], stats[5]);
+        final QuicheQuicConnectionStats connStats =
+            new QuicheQuicConnectionStats(stats[0], stats[1], stats[2], stats[3], stats[4], stats[5]);
         promise.setSuccess(connStats);
         return connStats;
     }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannelConfig.java
@@ -28,11 +28,11 @@ import java.util.Map;
 /**
  * Default {@link QuicChannelConfig} implementation.
  */
-final class DefaultQuicChannelConfig extends DefaultChannelConfig implements QuicChannelConfig {
+final class QuicheQuicChannelConfig extends DefaultChannelConfig implements QuicChannelConfig {
 
     private volatile QLogConfiguration qLogConfiguration;
 
-    DefaultQuicChannelConfig(Channel channel) {
+    QuicheQuicChannelConfig(Channel channel) {
         super(channel);
     }
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnectionStats.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnectionStats.java
@@ -17,7 +17,7 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.util.internal.StringUtil;
 
-final class DefaultQuicConnectionStats implements QuicConnectionStats {
+final class QuicheQuicConnectionStats implements QuicConnectionStats {
 
     private final long recv;
     private final long sent;
@@ -26,7 +26,7 @@ final class DefaultQuicConnectionStats implements QuicConnectionStats {
     private final long congestionWindow;
     private final long deliveryRate;
 
-    DefaultQuicConnectionStats(long recv, long sent, long lost, long rttNanos, long cwnd, long deliveryRate) {
+    QuicheQuicConnectionStats(long recv, long sent, long lost, long rttNanos, long cwnd, long deliveryRate) {
         this.recv = recv;
         this.sent = sent;
         this.lost = lost;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -64,7 +64,7 @@ final class QuicheQuicStreamChannel extends AbstractChannel implements QuicStrea
 
     QuicheQuicStreamChannel(QuicheQuicChannel parent, long streamId) {
         super(parent);
-        config = new DefaultQuicStreamChannelConfig(this);
+        config = new QuicheQuicStreamChannelConfig(this);
         this.address = new QuicStreamAddress(streamId);
 
         // Local created unidirectional streams have the input shutdown by spec. There will never be any data for

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannelConfig.java
@@ -24,13 +24,13 @@ import io.netty.channel.WriteBufferWaterMark;
 
 import java.util.Map;
 
-final class DefaultQuicStreamChannelConfig extends DefaultChannelConfig implements QuicStreamChannelConfig {
+final class QuicheQuicStreamChannelConfig extends DefaultChannelConfig implements QuicStreamChannelConfig {
     // We should use half-closure sementatics by default as this is what QUIC does by default.
     // If you receive a FIN you should still keep the stream open until you write a FIN as well.
     private volatile boolean allowHalfClosure = true;
     private volatile boolean readFrames;
 
-    DefaultQuicStreamChannelConfig(QuicStreamChannel channel) {
+    QuicheQuicStreamChannelConfig(QuicStreamChannel channel) {
         super(channel);
     }
 


### PR DESCRIPTION
Motivation:

Rename the package-private implementations which are not part of the API to make things more consistent

Modifications:

Rename package-private classes

Result:

More consistent code naming