### PR TITLE
Make it more flexible in terms of supporting GSO

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannelOption.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannelOption.java
@@ -38,10 +38,10 @@ public final class QuicChannelOption<T> extends ChannelOption<T> {
 
     /**
      * Use <a href="https://blog.cloudflare.com/accelerating-udp-packet-transmission-for-quic/">GSO</a>
-     * for QUIC packets if possible. If the number is bigger then 1 we will try to use segments.
+     * for QUIC packets if possible.
      */
-    public static final ChannelOption<Integer> UDP_SEGMENTS =
-            valueOf(QuicChannelOption.class, "QUIC_UDP_SEGMENTS");
+    public static final ChannelOption<SegmentedDatagramPacketAllocator> SEGMENTED_DATAGRAM_PACKET_ALLOCATOR =
+            valueOf(QuicChannelOption.class, "SEGMENTED_DATAGRAM_PACKET_ALLOCATOR");
 
     @SuppressWarnings({ "deprecation" })
     private QuicChannelOption() {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -32,8 +32,6 @@ import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.DefaultChannelPipeline;
 import io.netty.channel.EventLoop;
 import io.netty.channel.RecvByteBufAllocator;
-import io.netty.channel.epoll.EpollDatagramChannel;
-import io.netty.channel.epoll.SegmentedDatagramPacket;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.AttributeKey;
 import io.netty.util.collection.LongObjectHashMap;
@@ -111,7 +109,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private final Map.Entry<AttributeKey<?>, Object>[] streamAttrsArray;
     private final TimeoutHandler timeoutHandler = new TimeoutHandler();
     private final InetSocketAddress remote;
-    private final boolean supportsUdpSegment;
 
     private QuicheQuicConnection connection;
     private boolean inFireChannelReadCompleteQueue;
@@ -153,7 +150,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                               Map.Entry<ChannelOption<?>, Object>[] streamOptionsArray,
                               Map.Entry<AttributeKey<?>, Object>[] streamAttrsArray) {
         super(parent);
-        this.supportsUdpSegment = SegmentedDatagramPacket.isSupported() && parent instanceof EpollDatagramChannel;
         config = new QuicheQuicChannelConfig(this);
         this.server = server;
         this.idGenerator = new QuicStreamIdGenerator(server);
@@ -877,8 +873,8 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         return connection == null;
     }
 
-    private boolean connectionSendSegments(int maxSegments) {
-        final int bufferSize = maxSegments * Quic.MAX_DATAGRAM_SIZE;
+    private boolean connectionSendSegments(SegmentedDatagramPacketAllocator segmentedDatagramPacketAllocator) {
+        final int bufferSize = segmentedDatagramPacketAllocator.maxNumSegments() * Quic.MAX_DATAGRAM_SIZE;
 
         long connAddr = connection.address();
         boolean packetWasWritten = false;
@@ -908,7 +904,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 int readable = out.readableBytes();
                 if (readable != 0) {
                     if (lastWritten != -1 && readable > lastWritten) {
-                        parent().write(new SegmentedDatagramPacket(out, lastWritten, remote));
+                        parent().write(segmentedDatagramPacketAllocator.newPacket(out, lastWritten, remote));
                     } else {
                         parent().write(new DatagramPacket(out, remote));
                     }
@@ -923,7 +919,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 // The write was smaller then the write before. This means we can write all together as the
                 // last segment can be smaller then the other segments.
                 out.writerIndex(writerIndex + written);
-                parent().write(new SegmentedDatagramPacket(out, lastWritten, remote));
+                parent().write(segmentedDatagramPacketAllocator.newPacket(out, lastWritten, remote));
                 packetWasWritten = true;
 
                 out = alloc().directBuffer(bufferSize);
@@ -939,7 +935,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 // As the last write was smaller then this write we first need to write what we had before as
                 // a segment can never be bigger then the previous segment. After this we will try to build a new
                 // chain of segments for the writes to follow.
-                parent().write(new SegmentedDatagramPacket(out, lastWritten, remote));
+                parent().write(segmentedDatagramPacketAllocator.newPacket(out, lastWritten, remote));
                 packetWasWritten = true;
 
                 out = newOut;
@@ -953,9 +949,9 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
             // check if we either built the maximum number of segments for a write or if the ByteBuf is not writable
             // anymore. In this case lets write what we have and start a new chain of segments.
-            if (numSegments == maxSegments ||
+            if (numSegments == segmentedDatagramPacketAllocator.maxNumSegments() ||
                     !out.isWritable()) {
-                parent().write(new SegmentedDatagramPacket(out, lastWritten, remote));
+                parent().write(segmentedDatagramPacketAllocator.newPacket(out, lastWritten, remote));
                 packetWasWritten = true;
 
                 out = alloc().directBuffer(bufferSize);
@@ -1010,9 +1006,10 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         inConnectionSend = true;
         try {
             boolean packetWasWritten;
-            int segments = supportsUdpSegment ? config.getUdpSegments() : 0;
-            if (segments > 0) {
-                packetWasWritten = connectionSendSegments(segments);
+            SegmentedDatagramPacketAllocator segmentedDatagramPacketAllocator =
+                    config.getSegmentedDatagramPacketAllocator();
+            if (segmentedDatagramPacketAllocator.maxNumSegments() > 0) {
+                packetWasWritten = connectionSendSegments(segmentedDatagramPacketAllocator);
             } else {
                 packetWasWritten = connectionSendSimple();
             }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannelConfig.java
@@ -31,8 +31,8 @@ import java.util.Map;
 final class QuicheQuicChannelConfig extends DefaultChannelConfig implements QuicChannelConfig {
 
     private volatile QLogConfiguration qLogConfiguration;
-    // Try to use UDP_SEGMENT by default if possible
-    private volatile int udpSegment = 10;
+    private volatile SegmentedDatagramPacketAllocator segmentedDatagramPacketAllocator =
+            SegmentedDatagramPacketAllocator.NONE;
 
     QuicheQuicChannelConfig(Channel channel) {
         super(channel);
@@ -41,7 +41,7 @@ final class QuicheQuicChannelConfig extends DefaultChannelConfig implements Quic
     @Override
     public Map<ChannelOption<?>, Object> getOptions() {
         return getOptions(super.getOptions(),
-                QuicChannelOption.QLOG, QuicChannelOption.UDP_SEGMENTS);
+                QuicChannelOption.QLOG, QuicChannelOption.SEGMENTED_DATAGRAM_PACKET_ALLOCATOR);
     }
 
     @SuppressWarnings("unchecked")
@@ -50,8 +50,8 @@ final class QuicheQuicChannelConfig extends DefaultChannelConfig implements Quic
         if (option == QuicChannelOption.QLOG) {
             return (T) getQLogConfiguration();
         }
-        if (option == QuicChannelOption.UDP_SEGMENTS) {
-            return (T) Integer.valueOf(getUdpSegments());
+        if (option == QuicChannelOption.SEGMENTED_DATAGRAM_PACKET_ALLOCATOR) {
+            return (T) getSegmentedDatagramPacketAllocator();
         }
         return super.getOption(option);
     }
@@ -62,8 +62,8 @@ final class QuicheQuicChannelConfig extends DefaultChannelConfig implements Quic
             setQLogConfiguration((QLogConfiguration) value);
             return true;
         }
-        if (option == QuicChannelOption.UDP_SEGMENTS) {
-            setUdpSegments((Integer) value);
+        if (option == QuicChannelOption.SEGMENTED_DATAGRAM_PACKET_ALLOCATOR) {
+            setSegmentedDatagramPacketAllocator((SegmentedDatagramPacketAllocator) value);
             return true;
         }
         return super.setOption(option, value);
@@ -147,11 +147,12 @@ final class QuicheQuicChannelConfig extends DefaultChannelConfig implements Quic
         this.qLogConfiguration = qLogConfiguration;
     }
 
-    int getUdpSegments() {
-        return udpSegment;
+    SegmentedDatagramPacketAllocator getSegmentedDatagramPacketAllocator() {
+        return segmentedDatagramPacketAllocator;
     }
 
-    private void setUdpSegments(int udpSegment) {
-        this.udpSegment = udpSegment;
+    private void setSegmentedDatagramPacketAllocator(
+            SegmentedDatagramPacketAllocator segmentedDatagramPacketAllocator) {
+        this.segmentedDatagramPacketAllocator = segmentedDatagramPacketAllocator;
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/SegmentedDatagramPacketAllocator.java
+++ b/src/main/java/io/netty/incubator/codec/quic/SegmentedDatagramPacketAllocator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.socket.DatagramPacket;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Used to allocate datagram packets that use UDP_SEGMENT (GSO).
+ */
+public interface SegmentedDatagramPacketAllocator {
+
+    /**
+     * {@link SegmentedDatagramPacketAllocator} which should be used if no UDP_SEGMENT is supported and used.
+     */
+    SegmentedDatagramPacketAllocator NONE = new SegmentedDatagramPacketAllocator() {
+        @Override
+        public int maxNumSegments() {
+            return 0;
+        }
+
+        @Override
+        public DatagramPacket newPacket(ByteBuf buffer, int segmentSize, InetSocketAddress remoteAddress) {
+            throw new UnsupportedOperationException();
+        }
+    };
+
+    /**
+     * The maximum number of segments to use per packet.
+     *
+     * @return  the segments.
+     */
+    int maxNumSegments();
+
+    /**
+     * Return a new segmented {@link DatagramPacket}.
+     *
+     * @param buffer        the {@link ByteBuf} that is used as content.
+     * @param segmentSize   the size of each segment.
+     * @param remoteAddress the remote address to send to.
+     * @return              the packet.
+     */
+    DatagramPacket newPacket(ByteBuf buffer, int segmentSize, InetSocketAddress remoteAddress);
+}

--- a/src/test/java/io/netty/incubator/codec/quic/EpollSegmentedDatagramPacketAllocator.java
+++ b/src/test/java/io/netty/incubator/codec/quic/EpollSegmentedDatagramPacketAllocator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.epoll.SegmentedDatagramPacket;
+import io.netty.channel.socket.DatagramPacket;
+
+import java.net.InetSocketAddress;
+
+final class EpollSegmentedDatagramPacketAllocator implements SegmentedDatagramPacketAllocator {
+
+    private final int maxNumSegments;
+
+    EpollSegmentedDatagramPacketAllocator(int maxNumSegments) {
+        this.maxNumSegments = maxNumSegments;
+    }
+
+    @Override
+    public int maxNumSegments() {
+        return maxNumSegments;
+    }
+
+    @Override
+    public DatagramPacket newPacket(ByteBuf buffer, int segmentSize, InetSocketAddress remoteAddress) {
+        return new SegmentedDatagramPacket(buffer, segmentSize, remoteAddress);
+    }
+
+    static boolean isSupported() {
+        return SegmentedDatagramPacket.isSupported();
+    }
+}

--- a/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
@@ -16,13 +16,16 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.SegmentedDatagramPacket;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -98,7 +101,7 @@ final class QuicTestUtils {
     }
 
     static QuicServerCodecBuilder newQuicServerBuilder(QuicSslContext context) {
-        return new QuicServerCodecBuilder()
+        QuicServerCodecBuilder builder = new QuicServerCodecBuilder()
                 .sslEngineProvider(q -> context.newEngine(q.alloc()))
                 .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
                 .initialMaxData(10000000)
@@ -108,6 +111,11 @@ final class QuicTestUtils {
                 .initialMaxStreamsBidirectional(100)
                 .initialMaxStreamsUnidirectional(100)
                 .activeMigration(false);
+        if (GROUP instanceof EpollEventLoopGroup && EpollSegmentedDatagramPacketAllocator.isSupported()) {
+            builder.option(QuicChannelOption.SEGMENTED_DATAGRAM_PACKET_ALLOCATOR,
+                    new EpollSegmentedDatagramPacketAllocator(10));
+        }
+        return builder;
     }
 
     private static Bootstrap newServerBootstrap(QuicServerCodecBuilder serverBuilder,
@@ -148,4 +156,5 @@ final class QuicTestUtils {
             channel.close().sync();
         }
     }
+
 }


### PR DESCRIPTION
Motivation:

At the moment we hardcode the support for GSO for epoll. This is not really flexible enough as we may be able to support it for other transport implementations (like io uring).

Modifications:

Introduce a new API that can be used to plugin GSO support

Result:

Remove dependency on epoll and make the GSO support pluggable