### PR TITLE
We should only create an exception if needed as fill in the stacktrac…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -542,7 +542,10 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
             } catch (Exception ignore) {
                 // Just ignore
             } finally {
-                queue.removeAndFailAll(new ClosedChannelException());
+                if (!queue.isEmpty()) {
+                    // Only fail if the queue is non-empty.
+                    queue.removeAndFailAll(new ClosedChannelException());
+                }
 
                 promise.trySuccess();
                 closePromise.trySuccess();


### PR DESCRIPTION
…e is expensive

Motivation:

Creating exceptions is expensive so we should only do it if needed

Modifications:

Check if the queue is non empty before create an exception

Result:

Less overhead when closing streams