### PR TITLE
Use netty-jni-util 0.0.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -835,7 +835,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-jni-util</artifactId>
-      <version>0.0.2.Final</version>
+      <version>0.0.3.Final</version>
       <classifier>sources</classifier>
       <optional>true</optional>
     </dependency>

--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -23,8 +23,8 @@
 #include "netty_quic_boringssl.h"
 #include "netty_quic.h"
 
-// Add define if NETTY_BUILD_STATIC is defined so it is picked up in netty_jni_util.c
-#ifdef NETTY_BUILD_STATIC
+// Add define if NETTY_QUIC_BUILD_STATIC is defined so it is picked up in netty_jni_util.c
+#ifdef NETTY_QUIC_BUILD_STATIC
 #define NETTY_JNI_UTIL_BUILD_STATIC
 #endif
 
@@ -36,6 +36,7 @@ static jclass    quiche_logger_class;
 static jmethodID quiche_logger_class_log;
 static jobject   quiche_logger;
 static JavaVM     *global_vm = NULL;
+static char* staticPackagePrefix = NULL;
 
 jint quic_get_java_env(JNIEnv **env)
 {
@@ -596,6 +597,9 @@ static jint netty_quiche_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     }
     boringsslLoaded = 1;
 
+    if (packagePrefix) {
+        staticPackagePrefix = strdup(packagePrefix);
+    }
     ret = NETTY_JNI_UTIL_JNI_VERSION;
 done:
     if (ret == JNI_ERR) {
@@ -615,18 +619,20 @@ done:
     return ret;
 }
 
-static void netty_quiche_JNI_OnUnload(JNIEnv* env, const char* packagePrefix) {
-    netty_boringssl_JNI_OnUnload(env, packagePrefix);
+static void netty_quiche_JNI_OnUnload(JNIEnv* env) {
+    netty_boringssl_JNI_OnUnload(env, staticPackagePrefix);
 
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, quiche_logger_class);
 
-    netty_jni_util_unregister_natives(env, packagePrefix, STATICALLY_CLASSNAME);
-    netty_jni_util_unregister_natives(env, packagePrefix, QUICHE_CLASSNAME);
+    netty_jni_util_unregister_natives(env, staticPackagePrefix, STATICALLY_CLASSNAME);
+    netty_jni_util_unregister_natives(env, staticPackagePrefix, QUICHE_CLASSNAME);
 
     if (quiche_logger != NULL) {
         (*env)->DeleteGlobalRef(env, quiche_logger);
         quiche_logger = NULL;
     }
+    free(staticPackagePrefix);
+    staticPackagePrefix = NULL;
 }
 
 // Invoked by the JVM when statically linked
@@ -646,7 +652,7 @@ JNIEXPORT void JNI_OnUnload_netty_quiche(JavaVM* vm, void* reserved) {
     global_vm = NULL;
 }
 
-#ifndef NETTY_BUILD_STATIC
+#ifndef NETTY_QUIC_BUILD_STATIC
 JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     global_vm = vm;
     return netty_jni_util_JNI_OnLoad(vm, reserved, LIBRARYNAME, netty_quiche_JNI_OnLoad);
@@ -656,4 +662,4 @@ JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved) {
     netty_jni_util_JNI_OnUnload(vm, reserved, netty_quiche_JNI_OnUnload);
     global_vm = NULL;
 }
-#endif /* NETTY_BUILD_STATIC */
+#endif /* NETTY_QUIC_BUILD_STATIC */

--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -38,6 +38,9 @@ static jobject   quiche_logger;
 static JavaVM     *global_vm = NULL;
 static char* staticPackagePrefix = NULL;
 
+// Add extern declaration to let it compile with -std=c99 
+extern char* strdup(const char*);
+
 jint quic_get_java_env(JNIEnv **env)
 {
     return (*global_vm)->GetEnv(global_vm, (void **)env, NETTY_JNI_UTIL_JNI_VERSION);


### PR DESCRIPTION
Motifivation:

netty-jni-util 0.0.2.Final is incompatible with static linking. netty-jni-util 0.0.3.Final adds static linking compatibility.

Modifications:

Bump netty-jni-util to version 0.0.3.Final and update to its new API
which requires the caller to manage packagePrefix.

Result:

Using latest version of netty-jni-util and support static linking
compatibility.