### PR TITLE
Add support for cross-compiling to linux aarch64

### DIFF
--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -1,0 +1,68 @@
+FROM centos:7.6.1810
+
+ARG GCC_VERSION=10.2-2020.11
+ENV SOURCE_DIR /root/source
+ENV WORKSPACE_DIR /root/workspace
+ENV PROJECT_DIR /root/workspace/project
+
+# We want to have git 2.x for the maven scm plugin and also for boringssl
+RUN yum install -y http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm
+
+RUN yum -y install epel-release
+
+# Install requirements
+RUN yum install -y \
+ apr-devel \
+ autoconf \
+ automake \
+ bzip2 \
+ git \
+ glibc-devel \
+ golang \
+ gnupg \
+ libtool \
+ lsb-core \
+ ninja-build \
+ make \
+ perl \
+ tar \
+ unzip \
+ wget
+
+
+RUN mkdir $SOURCE_DIR
+WORKDIR $SOURCE_DIR
+
+# Install Java
+RUN yum install -y java-1.8.0-openjdk-devel golang
+ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk/"
+
+# Install aarch64 gcc 10.2 toolchain
+RUN wget https://developer.arm.com/-/media/Files/downloads/gnu-a/$GCC_VERSION/binrel/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && \
+  tar xvf gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && mv gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu /opt/
+ENV PATH="/opt/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu/bin:${PATH}"
+
+# Install CMake
+RUN yum install -y cmake3 && ln -s /usr/bin/cmake3 /usr/bin/cmake
+
+# install rust and setup PATH and install correct toolchain
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="$HOME/.cargo/bin:${PATH}"
+RUN /root/.cargo/bin/rustup target add aarch64-unknown-linux-gnu
+
+# Setup the correct linker
+RUN echo '[target.aarch64-unknown-linux-gnu]' >> /root/.cargo/config
+RUN echo 'linker = "aarch64-none-linux-gnu-gcc"' >> /root/.cargo/config
+
+
+WORKDIR /opt
+RUN curl https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar -xz
+RUN echo 'PATH=/opt/apache-maven-3.6.3/bin/:$PATH' >> ~/.bashrc
+
+# Prepare our own build
+ENV PATH /opt/apache-maven-3.6.3/bin/:$PATH
+
+COPY ./pom.xml $SOURCE_DIR/pom.xml
+WORKDIR $SOURCE_DIR
+RUN /bin/bash -c 'source $HOME/.bashrc && mvn dependency:go-offline surefire:test -ntp && rm -rf target'
+

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -1,0 +1,67 @@
+version: "3"
+
+services:
+
+  cross-compile-aarch64-runtime-setup:
+    image: netty-quic-centos:cross_compile_aarch64
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile.cross_compile_aarch64
+      args:
+        gcc_version: "10.2-2020.11"
+
+  cross-compile-aarch64-common: &cross-compile-aarch64-common
+    image: netty-quic-centos:cross_compile_aarch64
+    depends_on: [cross-compile-aarch64-runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh:delegated
+      - ~/.gnupg:/root/.gnupg:delegated
+      - ~/.gitconfig:/root/.gitconfig:delegated
+      - ~/.gitignore:/root/.gitignore:delegated
+      - ..:/code:delegated
+    working_dir: /code
+
+  cross-compile-aarch64-shell:
+    <<: *cross-compile-aarch64-common
+    volumes:
+      - ~/.ssh:/root/.ssh:delegated
+      - ~/.gnupg:/root/.gnupg:delegated
+      - ~/.m2:/root/.m2:delegated
+      - ~/.gitconfig:/root/.gitconfig:delegated
+      - ~/.gitignore:/root/.gitignore:delegated
+      - ..:/code:delegated
+    entrypoint: /bin/bash
+
+  cross-compile-aarch64-build:
+    <<: *cross-compile-aarch64-common
+    command: /bin/bash -cl "mvn clean package -Plinux-aarch64 -DskipTests"
+
+  cross-compile-aarch64-deploy:
+    <<: *cross-compile-aarch64-common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2/settings.xml:/root/.m2/settings.xml
+    command: /bin/bash -cl "mvn clean deploy -Plinux-aarch64 -DskipTests"
+
+  cross-compile-aarch64-stage-snapshot:
+    <<: *cross-compile-aarch64-common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/local-staging:/root/local-staging
+      - ..:/code
+    command: /bin/bash -cl "mvn -Plinux-aarch64 clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+
+  cross-compile-aarch64-stage-release:
+    <<: *cross-compile-aarch64-common
+    environment:
+      - GPG_KEYNAME
+      - GPG_PASSPHRASE
+      - GPG_PRIVATE_KEY
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.m2/settings.xml:/root/.m2/settings.xml
+      - ~/local-staging:/root/local-staging
+      - ..:/code
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && mvn -Plinux-aarch64 clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"

--- a/pom.xml
+++ b/pom.xml
@@ -97,10 +97,12 @@
     <cargoTarget />
     <cflags>-std=c99 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3 -I${quicheHomeIncludeDir} -I${boringsslHomeIncludeDir}</cflags>
     <ldflags>-L${quicheHomeBuildDir} -lquiche -L${boringsslHomeBuildDir} -lssl -lcrypto</ldflags>
+    <extraCmakeFlags />
     <extraCflags />
     <extraCxxflags />
     <extraLdflags />
     <extraConfigureArg />
+    <extraConfigureArg2 />
     <!-- We need 10.12 as minimum to compile quiche and use it.
          Anything below will fail when trying to load quiche with:
          Symbol not found: ___isPlatformVersionAtLeast
@@ -108,6 +110,7 @@
     <macosxDeploymentTarget />
     <test.argLine>-D_</test.argLine>
     <bundleNativeCode />
+    <crossCompile />
   </properties>
   <profiles>
     <profile>
@@ -181,6 +184,34 @@
         <libquiche>libquiche.a</libquiche>
         <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL -lrt</extraLdflags>
         <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=${os.detected.arch}</bundleNativeCode>
+      </properties>
+    </profile>
+    <profile>
+      <id>linux-aarch64</id>
+      <properties>
+        <extraCflags>-O3 -fno-omit-frame-pointer</extraCflags>
+        <extraCxxflags>-O3 -fno-omit-frame-pointer</extraCxxflags>
+        <!-- On *nix, add ASM flags to disable executable stack -->
+        <cmakeAsmFlags>-Wa,--noexecstack</cmakeAsmFlags>
+        <cmakeCFlags>${extraCflags} -DOPENSSL_C11_ATOMIC</cmakeCFlags>
+        <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
+        <cmakeCxxFlags>${extraCxxflags} -DOPENSSL_C11_ATOMIC -Wno-error=maybe-uninitialized -Wno-error=shadow -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS</cmakeCxxFlags>
+        <libssl>libssl.a</libssl>
+        <libcrypto>libcrypto.a</libcrypto>
+        <libquiche>libquiche.a</libquiche>
+        <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL -lrt</extraLdflags>
+        <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=aarch_64</bundleNativeCode>
+        <jniLibName>netty_quiche_linux_aarch_64</jniLibName>
+        <jni.classifier>linux-aarch_64</jni.classifier>
+        <extraConfigureArg>--host=aarch64-linux-gnu</extraConfigureArg>
+        <extraConfigureArg2>CC=aarch64-none-linux-gnu-gcc</extraConfigureArg2>
+        <extraCmakeFlags>-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-none-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-none-linux-gnu-g++</extraCmakeFlags>
+        <!-- Don't run tests as we can't load the aarch64 lib on a x86_64 system -->
+        <skipTests>true</skipTests>
+        <crossCompile>true</crossCompile>
+        <quicheTarget>aarch64-unknown-linux-gnu</quicheTarget>
+        <cargoTarget>--target=${quicheTarget}</cargoTarget>
+        <quicheBuildDir>${quicheSourceDir}/target/${quicheTarget}/release</quicheBuildDir>
       </properties>
     </profile>
     <profile>
@@ -317,6 +348,8 @@
                     <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
                     <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
                     <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                    <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                    <arg line="${extraCmakeFlags}" />
                     <arg value="-GNinja" />
                     <arg value="${boringsslSourceDir}" />
                   </exec>
@@ -403,7 +436,20 @@
                         <env key="OPT_LEVEL" value="3" />
                         <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
                       </exec>
-                   </then>
+                    </then>
+                    <elseif>
+                     <equals arg1="${crossCompile}" arg2="true" />
+                      <then>
+                        <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
+                          <arg line="build --features &quot;ffi qlog&quot; --release" />
+                          <arg value="${cargoTarget}" />
+                          <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
+                          <!-- Lets enable frame-pointers so we can profile better -->
+                          <env key="RUSTFLAGS" value="-Cforce-frame-pointers=yes" />
+                          <env key="TARGET_CC" value="aarch64-none-linux-gnu-gcc" />
+                        </exec>
+                      </then>
+                    </elseif>
                     <else>
                       <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
                         <arg line="build --features &quot;ffi qlog&quot; --release" />
@@ -731,6 +777,7 @@
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <configureArgs>
                 <configureArg>${extraConfigureArg}</configureArg>
+                <configureArg>${extraConfigureArg2}</configureArg>
                 <configureArg>CFLAGS=${cflags}</configureArg>
                 <configureArg>LDFLAGS=${ldflags} ${extraLdflags}</configureArg>
                 <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>


### PR DESCRIPTION
Motivation:

We should also release artifacts for linux aarch64 in the future.

Modifications:

Add docker (compose) files which allow to cross compile for linux aarch64

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/80