### PR TITLE
Use default methods when possible

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -19,14 +19,122 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelProgressivePromise;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
+
+import java.net.SocketAddress;
 
 /**
  * A QUIC {@link Channel}.
  */
 public interface QuicChannel extends Channel {
+
+    @Override
+    default ChannelFuture bind(SocketAddress localAddress) {
+        return pipeline().bind(localAddress);
+    }
+
+    @Override
+    default ChannelFuture connect(SocketAddress remoteAddress) {
+        return pipeline().connect(remoteAddress);
+    }
+
+    @Override
+    default ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+        return pipeline().connect(remoteAddress, localAddress);
+    }
+
+    @Override
+    default ChannelFuture disconnect() {
+        return pipeline().disconnect();
+    }
+
+    @Override
+    default ChannelFuture close() {
+        return pipeline().close();
+    }
+
+    @Override
+    default ChannelFuture deregister() {
+        return pipeline().deregister();
+    }
+
+    @Override
+    default ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+        return pipeline().bind(localAddress, promise);
+    }
+
+    @Override
+    default ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
+        return pipeline().connect(remoteAddress, promise);
+    }
+
+    @Override
+    default ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        return pipeline().connect(remoteAddress, localAddress, promise);
+    }
+
+    @Override
+    default ChannelFuture disconnect(ChannelPromise promise) {
+        return pipeline().disconnect(promise);
+    }
+
+    @Override
+    default ChannelFuture close(ChannelPromise promise) {
+        return pipeline().close(promise);
+    }
+
+    @Override
+    default ChannelFuture deregister(ChannelPromise promise) {
+        return pipeline().deregister(promise);
+    }
+
+    @Override
+    default ChannelFuture write(Object msg) {
+        return pipeline().write(msg);
+    }
+
+    @Override
+    default ChannelFuture write(Object msg, ChannelPromise promise) {
+        return pipeline().write(msg, promise);
+    }
+
+    @Override
+    default ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+        return pipeline().writeAndFlush(msg, promise);
+    }
+
+    @Override
+    default ChannelFuture writeAndFlush(Object msg) {
+        return pipeline().writeAndFlush(msg);
+    }
+
+    @Override
+    default ChannelPromise newPromise() {
+        return pipeline().newPromise();
+    }
+
+    @Override
+    default ChannelProgressivePromise newProgressivePromise() {
+        return pipeline().newProgressivePromise();
+    }
+
+    @Override
+    default ChannelFuture newSucceededFuture() {
+        return pipeline().newSucceededFuture();
+    }
+
+    @Override
+    default ChannelFuture newFailedFuture(Throwable cause) {
+        return pipeline().newFailedFuture(cause);
+    }
+
+    @Override
+    default ChannelPromise voidPromise() {
+        return pipeline().voidPromise();
+    }
 
     @Override
     QuicChannel read();

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
@@ -17,8 +17,11 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelProgressivePromise;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.socket.DuplexChannel;
+
+import java.net.SocketAddress;
 
 /**
  * A QUIC stream.
@@ -45,6 +48,112 @@ public interface QuicStreamChannel extends DuplexChannel {
      * writes will be allowed after this point.
      */
     ChannelFutureListener SHUTDOWN_OUTPUT = WRITE_FIN;
