### PR TITLE
Enable frame-pointers in quiche

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -411,6 +411,8 @@
                         <env key="CFLAGS" value="${extraCflags}" />
                         <env key="CXXFLAGS" value="${extraCxxflags}" />
                         <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
+                        <!-- Lets enable frame-pointers so we can profile better -->
+                        <env key="RUSTFLAGS" value="-Cforce-frame-pointers=yes" />
                       </exec>
                     </else>
                   </if>


### PR DESCRIPTION
Motivation:

To be able to profile with things like perf we should enable frame-pointers when building quiche

Modifications:

Add flag to enable frame-pointers

Result:

Be able to use perf / dtrace when profile quiche