### PR TITLE
Simplify usage of PendingWriteQueue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
     <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
     <skipTests>false</skipTests>
-    <netty.version>4.1.59.Final</netty.version>
+    <netty.version>4.1.60.Final</netty.version>
     <netty.build.version>28</netty.build.version>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <jniLibName>netty_quiche_${os.detected.name}_${os.detected.arch}</jniLibName>

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelId;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
@@ -85,11 +84,9 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
             // TODO: add some overrides maybe ?
         };
         config = new QuicheQuicStreamChannelConfig(this);
-        // Add a noop handler to the pipeline so we can construct the PendingWriteQueue.
-        this.pipeline.addLast(new ChannelHandlerAdapter() { });
-        queue = new PendingWriteQueue(pipeline.firstContext());
         this.address = new QuicStreamAddress(streamId);
         this.closePromise = newPromise();
+        queue = new PendingWriteQueue(this);
         // Local created unidirectional streams have the input shutdown by spec. There will never be any data for
         // these to be read.
         if (parent.streamType(streamId) == QuicStreamType.UNIDIRECTIONAL && parent.isStreamLocalCreated(streamId)) {


### PR DESCRIPTION
Motivation:

We can simplify the usage of PendingWriteQueue by directly pass the Channel to the constructor

Modifications:

Change constructor usage

Result:

Cleanup