### PR TITLE
Make it easier for users to setup GSO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -817,12 +817,21 @@
       <artifactId>netty-transport</artifactId>
       <version>${netty.version}</version>
     </dependency>
+    <!-- Lets add this as optional dependency so users can include it for GSO support -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>${netty.version}</version>
+      <optional>true</optional>
+    </dependency>
+
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
       <version>${netty.version}</version>
       <classifier>linux-x86_64</classifier>
       <scope>test</scope>
+      <optional>false</optional>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/io/netty/incubator/codec/quic/EpollSegmentedDatagramPacketAllocator.java
+++ b/src/main/java/io/netty/incubator/codec/quic/EpollSegmentedDatagramPacketAllocator.java
@@ -18,15 +18,20 @@ package io.netty.incubator.codec.quic;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.epoll.SegmentedDatagramPacket;
 import io.netty.channel.socket.DatagramPacket;
+import io.netty.util.internal.ObjectUtil;
 
 import java.net.InetSocketAddress;
 
+/**
+ * {@link SegmentedDatagramPacketAllocator} for epoll. It's important that we only access this class if we are sure
+ * that the user actually has the epoll classes on the classpath.
+ */
 final class EpollSegmentedDatagramPacketAllocator implements SegmentedDatagramPacketAllocator {
 
     private final int maxNumSegments;
 
     EpollSegmentedDatagramPacketAllocator(int maxNumSegments) {
-        this.maxNumSegments = maxNumSegments;
+        this.maxNumSegments = ObjectUtil.checkPositive(maxNumSegments, "maxNumSegments");
     }
 
     @Override

--- a/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
@@ -16,22 +16,18 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.epoll.SegmentedDatagramPacket;
 import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.NetUtil;
 
-import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
@@ -111,9 +107,9 @@ final class QuicTestUtils {
                 .initialMaxStreamsBidirectional(100)
                 .initialMaxStreamsUnidirectional(100)
                 .activeMigration(false);
-        if (GROUP instanceof EpollEventLoopGroup && EpollSegmentedDatagramPacketAllocator.isSupported()) {
+        if (GROUP instanceof EpollEventLoopGroup) {
             builder.option(QuicChannelOption.SEGMENTED_DATAGRAM_PACKET_ALLOCATOR,
-                    new EpollSegmentedDatagramPacketAllocator(10));
+                    Quic.newSegmentedAllocator(EpollDatagramChannel.class));
         }
         return builder;
     }

--- a/src/test/java/io/netty/incubator/codec/quic/example/QuicServerExample.java
+++ b/src/test/java/io/netty/incubator/codec/quic/example/QuicServerExample.java
@@ -22,16 +22,24 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollDatagramChannel;
+import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.incubator.codec.quic.InsecureQuicTokenHandler;
+import io.netty.incubator.codec.quic.Quic;
 import io.netty.incubator.codec.quic.QuicChannel;
+import io.netty.incubator.codec.quic.QuicChannelOption;
 import io.netty.incubator.codec.quic.QuicServerCodecBuilder;
 import io.netty.incubator.codec.quic.QuicSslContext;
 import io.netty.incubator.codec.quic.QuicSslContextBuilder;
 import io.netty.incubator.codec.quic.QuicStreamChannel;
+import io.netty.incubator.codec.quic.SegmentedDatagramPacketAllocator;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -50,72 +58,89 @@ public final class QuicServerExample {
         QuicSslContext context = QuicSslContextBuilder.forServer(
                 selfSignedCertificate.privateKey(), null, selfSignedCertificate.certificate())
                 .applicationProtocols("http/0.9").build();
-        NioEventLoopGroup group = new NioEventLoopGroup(1);
-        ChannelHandler codec = new QuicServerCodecBuilder().sslContext(context)
-                .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
-                // Configure some limits for the maximal number of streams (and the data) that we want to handle.
-                .initialMaxData(10000000)
-                .initialMaxStreamDataBidirectionalLocal(1000000)
-                .initialMaxStreamDataBidirectionalRemote(1000000)
-                .initialMaxStreamsBidirectional(100)
-                .initialMaxStreamsUnidirectional(100)
+        EventLoopGroup group = null;
+        Class<? extends DatagramChannel> channelType;
+        try {
+            if (Epoll.isAvailable()) {
+                group = new EpollEventLoopGroup(1);
+                channelType = EpollDatagramChannel.class;
+            } else {
+                group = new NioEventLoopGroup(1);
+                channelType = NioDatagramChannel.class;
+            }
+            // Use GSO if possible.
+            final SegmentedDatagramPacketAllocator segmentedAllocator = Quic.newSegmentedAllocator(channelType);
 
-                // Setup a token handler. In a production system you would want to implement and provide your custom
-                // one.
-                .tokenHandler(InsecureQuicTokenHandler.INSTANCE)
-                // ChannelHandler that is added into QuicChannel pipeline.
-                .handler(new ChannelInboundHandlerAdapter() {
-                    @Override
-                    public void channelActive(ChannelHandlerContext ctx) {
-                        QuicChannel channel = (QuicChannel) ctx.channel();
-                        // Create streams etc..
-                    }
+            ChannelHandler codec = new QuicServerCodecBuilder().sslContext(context)
+                    .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
+                    // Configure some limits for the maximal number of streams (and the data) that we want to handle.
+                    .initialMaxData(10000000)
+                    .initialMaxStreamDataBidirectionalLocal(1000000)
+                    .initialMaxStreamDataBidirectionalRemote(1000000)
+                    .initialMaxStreamsBidirectional(100)
+                    .initialMaxStreamsUnidirectional(100)
 
-                    public void channelInactive(ChannelHandlerContext ctx) {
-                        ((QuicChannel) ctx.channel()).collectStats().addListener(f -> {
-                            if (f.isSuccess()) {
-                                LOGGER.info("Connection closed: {}", f.getNow());
-                            }
-                        });
-                    }
+                    // Setup a token handler. In a production system you would want to implement and provide your custom
+                    // one.
+                    .tokenHandler(InsecureQuicTokenHandler.INSTANCE)
+                    // ChannelHandler that is added into QuicChannel pipeline.
+                    .handler(new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void channelActive(ChannelHandlerContext ctx) {
+                            QuicChannel channel = (QuicChannel) ctx.channel();
+                            // Create streams etc..
+                        }
 
-                    @Override
-                    public boolean isSharable() {
-                        return true;
-                    }
-                })
-                .streamHandler(new ChannelInitializer<QuicStreamChannel>() {
-                    @Override
-                    protected void initChannel(QuicStreamChannel ch)  {
-                        // Add a LineBasedFrameDecoder here as we just want to do some simple HTTP 0.9 handling.
-                        ch.pipeline().addLast(new LineBasedFrameDecoder(1024))
-                                .addLast(new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void channelInactive(ChannelHandlerContext ctx) {
+                            ((QuicChannel) ctx.channel()).collectStats().addListener(f -> {
+                                if (f.isSuccess()) {
+                                    LOGGER.info("Connection closed: {}", f.getNow());
+                                }
+                            });
+                        }
+
+                        @Override
+                        public boolean isSharable() {
+                            return true;
+                        }
+                    })
+                    .streamHandler(new ChannelInitializer<QuicStreamChannel>() {
+                        @Override
+                        protected void initChannel(QuicStreamChannel ch)  {
+                            // Add a LineBasedFrameDecoder here as we just want to do some simple HTTP 0.9 handling.
+                            ch.pipeline().addLast(new LineBasedFrameDecoder(1024))
+                                    .addLast(new ChannelInboundHandlerAdapter() {
                             @Override
                             public void channelRead(ChannelHandlerContext ctx, Object msg) {
-                                ByteBuf byteBuf = (ByteBuf) msg;
-                                try {
-                                    if (byteBuf.toString(CharsetUtil.US_ASCII).trim().equals("GET /")) {
-                                        ByteBuf buffer = ctx.alloc().directBuffer();
-                                        buffer.writeCharSequence("Hello World!\r\n", CharsetUtil.US_ASCII);
-                                        // Write the buffer and shutdown the output by writing a FIN.
-                                        ctx.writeAndFlush(buffer).addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
+                                    ByteBuf byteBuf = (ByteBuf) msg;
+                                    try {
+                                        if (byteBuf.toString(CharsetUtil.US_ASCII).trim().equals("GET /")) {
+                                            ByteBuf buffer = ctx.alloc().directBuffer();
+                                            buffer.writeCharSequence("Hello World!\r\n", CharsetUtil.US_ASCII);
+                                            // Write the buffer and shutdown the output by writing a FIN.
+                                            ctx.writeAndFlush(buffer).addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
+                                        }
+                                    } finally {
+                                        byteBuf.release();
                                     }
-                                } finally {
-                                    byteBuf.release();
                                 }
-                            }
-                        });
-                    }
-                }).build();
-        try {
+                            });
+                        }
+                    })
+                    .option(QuicChannelOption.SEGMENTED_DATAGRAM_PACKET_ALLOCATOR, segmentedAllocator)
+                    .build();
+
             Bootstrap bs = new Bootstrap();
             Channel channel = bs.group(group)
-                    .channel(NioDatagramChannel.class)
+                    .channel(channelType)
                     .handler(codec)
                     .bind(new InetSocketAddress(9999)).sync().channel();
             channel.closeFuture().sync();
         } finally {
-            group.shutdownGracefully();
+            if (group != null) {
+                group.shutdownGracefully();
+            }
         }
     }
 }


### PR DESCRIPTION
Motivation:

We added an API for GSO suipport recently but it was kind of hard for users to setup as an own SegmentedDatagraPacketAllocator needs to be implemented.

Modifications:

- Add some utility method to Quic class which return a SegmentedDatagramPacketAllocator for the user based on the Channel type that is used.
- Add epoll as optional dependency
- Update examples to show how the GSO setup should be done.

Result:

Easier for people to use GSO