### PR TITLE
Make use of GSO when possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
     <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
     <skipTests>false</skipTests>
-    <netty.version>4.1.59.Final</netty.version>
+    <netty.version>4.1.60.Final</netty.version>
     <netty.build.version>28</netty.build.version>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <jniLibName>netty_quiche_${os.detected.name}_${os.detected.arch}</jniLibName>
@@ -816,6 +816,18 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
       <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>${netty.version}</version>
+      <classifier>linux-x86_64</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelOption.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelOption.java
@@ -36,6 +36,13 @@ public final class QuicChannelOption<T> extends ChannelOption<T> {
      */
     public static final ChannelOption<QLogConfiguration> QLOG = valueOf(QuicChannelOption.class, "QLOG");
 
+    /**
+     * Use <a href="https://blog.cloudflare.com/accelerating-udp-packet-transmission-for-quic/">GSO</a>
+     * for QUIC packets if possible. If the number is bigger then 1 we will try to use segments.
+     */
+    public static final ChannelOption<Integer> UDP_SEGMENTS =
+            valueOf(QuicChannelOption.class, "QUIC_UDP_SEGMENTS");
+
     @SuppressWarnings({ "deprecation" })
     private QuicChannelOption() {
         super(null);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannelConfig.java
@@ -31,6 +31,8 @@ import java.util.Map;
 final class QuicheQuicChannelConfig extends DefaultChannelConfig implements QuicChannelConfig {
 
     private volatile QLogConfiguration qLogConfiguration;
+    // Try to use UDP_SEGMENT by default if possible
+    private volatile int udpSegment = 10;
 
     QuicheQuicChannelConfig(Channel channel) {
         super(channel);
@@ -38,7 +40,8 @@ final class QuicheQuicChannelConfig extends DefaultChannelConfig implements Quic
 
     @Override
     public Map<ChannelOption<?>, Object> getOptions() {
-        return getOptions(super.getOptions(), QuicChannelOption.QLOG);
+        return getOptions(super.getOptions(),
+                QuicChannelOption.QLOG, QuicChannelOption.UDP_SEGMENTS);
     }
 
     @SuppressWarnings("unchecked")
@@ -47,6 +50,9 @@ final class QuicheQuicChannelConfig extends DefaultChannelConfig implements Quic
         if (option == QuicChannelOption.QLOG) {
             return (T) getQLogConfiguration();
         }
+        if (option == QuicChannelOption.UDP_SEGMENTS) {
+            return (T) Integer.valueOf(getUdpSegments());
+        }
         return super.getOption(option);
     }
 
@@ -54,6 +60,10 @@ final class QuicheQuicChannelConfig extends DefaultChannelConfig implements Quic
     public <T> boolean setOption(ChannelOption<T> option, T value) {
         if (option == QuicChannelOption.QLOG) {
             setQLogConfiguration((QLogConfiguration) value);
+            return true;
+        }
+        if (option == QuicChannelOption.UDP_SEGMENTS) {
+            setUdpSegments((Integer) value);
             return true;
         }
         return super.setOption(option, value);
@@ -135,5 +145,13 @@ final class QuicheQuicChannelConfig extends DefaultChannelConfig implements Quic
             throw new IllegalStateException("QLOG can only be enabled before the Channel was registered");
         }
         this.qLogConfiguration = qLogConfiguration;
+    }
+
+    int getUdpSegments() {
+        return udpSegment;
+    }
+
+    private void setUdpSegments(int udpSegment) {
+        this.udpSegment = udpSegment;
     }
 }


### PR DESCRIPTION
Motivation:

Using GSO / UDP_SEGMENT can improve the performance quite a lot for
QUIC. When possible we should use it.

Modifications:

Make use of new netty feature for UDP_SEGMENT when possible

Result:

Better performance on Linux when UDP_SEGMENT is supported