+
+    @Override
+    default ChannelFuture bind(SocketAddress socketAddress) {
+        return pipeline().bind(socketAddress);
+    }
+
+    @Override
+    default ChannelFuture connect(SocketAddress remoteAddress) {
+        return pipeline().connect(remoteAddress);
+    }
+
+    @Override
+    default ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+        return pipeline().connect(remoteAddress, localAddress);
+    }
+
+    @Override
+    default ChannelFuture disconnect() {
+        return pipeline().disconnect();
+    }
+
+    @Override
+    default ChannelFuture close() {
+        return pipeline().close();
+    }
+
+    @Override
+    default ChannelFuture deregister() {
+        return pipeline().deregister();
+    }
+
+    @Override
+    default ChannelFuture bind(SocketAddress localAddress, ChannelPromise channelPromise) {
+        return pipeline().bind(localAddress, channelPromise);
+    }
+
+    @Override
+    default ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise channelPromise) {
+        return pipeline().connect(remoteAddress, channelPromise);
+    }
+
+    @Override
+    default ChannelFuture connect(
+            SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise channelPromise) {
+        return pipeline().connect(remoteAddress, localAddress, channelPromise);
+    }
+
+    @Override
+    default ChannelFuture disconnect(ChannelPromise channelPromise) {
+        return pipeline().disconnect(channelPromise);
+    }
+
+    @Override
+    default ChannelFuture close(ChannelPromise channelPromise) {
+        return pipeline().close(channelPromise);
+    }
+
+    @Override
+    default ChannelFuture deregister(ChannelPromise channelPromise) {
+        return pipeline().deregister(channelPromise);
+    }
+
+    @Override
+    default ChannelFuture write(Object msg) {
+        return pipeline().write(msg);
+    }
+
+    @Override
+    default ChannelFuture write(Object msg, ChannelPromise channelPromise) {
+        return pipeline().write(msg, channelPromise);
+    }
+
+    @Override
+    default ChannelFuture writeAndFlush(Object msg, ChannelPromise channelPromise) {
+        return pipeline().writeAndFlush(msg, channelPromise);
+    }
+
+    @Override
+    default ChannelFuture writeAndFlush(Object msg) {
+        return pipeline().writeAndFlush(msg);
+    }
+
+    @Override
+    default ChannelPromise newPromise() {
+        return pipeline().newPromise();
+    }
+
+    @Override
+    default ChannelProgressivePromise newProgressivePromise() {
+        return pipeline().newProgressivePromise();
+    }
+
+    @Override
+    default ChannelFuture newSucceededFuture() {
+        return pipeline().newSucceededFuture();
+    }
+
+    @Override
+    default ChannelFuture newFailedFuture(Throwable cause) {
+        return pipeline().newFailedFuture(cause);
+    }
+
+    @Override
+    default ChannelPromise voidPromise() {
+        return pipeline().voidPromise();
+    }
 
     @Override
     default ChannelFuture shutdownInput() {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -24,7 +24,6 @@ import io.netty.channel.ChannelId;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.ChannelProgressivePromise;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.ChannelPromiseNotifier;
 import io.netty.channel.DefaultChannelId;
@@ -335,111 +334,6 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     @Override
     public ByteBufAllocator alloc() {
         return config.getAllocator();
-    }
-
-    @Override
-    public ChannelFuture bind(SocketAddress localAddress) {
-        return pipeline.bind(localAddress);
-    }
-
-    @Override
-    public ChannelFuture connect(SocketAddress remoteAddress) {
-        return pipeline.connect(remoteAddress);
-    }
-
-    @Override
-    public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
-        return pipeline.connect(remoteAddress, localAddress);
-    }
-
-    @Override
-    public ChannelFuture disconnect() {
-        return pipeline.disconnect();
-    }
-
-    @Override
-    public ChannelFuture close() {
-        return pipeline.close();
-    }
-
-    @Override
-    public ChannelFuture deregister() {
-        return pipeline.deregister();
-    }
-
-    @Override
-    public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
-        return pipeline.bind(localAddress, promise);
-    }
-
-    @Override
-    public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
-        return pipeline.connect(remoteAddress, promise);
-    }
-
-    @Override
-    public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-        return pipeline.connect(remoteAddress, localAddress, promise);
-    }
-
-    @Override
-    public ChannelFuture disconnect(ChannelPromise promise) {
-        return pipeline.disconnect(promise);
-    }
-
-    @Override
-    public ChannelFuture close(ChannelPromise promise) {
-        return pipeline.close(promise);
-    }
-
-    @Override
-    public ChannelFuture deregister(ChannelPromise promise) {
-        return pipeline.deregister(promise);
-    }
-
-    @Override
-    public ChannelFuture write(Object msg) {
-        return pipeline.write(msg);
-    }
-
-    @Override
-    public ChannelFuture write(Object msg, ChannelPromise promise) {
-        return pipeline.write(msg, promise);
-    }
-
-    @Override
-    public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
-        return pipeline.writeAndFlush(msg, promise);
-    }
-
-    @Override
-    public ChannelFuture writeAndFlush(Object msg) {
-        return pipeline.writeAndFlush(msg);
-    }
-
-    @Override
-    public ChannelPromise newPromise() {
-        return pipeline.newPromise();
-    }
-
-    @Override
-    public ChannelProgressivePromise newProgressivePromise() {
-        return pipeline.newProgressivePromise();
-    }
-
-    @Override
-    public ChannelFuture newSucceededFuture() {
-        return pipeline.newProgressivePromise();
-    }
-
-    @Override
-    public ChannelFuture newFailedFuture(Throwable cause) {
-        return pipeline.newFailedFuture(cause);
-    }
-
-    @Override
-    public ChannelPromise voidPromise() {
-        return pipeline.voidPromise();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Let's use default methods in QuicChannel and QuicStreamChannel to make it easier to implement these interfaces

Modifications:

Add default methods whenever possible to make custom implementations easier and less boilerplate

Result:

Share more code / cleanup