### PR TITLE
Update to netty 4.1.61.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
     <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
     <skipTests>false</skipTests>
-    <netty.version>4.1.60.Final</netty.version>
+    <netty.version>4.1.61.Final</netty.version>
     <netty.build.version>29</netty.build.version>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <jniLibName>netty_quiche_${os.detected.name}_${os.detected.arch}</jniLibName>


### PR DESCRIPTION
Motivation:

A new netty version was released. Let's update

Modifications:

Update to netty 4.1.61.Final

Result:

Use latest netty version