### PR TITLE
Add more methods for shutdown the stream

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamFrame.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamFrame.java
@@ -17,11 +17,82 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.Unpooled;
 
 /**
  * A QUIC STREAM_FRAME.
  */
 public interface QuicStreamFrame extends ByteBufHolder {
+
+    /**
+     * An empty {@link QuicStreamFrame} that has the {@code FIN} flag set.
+     */
+    QuicStreamFrame EMPTY_FIN = new QuicStreamFrame() {
+        @Override
+        public boolean hasFin() {
+            return true;
+        }
+
+        @Override
+        public QuicStreamFrame copy() {
+            return this;
+        }
+
+        @Override
+        public QuicStreamFrame duplicate() {
+            return this;
+        }
+
+        @Override
+        public QuicStreamFrame retainedDuplicate() {
+            return this;
+        }
+
+        @Override
+        public QuicStreamFrame replace(ByteBuf content) {
+            return new DefaultQuicStreamFrame(content, hasFin());
+        }
+
+        @Override
+        public QuicStreamFrame retain() {
+            return this;
+        }
+
+        @Override
+        public QuicStreamFrame retain(int increment) {
+            return this;
+        }
+
+        @Override
+        public QuicStreamFrame touch() {
+            return this;
+        }
+
+        @Override
+        public QuicStreamFrame touch(Object hint) {
+            return this;
+        }
+
+        @Override
+        public ByteBuf content() {
+            return Unpooled.EMPTY_BUFFER;
+        }
+
+        @Override
+        public int refCnt() {
+            return 1;
+        }
+
+        @Override
+        public boolean release() {
+            return false;
+        }
+
+        @Override
+        public boolean release(int decrement) {
+            return false;
+        }
+    };
 
     /**
      * Returns {@code true} if the frame has the FIN set, which means it notifies the remote peer that

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -676,15 +676,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         return (streamId & 0x2) == 0 ? QuicStreamType.BIDIRECTIONAL : QuicStreamType.UNIDIRECTIONAL;
     }
 
-    void streamShutdownRead(long streamId, int err, ChannelPromise promise) {
-        streamShutdown0(streamId, true, false, err, promise);
-    }
-
-    void streamShutdownWrite(long streamId, int err, ChannelPromise promise) {
-        streamShutdown0(streamId, false, true, err, promise);
-    }
-
-    private void streamShutdown0(long streamId, boolean read, boolean write, int err, ChannelPromise promise) {
+    void streamShutdown(long streamId, boolean read, boolean write, int err, ChannelPromise promise) {
         final long connectionAddress;
         try {
             connectionAddress = connectionAddressChecked();

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
@@ -77,7 +77,7 @@ public class QuicStreamFrameTest extends AbstractQuicTest {
                 public void channelActive(ChannelHandlerContext ctx)  {
                     // Do the write and close the channel
                     ctx.writeAndFlush(Unpooled.buffer().writeZero(8))
-                            .addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
+                            .addListener(QuicStreamChannel.WRITE_FIN);
                 }
             });
         }

--- a/src/test/java/io/netty/incubator/codec/quic/example/QuicClientExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/example/QuicClientExample.java
@@ -97,7 +97,7 @@ public final class QuicClientExample {
                     }).sync().getNow();
             // Write the data and send the FIN. After this its not possible anymore to write any more data.
             streamChannel.writeAndFlush(Unpooled.copiedBuffer("GET /\r\n", CharsetUtil.US_ASCII))
-                    .addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
+                    .addListener(QuicStreamChannel.WRITE_FIN);
 
             // Wait for the stream channel and quic channel to be closed (this will happen after we received the FIN).
             // After this is done we will close the underlying datagram channel.

--- a/src/test/java/io/netty/incubator/codec/quic/example/QuicServerExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/example/QuicServerExample.java
@@ -98,7 +98,7 @@ public final class QuicServerExample {
                                         ByteBuf buffer = ctx.alloc().directBuffer();
                                         buffer.writeCharSequence("Hello World!\r\n", CharsetUtil.US_ASCII);
                                         // Write the buffer and shutdown the output by writing a FIN.
-                                        ctx.writeAndFlush(buffer).addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
+                                        ctx.writeAndFlush(buffer).addListener(QuicStreamChannel.WRITE_FIN);
                                     }
                                 } finally {
                                     byteBuf.release();


### PR DESCRIPTION
Motivation:

Shutdown the stream is something that has some "meaning" in quic so we should follow it.

Modifications:

- Add more overloads for shutting down the stream
- Deprecate QuicStreamChannel.SHUTDOWN_OUTPUT and users should use QuicStreamChannel.SEND_FIN

Result:

Clearer API / better semantics