### PR TITLE
Add default implementation for maxNumSegments()

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/SegmentedDatagramPacketAllocator.java
+++ b/src/main/java/io/netty/incubator/codec/quic/SegmentedDatagramPacketAllocator.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 /**
  * Used to allocate datagram packets that use UDP_SEGMENT (GSO).
  */
+@FunctionalInterface
 public interface SegmentedDatagramPacketAllocator {
 
     /**
@@ -41,11 +42,14 @@ public interface SegmentedDatagramPacketAllocator {
     };
 
     /**
-     * The maximum number of segments to use per packet.
+     * The maximum number of segments to use per packet. By default this is {@code 10} but this may be overriden by
+     * the implementation of the interface.
      *
      * @return  the segments.
      */
-    int maxNumSegments();
+    default int maxNumSegments() {
+        return 10;
+    }
 
     /**
      * Return a new segmented {@link DatagramPacket}.


### PR DESCRIPTION
Motivation:

Use it is good enough to just use 10 as the maxNumSegments() by default. Let's just implement it as a default method. This also makes it possible to declare
SegmentedDatagramPacketAllocator as FunctionalInterface

Modifications:

- Add default maxNumSegments() implementation
- Mark interface as FunctionalInterface

Result:

Easier for users to make use of GSO