### PR TITLE
Deploy snapshots for aarch64 and also include in release process

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -11,11 +11,32 @@ on:
   workflow_dispatch:
 
 jobs:
-  stage-snapshot-linux-x86_64:
+  stage-snapshot-linux:
     runs-on: ubuntu-latest
-    name: stage-snapshot-linux-x86_64
+    strategy:
+      matrix:
+        include:
+          - setup: linux-x86_64
+            docker-compose-build: "-f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run stage-snapshot"
+          - setup: linux-aarch64
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-stage-snapshot"
+
+    name: stage-snapshot-${{ matrix.setup }}
     steps:
       - uses: actions/checkout@v2
+
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        env:
+          cache-name: staging-${{ matrix.setup }}-cache-m2-repository
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-staging-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-staging-${{ env.cache-name }}-
+            ${{ runner.os }}-staging-
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
@@ -31,18 +52,17 @@ jobs:
         run: mkdir -p ~/local-staging
 
       - name: Build docker image
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
+        run: docker-compose ${{ matrix.docker-compose-build }}
 
       - name: Stage snapshots to local staging directory
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run stage-snapshot
+        run: docker-compose ${{ matrix.docker-compose-run }}
 
       - name: Upload local staging directory
         uses: actions/upload-artifact@v2
         with:
-          name: linux-x86_64-local-staging
+          name: ${{ matrix.setup }}-local-staging
           path: ~/local-staging
           if-no-files-found: error
-
 
   stage-snapshot-windows-x86_64:
     runs-on: windows-2016
@@ -100,7 +120,7 @@ jobs:
   deploy-staged-snapshots:
     runs-on: ubuntu-18.04
     # Wait until we have staged everything
-    needs: [stage-snapshot-linux-x86_64, stage-snapshot-windows-x86_64]
+    needs: [stage-snapshot-linux, stage-snapshot-windows-x86_64]
     steps:
       - uses: actions/checkout@v2
 
@@ -133,6 +153,12 @@ jobs:
           name: windows-x86_64-local-staging
           path: ~/windows-x86_64-local-staging
 
+      - name: Download linux-aarch64 staging directory
+        uses: actions/download-artifact@v2
+        with:
+          name: linux-aarch64-local-staging
+          path: ~/linux-aarch64-local-staging
+
       - name: Download linux-x86_64 staging directory
         uses: actions/download-artifact@v2
         with:
@@ -140,7 +166,7 @@ jobs:
           path: ~/linux-x86_64-local-staging
 
       - name: Merge staging repositories
-        run: bash ./.github/scripts/merge_local_staging.sh ~/local-staging ~/windows-x86_64-local-staging ~/linux-x86_64-local-staging
+        run: bash ./.github/scripts/merge_local_staging.sh ~/local-staging ~/windows-x86_64-local-staging ~/linux-aarch64-local-staging ~/linux-x86_64-local-staging
 
       - uses: s4u/maven-settings-action@v2.2.0
         with:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -53,16 +53,30 @@ jobs:
           name: prepare-release-workspace
           path: ${{ github.workspace }}/**
 
-  stage-release-linux-x86_64:
+  stage-release-linux:
     runs-on: ubuntu-latest
     needs: prepare-release
-    name: stage-release-linux-x86_64
+    strategy:
+      matrix:
+        include:
+          - setup: linux-x86_64-java8
+            docker-compose-build: "-f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run stage-release"
+          - setup: linux-aarch64
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-stage-release"
+
+    name: stage-release-${{ matrix.setup }}
+
     steps:
       - name: Download release-workspace
         uses: actions/download-artifact@v2
         with:
           name: prepare-release-workspace
           path: ./prepare-release-workspace/
+
+      - name: Adjust mvnw permissions
+        run: chmod 755 ./prepare-release-workspace/mvnw
 
       - name: Set up JDK 8
         uses: actions/setup-java@v1
@@ -90,9 +104,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-staging-${{ env.docker-cache-name }}-
 
-      - name: Create local staging directory
-        run: mkdir -p ~/local-staging
-
       - uses: s4u/maven-settings-action@v2.2.0
         with:
           servers: |
@@ -102,9 +113,12 @@ jobs:
               "password": "${{ secrets.SONATYPE_PASSWORD }}"
             }]
 
+      - name: Create local staging directory
+        run: mkdir -p ~/local-staging
+
       - name: Build docker image
         working-directory: ./prepare-release-workspace/
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
+        run: docker-compose ${{ matrix.docker-compose-build }}
 
       - name: Stage release to local staging directory
         working-directory: ./prepare-release-workspace/
@@ -112,13 +126,14 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_KEYNAME: ${{ secrets.GPG_KEYNAME }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run stage-release
+        run: docker-compose ${{ matrix.docker-compose-run }}
 
       - name: Upload local staging directory
         uses: actions/upload-artifact@v2
         with:
-          name: linux-x86_64-local-staging
+          name: ${{ matrix.setup }}-local-staging
           path: ~/local-staging
+          if-no-files-found: error
 
       - name: Rollback release on failure
         working-directory: ./prepare-release-workspace/
@@ -221,7 +236,7 @@ jobs:
   deploy-staged-release:
     runs-on: ubuntu-18.04
     # Wait until we have staged everything
-    needs: [stage-release-linux-x86_64, stage-release-windows-x86_64]
+    needs: [stage-release-linux, stage-release-windows-x86_64]
     steps:
       - name: Download release-workspace
         uses: actions/download-artifact@v2
@@ -256,6 +271,12 @@ jobs:
       - name: Download linux-x86_64 staging directory
         uses: actions/download-artifact@v2
         with:
+          name: linux-aarch64-local-staging
+          path: ~/linux-aarch64-local-staging
+
+      - name: Download linux-x86_64 staging directory
+        uses: actions/download-artifact@v2
+        with:
           name: linux-x86_64-local-staging
           path: ~/linux-x86_64-local-staging
 
@@ -263,7 +284,7 @@ jobs:
       # all together with one maven command.
       - name: Merge staging repositories
         working-directory: ./prepare-release-workspace/
-        run: bash ./.github/scripts/merge_local_staging.sh /home/runner/local-staging/staging ~/windows-x86_64-local-staging/staging ~/linux-x86_64-local-staging/staging
+        run: bash ./.github/scripts/merge_local_staging.sh /home/runner/local-staging/staging ~/windows-x86_64-local-staging/staging ~/linux-aarch64-local-staging/staging ~/linux-x86_64-local-staging/staging
 
       - uses: s4u/maven-settings-action@v2.2.0
         with:


### PR DESCRIPTION
Motivation:

7ea4ab462ec9bcf5f11d7577f751c4f758dc6117 added support for cross-compiling for aarch64. We should also deploy snaphots for it and include these in the release process

Modifications:

Adjust github workflow to also include aarch64

Result:

Support more platforms