### PR TITLE
Flush when connection is freed and also not force flush when FIN was …

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -340,6 +340,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
             timeoutHandler.cancel();
         } finally {
+            flushParent();
             conn.free();
         }
     }
@@ -828,8 +829,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             //
             // See https://docs.rs/quiche/0.6.0/quiche/struct.Connection.html#method.send
             if (connectionSend()) {
-                // Let's try to send as fast as possible.
-                forceFlushParent();
+                flushParent();
             }
         }
     }


### PR DESCRIPTION
…sent

Motivation:

We should try to flush one last time when the connection was freed to ensure we always transmit all data. Also we dont need to force the flush on the FIN.

Modifications:

Less flushes in general + extra flush when connection is closed

Result:

Less overhead and correctness fix