### PR TITLE
Add FlushStrategy to be even more flexible

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/FlushStrategy.java
+++ b/src/main/java/io/netty/incubator/codec/quic/FlushStrategy.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.util.internal.ObjectUtil;
+
+/**
+ * Allows to configure a strategy for when flushes should be happening.
+ */
+public interface FlushStrategy {
+
+    /**
+     * Default {@link FlushStrategy} implementation.
+     */
+    FlushStrategy DEFAULT = afterNumBytes(20 * Quic.MAX_DATAGRAM_SIZE);
+
+    /**
+     * Returns {@code true} if a flush should happen now, {@code false} otherwise.
+     *
+     * @param numPackets    the number of packets that were written since the last flush.
+     * @param numBytes      the number of bytes that were written since the last flush.
+     * @return              {@code true} if a flush should be done now, {@code false} otherwise.
+     */
+    boolean shouldFlushNow(int numPackets, int numBytes);
+
+    /**
+     * Implementation that flushes after a number of bytes.
+     *
+     * @param bytes the number of bytes after which we should issue a flush.
+     * @return the {@link FlushStrategy}.
+     */
+    static FlushStrategy afterNumBytes(int bytes) {
+        ObjectUtil.checkPositive(bytes, "bytes");
+        return (numPackets, numBytes) -> numBytes > bytes;
+    }
+
+    /**
+     * Implementation that flushes after a number of packets.
+     *
+     * @param packets the number of packets after which we should issue a flush.
+     * @return the {@link FlushStrategy}.
+     */
+    static FlushStrategy afterNumPackets(int packets) {
+        ObjectUtil.checkPositive(packets, "packets");
+        return (numPackets, numBytes) -> numPackets > packets;
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
@@ -44,7 +44,7 @@ public final class QuicClientCodecBuilder extends QuicCodecBuilder<QuicClientCod
     @Override
     protected ChannelHandler build(QuicheConfig config,
                                    Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider,
-                                   int localConnIdLength, int maxBytesBeforeFlush) {
-        return new QuicheQuicClientCodec(config, sslEngineProvider, localConnIdLength, maxBytesBeforeFlush);
+                                   int localConnIdLength, FlushStrategy flushStrategy) {
+        return new QuicheQuicClientCodec(config, sslEngineProvider, localConnIdLength, flushStrategy);
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -184,7 +184,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     @Override
     protected ChannelHandler build(QuicheConfig config,
                                    Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider,
-                                   int localConnIdLength, int maxBytesBeforeFlush) {
+                                   int localConnIdLength, FlushStrategy flushStrategy) {
         validate();
         QuicTokenHandler tokenHandler = this.tokenHandler;
         QuicConnectionIdGenerator generator = connectionIdAddressGenerator;
@@ -193,7 +193,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
         }
         ChannelHandler handler = this.handler;
         ChannelHandler streamHandler = this.streamHandler;
-        return new QuicheQuicServerCodec(config, localConnIdLength, tokenHandler, generator, maxBytesBeforeFlush,
+        return new QuicheQuicServerCodec(config, localConnIdLength, tokenHandler, generator, flushStrategy,
                 sslEngineProvider, handler, Quic.toOptionsArray(options), Quic.toAttributesArray(attrs),
                 streamHandler, Quic.toOptionsArray(streamOptions), Quic.toAttributesArray(streamAttrs));
     }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
@@ -18,7 +18,6 @@ package io.netty.incubator.codec.quic;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.handler.ssl.SslContext;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -33,10 +32,10 @@ final class QuicheQuicClientCodec extends QuicheQuicCodec {
     private final Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider;
 
     QuicheQuicClientCodec(QuicheConfig config, Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider,
-                          int localConnIdLength, int maxBytesBeforeFlush) {
+                          int localConnIdLength, FlushStrategy flushStrategy) {
         // Let's just use Quic.MAX_DATAGRAM_SIZE as the maximum size for a token on the client side. This should be
         // safe enough and as we not have too many codecs at the same time this should be ok.
-        super(config, localConnIdLength, Quic.MAX_DATAGRAM_SIZE, maxBytesBeforeFlush);
+        super(config, localConnIdLength, Quic.MAX_DATAGRAM_SIZE, flushStrategy);
         this.sslEngineProvider = sslEngineProvider;
     }
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -54,7 +54,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
                           int localConnIdLength,
                           QuicTokenHandler tokenHandler,
                           QuicConnectionIdGenerator connectionIdAddressGenerator,
-                          int maxBytesBeforeFlush,
+                          FlushStrategy flushStrategy,
                           Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider,
                           ChannelHandler handler,
                           Map.Entry<ChannelOption<?>, Object>[] optionsArray,
@@ -62,7 +62,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
                           ChannelHandler streamHandler,
                           Map.Entry<ChannelOption<?>, Object>[] streamOptionsArray,
                           Map.Entry<AttributeKey<?>, Object>[] streamAttrsArray) {
-        super(config, localConnIdLength, tokenHandler.maxTokenLength(), maxBytesBeforeFlush);
+        super(config, localConnIdLength, tokenHandler.maxTokenLength(), flushStrategy);
         this.tokenHandler = tokenHandler;
         this.connectionIdAddressGenerator = connectionIdAddressGenerator;
         this.sslEngineProvider = sslEngineProvider;


### PR DESCRIPTION
Motivation:

85d313b4d43a79cf5f3e816991e83a7c86f727f3 added some sort of auto flushing after X bytes. While this works very well in practice some users may need something more flexible.

Modifications:

Add FlushStrategy as an API that can be used to influence how flushes are executed.
Add a default implementation which flushes after X bytes (just as we did before)

Result:

More flexible way of influence when flushes happen