### PR TITLE
Implement some sort of auto flush after X bytes are written

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
@@ -44,7 +44,7 @@ public final class QuicClientCodecBuilder extends QuicCodecBuilder<QuicClientCod
     @Override
     protected ChannelHandler build(QuicheConfig config,
                                    Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider,
-                                   int localConnIdLength) {
-        return new QuicheQuicClientCodec(config, sslEngineProvider, localConnIdLength);
+                                   int localConnIdLength, int maxBytesBeforeFlush) {
+        return new QuicheQuicClientCodec(config, sslEngineProvider, localConnIdLength, maxBytesBeforeFlush);
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -94,7 +94,6 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      * Sets the max number of bytes that were written before we force a flush of the data. While batching more bytes may
      * help to reduce syscalls it may also make the latency worse. Only adjust the setting if you really know what you
      * are doing.
-
      *
      * @param maxBytesBeforeFlush   the maximum number of bytes before a flush will be forced.
      * @return                      the instance itself.

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.channel.ChannelHandler;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -30,6 +31,7 @@ import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
  * @param <B> the type of the {@link QuicCodecBuilder}.
  */
 public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
+    private static final int DEFAULT_MAX_BYTES_BEFORE_FLUSH = 20 * Quic.MAX_DATAGRAM_SIZE;
     private final boolean server;
     private Boolean grease;
     private Long maxIdleTimeout;
@@ -48,6 +50,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     private QuicCongestionControlAlgorithm congestionControlAlgorithm;
     private int localConnIdLength = Quiche.QUICHE_MAX_CONN_ID_LEN;
     private Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider;
+    private int maxBytesBeforeFlush = DEFAULT_MAX_BYTES_BEFORE_FLUSH;
 
     QuicCodecBuilder(boolean server) {
         Quic.ensureAvailability();
@@ -74,6 +77,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
         this.congestionControlAlgorithm = builder.congestionControlAlgorithm;
         this.localConnIdLength = builder.localConnIdLength;
         this.sslEngineProvider = builder.sslEngineProvider;
+        this.maxBytesBeforeFlush = builder.maxBytesBeforeFlush;
     }
 
     /**
@@ -84,6 +88,20 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     @SuppressWarnings("unchecked")
     protected final B self() {
         return (B) this;
+    }
+
+    /**
+     * Sets the max number of bytes that were written before we force a flush of the data. While batching more bytes may
+     * help to reduce syscalls it may also make the latency worse. Only adjust the setting if you really know what you
+     * are doing.
+
+     *
+     * @param maxBytesBeforeFlush   the maximum number of bytes before a flush will be forced.
+     * @return                      the instance itself.
+     */
+    public final B maxBytesBeforeFlush(int maxBytesBeforeFlush) {
+        this.maxBytesBeforeFlush = ObjectUtil.checkPositive(maxBytesBeforeFlush, "maxBytesBeforeFlush");
+        return self();
     }
 
     /**
@@ -394,7 +412,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
         validate();
         QuicheConfig config = createConfig();
         try {
-            return build(config, sslEngineProvider, localConnIdLength);
+            return build(config, sslEngineProvider, localConnIdLength, maxBytesBeforeFlush);
         } catch (Throwable cause) {
             config.free();
             throw cause;
@@ -418,5 +436,5 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      */
     protected abstract ChannelHandler build(QuicheConfig config,
                                             Function<QuicChannel, ? extends QuicSslEngine> sslContextProvider,
-                                            int localConnIdLength);
+                                            int localConnIdLength, int maxBytesBeforeFlush);
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -184,7 +184,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     @Override
     protected ChannelHandler build(QuicheConfig config,
                                    Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider,
-                                   int localConnIdLength) {
+                                   int localConnIdLength, int maxBytesBeforeFlush) {
         validate();
         QuicTokenHandler tokenHandler = this.tokenHandler;
         QuicConnectionIdGenerator generator = connectionIdAddressGenerator;
@@ -193,8 +193,8 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
         }
         ChannelHandler handler = this.handler;
         ChannelHandler streamHandler = this.streamHandler;
