### PR TITLE
QuicStreamAddress is part of the public API and so should have a publ…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamAddress.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamAddress.java
@@ -25,7 +25,7 @@ public final class QuicStreamAddress extends SocketAddress {
 
     private final long streamId;
 
-    QuicStreamAddress(long streamId) {
+    public QuicStreamAddress(long streamId) {
         this.streamId = streamId;
     }
 


### PR DESCRIPTION
…ic constructor

Motivation:

QuicStreamAddress is part of the public API so we should make it possible to construct it in other implementations of the QUIC api

Modifications:

Mark the constructor of QuicStreamAddress as public

Result:

Be able to construct QuicStreamAddress outside of our own package