### PR TITLE
Add workflow that verifies that we can load native libs on aarch64

### DIFF
--- a/.github/scripts/check_load_native.sh
+++ b/.github/scripts/check_load_native.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne 3 ]; then
+    echo "Expected jar directory, classname and method"
+    exit 1
+fi
+
+TEMP_FILE=$(mktemp)
+
+cat <<EOT > "$TEMP_FILE"
+public class Load {
+    public static void main(String... args) {
+        try {
+            System.out.println("Invoking " + args[0] + "." + args[1] + "();");
+            Class<?> clazz = Class.forName(args[0]);
+            clazz.getDeclaredMethod(args[1]).invoke(null);
+        } catch (Throwable cause) {
+            System.out.println("Native loading failed");
+            cause.printStackTrace();
+            System.exit(1);
+        }
+        System.out.println("Native loading successful");
+    }
+}
+EOT
+
+JAVA_FILE="$TEMP_FILE".java
+mv "$TEMP_FILE" "$JAVA_FILE"
+CLASSPATH=$(find "$1" -name '*.jar' | grep -v tests.jar | grep -v sources.jar | tr '\n' ':')
+java -cp "$CLASSPATH" "$JAVA_FILE" "$2" "$3"
+EXIT_CODE=$?
+rm "$JAVA_FILE"
+exit "$EXIT_CODE"

--- a/.github/workflows/ci-verify-load.yml
+++ b/.github/workflows/ci-verify-load.yml
@@ -1,0 +1,76 @@
+name: Verify native library loading
+
+on:
+  push:
+    branches: [ main ]
+
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  install-jars-linux-aarch64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Enable caching of Docker layers
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+        with:
+          key: pr-linux-x86_64-docker-cache-{hash}
+          restore-keys: |
+            pr-linux-x86_64-docker-cache-
+
+      - name: Build docker image
+        run: docker-compose -f docker/docker-compose.centos-7.yaml build
+
+      - name: Build project and install jars
+        run: docker-compose -f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-install
+
+      - name: Upload the maven repository
+        uses: actions/upload-artifact@v2
+        with:
+          name: maven-repository
+          # We only need the netty jars.
+          path: ~/.m2/repository/io/netty/
+          if-no-files-found: error
+
+  load-native-linux-aarch64:
+    # The host should always be Linux
+    runs-on: ubuntu-latest
+    needs: [ install-jars-linux-aarch64 ]
+    steps:
+      - uses: actions/checkout@v2.1.0
+
+      - name: Download the maven repository
+        uses: actions/download-artifact@v2
+        with:
+          name:  maven-repository
+          path: /home/runner/jars
+
+      - uses: uraimo/run-on-arch-action@v2.0.9
+        name: Check native loading
+        id: runcmd
+        with:
+          arch: aarch64
+          distro: ubuntu18.04
+
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
+
+          # Mount the .m2/repository
+          dockerRunArgs: |
+            --volume "/home/runner/jars:/root/jars"
+
+          # Install dependencies
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y openjdk-11-jdk
+
+          # Check if we can load the native code on aarch64
+          run: |
+            .github/scripts/check_load_native.sh /root/jars io.netty.incubator.codec.quic.Quic ensureAvailability

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -65,3 +65,12 @@ services:
       - ~/local-staging:/root/local-staging
       - ..:/code
     command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && mvn -Plinux-aarch64 clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+
+  cross-compile-aarch64-install:
+    <<: *cross-compile-aarch64-common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2:/root/.m2
+      - ..:/code
+    command: /bin/bash -cl "mvn clean install -Plinux-aarch64 -DskipTests=true"


### PR DESCRIPTION
Motivation:

Now that we cross-compile for aarch64 we should also ensure we can actually load the native library on this platform

Modifications:

Add workflow and script to check if we can load the library on aarch64

Result:

Ensure native library is usable on aarch64