### PR TITLE
Include aarch64 builds for PR and normal builds

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,6 +40,32 @@ jobs:
           name: target
           path: "**/target/"
 
+  build-linux-aarch64:
+    runs-on: ubuntu-latest
+    name: linux-x86_64
+    steps:
+      - uses: actions/checkout@v2
+
+      # Enable caching of Docker layers
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+        with:
+          key: build-linux-x86_64-docker-cache-{hash}
+          restore-keys: |
+            build-linux-x86_64-docker-cache-
+
+      - name: Build docker image
+        run: docker-compose -f docker/docker-compose.centos-7.yaml build
+
+      - name: Build project without leak detection
+        run: docker-compose -f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-build
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: target
+          path: "**/target/"
+
   build-windows:
     runs-on: windows-2016
     name: windows-x86_64

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -47,6 +47,33 @@ jobs:
           name: target
           path: "**/target/"
 
+  build-linux-aarch64:
+    runs-on: ubuntu-latest
+    name: linux-aarch64 build
+    steps:
+      - uses: actions/checkout@v2
+
+      # Enable caching of Docker layers
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+        with:
+          key: pr-linux-x86_64-docker-cache-{hash}
+          restore-keys: |
+            pr-linux-x86_64-docker-cache-
+
+      - name: Build docker image
+        run: docker-compose -f docker/docker-compose.centos-7.yaml build
+
+      - name: Build project with leak detection
+        run: docker-compose -f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-build
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: target
+          path: "**/target/"
+
+
   build-pr-windows:
     runs-on: windows-2016
     name: windows-x86_64 build

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -16,8 +16,6 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated
-      - ~/.gitconfig:/root/.gitconfig:delegated
-      - ~/.gitignore:/root/.gitignore:delegated
       - ..:/code:delegated
     working_dir: /code
 


### PR DESCRIPTION
Motivation:

Now that we support cross-compiling to aarch64 we should also do so during PR builds and normal builds

Modifications:

Add workflow config for aarch64

Result:

Ensure we can always build for aarch64 as well