-        return new QuicheQuicServerCodec(config, localConnIdLength, tokenHandler, generator, sslEngineProvider,
-                handler, Quic.toOptionsArray(options), Quic.toAttributesArray(attrs),
+        return new QuicheQuicServerCodec(config, localConnIdLength, tokenHandler, generator, maxBytesBeforeFlush,
+                sslEngineProvider, handler, Quic.toOptionsArray(options), Quic.toAttributesArray(attrs),
                 streamHandler, Quic.toOptionsArray(streamOptions), Quic.toAttributesArray(streamAttrs));
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
@@ -33,10 +33,10 @@ final class QuicheQuicClientCodec extends QuicheQuicCodec {
     private final Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider;
 
     QuicheQuicClientCodec(QuicheConfig config, Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider,
-                          int localConnIdLength) {
+                          int localConnIdLength, int maxBytesBeforeFlush) {
         // Let's just use Quic.MAX_DATAGRAM_SIZE as the maximum size for a token on the client side. This should be
         // safe enough and as we not have too many codecs at the same time this should be ok.
-        super(config, localConnIdLength, Quic.MAX_DATAGRAM_SIZE);
+        super(config, localConnIdLength, Quic.MAX_DATAGRAM_SIZE, maxBytesBeforeFlush);
         this.sslEngineProvider = sslEngineProvider;
     }
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -206,7 +206,9 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
     @Override
     public final void flush(ChannelHandlerContext ctx) {
-        flushNow(ctx);
+        if (pendingBytes > 0) {
+            flushNow(ctx);
+        }
     }
 
     private void flushNow(ChannelHandlerContext ctx) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -18,6 +18,8 @@ package io.netty.incubator.codec.quic;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -39,17 +41,21 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
     private final Map<ByteBuffer, QuicheQuicChannel> connections = new HashMap<>();
     private final Queue<QuicheQuicChannel> needsFireChannelReadComplete = new ArrayDeque<>();
     private final int maxTokenLength;
+    private final int maxBytesBeforeFlush;
 
+    private MessageSizeEstimator.Handle estimatorHandle;
     private QuicHeaderParser headerParser;
     private QuicHeaderParser.QuicHeaderProcessor parserCallback;
+    private int pendingBytes;
 
     protected final QuicheConfig config;
     protected final int localConnIdLength;
 
-    QuicheQuicCodec(QuicheConfig config, int localConnIdLength, int maxTokenLength) {
+    QuicheQuicCodec(QuicheConfig config, int localConnIdLength, int maxTokenLength, int maxBytesBeforeFlush) {
         this.config = config;
         this.localConnIdLength = localConnIdLength;
         this.maxTokenLength = maxTokenLength;
+        this.maxBytesBeforeFlush = maxBytesBeforeFlush;
     }
 
     protected QuicheQuicChannel getChannel(ByteBuffer key) {
@@ -74,6 +80,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
                 }
             }
         };
+        estimatorHandle = ctx.channel().config().getMessageSizeEstimator().newHandle();
     }
 
     @Override
@@ -177,6 +184,34 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
         }
 
         ctx.fireChannelWritabilityChanged();
+    }
+
+    @Override
+    public final void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)  {
+        int size = estimatorHandle.size(msg);
+        if (size > 0) {
+            pendingBytes += size;
+        }
+        try {
+            ctx.write(msg, promise);
+        } finally {
+            // If the number of bytes pending exceeds the max batch size we should force a flush() and so ensure
+            // these are delivered in a timely manner and also make room in the outboundbuffer again that belongs
+            // to the underlying channel.
+            if (pendingBytes > maxBytesBeforeFlush) {
+                flushNow(ctx);
+            }
+        }
+    }
+
+    @Override
+    public final void flush(ChannelHandlerContext ctx) {
+        flushNow(ctx);
+    }
+
+    private void flushNow(ChannelHandlerContext ctx) {
+        pendingBytes = 0;
+        ctx.flush();
     }
 
     private static void removeIfClosed(Iterator<?> iterator, QuicheQuicChannel current) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -54,6 +54,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
                           int localConnIdLength,
                           QuicTokenHandler tokenHandler,
                           QuicConnectionIdGenerator connectionIdAddressGenerator,
+                          int maxBytesBeforeFlush,
                           Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider,
                           ChannelHandler handler,
                           Map.Entry<ChannelOption<?>, Object>[] optionsArray,
@@ -61,7 +62,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
                           ChannelHandler streamHandler,
                           Map.Entry<ChannelOption<?>, Object>[] streamOptionsArray,
                           Map.Entry<AttributeKey<?>, Object>[] streamAttrsArray) {
-        super(config, localConnIdLength, tokenHandler.maxTokenLength());
+        super(config, localConnIdLength, tokenHandler.maxTokenLength(), maxBytesBeforeFlush);
         this.tokenHandler = tokenHandler;
         this.connectionIdAddressGenerator = connectionIdAddressGenerator;
         this.sslEngineProvider = sslEngineProvider;


### PR DESCRIPTION
Motivation:

To ensure we have some "timely" delivering of packets and also to ensure
we do some sort of "pacing" to make things more stable we should auto
flush after we have written X number of bytes to the underlying Channel.
This will help to make transfers more stable and ensure we make
progress.

Modifications:

- Add a new builder option which allows to configure after how many bytes
we should auto flush
- Use a default of 20 * 1350 bytes for auto flush for now

Result:

Not depend channel writability for auto flush and also make things more
stable