### PR TITLE
Change shutdownOutput() semantics again to do a "clean" shutdown

### DIFF
--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
@@ -77,7 +77,7 @@ public class QuicStreamFrameTest extends AbstractQuicTest {
                 public void channelActive(ChannelHandlerContext ctx)  {
                     // Do the write and close the channel
                     ctx.writeAndFlush(Unpooled.buffer().writeZero(8))
-                            .addListener(QuicStreamChannel.WRITE_FIN);
+                            .addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
                 }
             });
         }

--- a/src/test/java/io/netty/incubator/codec/quic/example/QuicClientExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/example/QuicClientExample.java
@@ -97,7 +97,7 @@ public final class QuicClientExample {
                     }).sync().getNow();
             // Write the data and send the FIN. After this its not possible anymore to write any more data.
             streamChannel.writeAndFlush(Unpooled.copiedBuffer("GET /\r\n", CharsetUtil.US_ASCII))
-                    .addListener(QuicStreamChannel.WRITE_FIN);
+                    .addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
 
             // Wait for the stream channel and quic channel to be closed (this will happen after we received the FIN).
             // After this is done we will close the underlying datagram channel.

--- a/src/test/java/io/netty/incubator/codec/quic/example/QuicServerExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/example/QuicServerExample.java
@@ -98,7 +98,7 @@ public final class QuicServerExample {
                                         ByteBuf buffer = ctx.alloc().directBuffer();
                                         buffer.writeCharSequence("Hello World!\r\n", CharsetUtil.US_ASCII);
                                         // Write the buffer and shutdown the output by writing a FIN.
-                                        ctx.writeAndFlush(buffer).addListener(QuicStreamChannel.WRITE_FIN);
+                                        ctx.writeAndFlush(buffer).addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
                                     }
                                 } finally {
                                     byteBuf.release();


### PR DESCRIPTION
Motivation:

We recently changes all shutdownOutput() methods to do a shutdown with a RESET_FRAME. This was not a good call and made things harder for users. Let's change it back to only do a reset when shutdownOutput(...) is caled with an error code.

Modifications:

Do a "clean" shutdown aka FIN when shutdownOutput() is called without an error code

Result:

Easier to use again