### PR TITLE
Support shutting down the stream with an error code

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
@@ -15,11 +15,12 @@
  */
 package io.netty.incubator.codec.quic;
 
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.socket.DuplexChannel;
+
+import java.net.Socket;
 
 /**
  * A QUIC stream.
@@ -31,6 +32,44 @@ public interface QuicStreamChannel extends DuplexChannel {
      * writes will happen.
      */
     ChannelFutureListener SHUTDOWN_OUTPUT = f -> ((QuicStreamChannel) f.channel()).shutdownOutput();
+
+    /**
+     * Shutdown the input of the stream with the given error code. This means a {@code STOP_SENDING} frame will
+     * be send to the remote peer and all data received will be discarded.
+     *
+     * @param error the error to send.
+     * @return the future that is notified on completion.
+     */
+    ChannelFuture shutdownInput(int error);
+
+    /**
+     * Shutdown the input of the stream with the given error code. This means a {@code STOP_SENDING} frame will
+     * be send to the remote peer and all data received will be discarded.
+     *
+     * @param error the error to send.
+     * @param promise will be notified on completion.
+     * @return the future that is notified on completion.
+     */
+    ChannelFuture shutdownInput(int error, ChannelPromise promise);
+
+    /**
+     * Shutdown the output of the stream with the given error code. This means a {@code RESET_STREAM} frame will
+     * be send to the remote peer and all data that is not sent yet will be discarded.
+     *
+     * @param error the error to send.
+     * @return the future that is notified on completion.
+     */
+    ChannelFuture shutdownOutput(int error);
+
+    /**
+     * Shutdown the output of the stream with the given error code. This means a {@code RESET_STREAM} frame will
+     * be send to the remote peer and all data that is not sent yet will be discarded.
+     *
+     * @param error the error to send.
+     * @param promise will be notified on completion.
+     * @return the future that is notified on completion.
+     */
+    ChannelFuture shutdownOutput(int error, ChannelPromise promise);
 
     @Override
     QuicStreamAddress localAddress();

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -676,16 +676,12 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         return (streamId & 0x2) == 0 ? QuicStreamType.BIDIRECTIONAL : QuicStreamType.UNIDIRECTIONAL;
     }
 
-    void streamShutdownRead(long streamId, ChannelPromise promise) {
-        streamShutdown0(streamId, true, false, 0, promise);
+    void streamShutdownRead(long streamId, int err, ChannelPromise promise) {
+        streamShutdown0(streamId, true, false, err, promise);
     }
 
-    void streamShutdownWrite(long streamId, ChannelPromise promise) {
-        streamShutdown0(streamId, false, true, 0, promise);
-    }
-
-    void streamShutdownReadAndWrite(long streamId, ChannelPromise promise) {
-        streamShutdown0(streamId, true, true, 0, promise);
+    void streamShutdownWrite(long streamId, int err, ChannelPromise promise) {
+        streamShutdown0(streamId, false, true, err, promise);
     }
 
     private void streamShutdown0(long streamId, boolean read, boolean write, int err, ChannelPromise promise) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -239,13 +239,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     }
 
     private void shutdownOutput0(int error, ChannelPromise channelPromise) {
-        try {
-            parent().streamShutdownWrite(streamId(), error, channelPromise);
-        } catch (Throwable e) {
-            channelPromise.setFailure(e);
-            return;
-        }
-        channelPromise.setSuccess();
+        parent().streamShutdownWrite(streamId(), error, channelPromise);
         outputShutdown = true;
         closeIfDone();
     }


### PR DESCRIPTION
Motivation:

We need to support shutting down the stream (read and write) with an error code to be able to propagate errors to the remote peer (like in H3).

Modifications:

Add method overloads that allow to include the error code when shutdown one side of the stream

Result:

Be able to propagate stream errors to the remote peer