### PR TITLE
Remove epoll dependency now that we not depend on it directly anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -821,11 +821,6 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
       <version>${netty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
       <classifier>linux-x86_64</classifier>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Motivation:

With 91c90cb4935503a3e00224294b924d760977d12b in we don't need a direct dependency on epoll anymore

Modifications:

Remove dependency

Result:

Cleanup