### PR TITLE
Android support

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -152,3 +152,52 @@ jobs:
         with:
           name: build-windows-target
           path: "**/target/"
+
+  build-android:
+    runs-on: ubuntu-latest
+    name: android
+    env:
+      SDK_VER: "platforms;android-21"
+      NDK_VER: "ndk;21.4.7075529"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup ninja-build
+        run: sudo apt-get install ninja-build
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+
+      - name: Install cargo-ndk
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-ndk
+
+      - name: Install Rust toolchain for Android architectures
+        run: rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Install Android SDK platforms
+        run: sdkmanager "${{ env.SDK_VER }}"
+
+      - name: Install Android NDK
+        run: sdkmanager "${{ env.NDK_VER }}"
+
+      - name: Setup environment
+        run: export ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}
+
+      - name: Build project
+        run: ./mvnw -B -ntp --file pom.xml clean package -Dandroid
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: target
+          path: "**/target/"

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,52 @@
       </properties>
     </profile>
     <profile>
+      <id>android-armeabi-v7a</id>
+      <activation>
+        <os>
+          <family>linux</family>
+        </os>
+        <property>
+          <name>android</name>
+        </property>
+      </activation>
+      <properties>
+        <!-- https://developer.android.com/ndk/guides/other_build_systems -->
+        <!-- https://github.com/android/ndk/issues/1324 -->
+        <androidAbi>armeabi-v7a</androidAbi>
+        <androidTriple>armv7a-linux-androideabi</androidTriple>
+        <androidTriple2>arm-linux-androideabi</androidTriple2>
+        <quicheTarget>armv7-linux-androideabi</quicheTarget>
+      </properties>
+    </profile>
+    <profile>
+      <id>android-arm64-v8a</id>
+      <properties>
+        <androidAbi>arm64-v8a</androidAbi>
+        <androidTriple>aarch64-linux-android</androidTriple>
+        <androidTriple2>aarch64-linux-android</androidTriple2>
+        <quicheTarget>aarch64-linux-android</quicheTarget>
+      </properties>
+    </profile>
+    <profile>
+      <id>android-x86</id>
+      <properties>
+        <androidAbi>x86</androidAbi>
+        <androidTriple>i686-linux-android</androidTriple>
+        <androidTriple2>i686-linux-android</androidTriple2>
+        <quicheTarget>i686-linux-android</quicheTarget>
+      </properties>
+    </profile>
+    <profile>
+      <id>android-x86_64</id>
+      <properties>
+        <androidAbi>x86_64</androidAbi>
+        <androidTriple>x86_64-linux-android</androidTriple>
+        <androidTriple2>x86_64-linux-android</androidTriple2>
+        <quicheTarget>x86_64-linux-android</quicheTarget>
+      </properties>
+    </profile>
+    <profile>
       <id>android</id>
       <activation>
         <os>
@@ -209,13 +255,8 @@
         <platform>android</platform>
         <androidNdkVersion>21</androidNdkVersion>
         <androidMinSdkVersion>21</androidMinSdkVersion>
-        <!-- https://developer.android.com/ndk/guides/other_build_systems -->
-        <!-- https://github.com/android/ndk/issues/1324 -->
-        <androidAbi>armeabi-v7a</androidAbi>
-        <androidTriple>armv7a-linux-androideabi</androidTriple>
-        <androidTriple2>arm-linux-androideabi</androidTriple2>
-        <quicheTarget>armv7-linux-androideabi</quicheTarget>
         <cargoTarget>--target=${quicheTarget}</cargoTarget>
+        <skipIteration>false</skipIteration>
         <nativeLibOnlyDir>${project.build.directory}/native-lib-only/${androidAbi}</nativeLibOnlyDir>
         <quicheBuildDir>${quicheSourceDir}/target/${quicheTarget}/release</quicheBuildDir>
         <extraCflags>-O3 -fno-omit-frame-pointer</extraCflags>
@@ -246,6 +287,49 @@
       </properties>
       <build>
         <plugins>
+          <plugin>
+            <groupId>com.soebes.maven.plugins</groupId>
+            <artifactId>iterator-maven-plugin</artifactId>
+            <!-- Don't use 0.5.1, it contains a change that merges all properties, 
+              and therefore doesn't re-evaluates "nested" properties (e.g. cargoTarget, which uses ${quicheTarget}).
+              Keep this version or provide a fix to disable merging of properties in iterator-maven-plugin -->
+            <version>0.5.0</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>invoker</goal>
+                </goals>
+                <configuration>
+                  <itemsWithProperties>
+                    <itemWithProperty>
+                      <name>arm64-v8a</name>
+                      <properties>
+                        <skipIteration>true</skipIteration>
+                      </properties>
+                    </itemWithProperty>
+                    <itemWithProperty>
+                      <name>x86</name>
+                      <properties>
+                        <skipIteration>true</skipIteration>
+                      </properties>
+                    </itemWithProperty>
+                    <itemWithProperty>
+                      <name>x86_64</name>
+                      <properties>
+                        <skipIteration>true</skipIteration>
+                      </properties>
+                    </itemWithProperty>
+                  </itemsWithProperties>
+                  <goals>
+                    <goal>package</goal>
+                  </goals>
+                  <profiles>android-@item@,android</profiles>
+                  <skip>${skipIteration}</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>org.fusesource.hawtjni</groupId>
             <artifactId>hawtjni-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -210,11 +210,14 @@
         <androidNdkVersion>21</androidNdkVersion>
         <androidMinSdkVersion>21</androidMinSdkVersion>
         <!-- https://developer.android.com/ndk/guides/other_build_systems -->
-        <androidAbi>arm64-v8a</androidAbi>
-        <androidTriple>aarch64-linux-android</androidTriple>
-        <quicheTarget>${androidAbi}</quicheTarget>
+        <!-- https://github.com/android/ndk/issues/1324 -->
+        <androidAbi>armeabi-v7a</androidAbi>
+        <androidTriple>armv7a-linux-androideabi</androidTriple>
+        <androidTriple2>arm-linux-androideabi</androidTriple2>
+        <quicheTarget>armv7-linux-androideabi</quicheTarget>
         <cargoTarget>--target=${quicheTarget}</cargoTarget>
-        <quicheBuildDir>${quicheSourceDir}/target/${androidTriple}/release</quicheBuildDir>
+        <nativeLibOnlyDir>${project.build.directory}/native-lib-only/${androidAbi}</nativeLibOnlyDir>
+        <quicheBuildDir>${quicheSourceDir}/target/${quicheTarget}/release</quicheBuildDir>
         <extraCflags>-O3 -fno-omit-frame-pointer</extraCflags>
         <extraCxxflags>-O3 -fno-omit-frame-pointer</extraCxxflags>
         <!-- On *nix, add ASM flags to disable executable stack -->
@@ -227,14 +230,19 @@
         <libquiche>libquiche.a</libquiche>
 
         <!-- https://developer.android.com/ndk/guides/other_build_systems -->
-        <jniLibName>netty_quiche_${platform}-${quicheTarget}</jniLibName>
-        <jni.classifier>${platform}-${quicheTarget}</jni.classifier>
+        <jniLibName>netty_quiche</jniLibName>
+        <jni.classifier>${platform}</jni.classifier>
         <cflags>-std=c99 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3 -I${quicheHomeIncludeDir} -I${boringsslHomeIncludeDir}</cflags>
         <bundleNativeCode>META-INF/native/${jniLibName}.dll;osname=android;processor=${androidAbi}</bundleNativeCode>
         <ndkToolchain>${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64</ndkToolchain>
         <extraLdflags>-Wl,-soname=${jniLibName}.so -Wl,--strip-debug -Wl,--exclude-libs,ALL -lm</extraLdflags>
 
         <extraConfigureArg>--host=${androidTriple}</extraConfigureArg>
+
+        <boringsslBuildDir>${boringsslSourceDir}/build/${androidAbi}</boringsslBuildDir>
+        <boringsslHomeDir>${project.build.directory}/boringssl/${androidAbi}</boringsslHomeDir>
+        <quicheHomeDir>${project.build.directory}/quiche/${androidAbi}</quicheHomeDir>
+        <hawtjniBuildDir>${project.build.directory}/native-build/${androidAbi}</hawtjniBuildDir>
       </properties>
       <build>
         <plugins>
@@ -250,19 +258,20 @@
                     <configureArg>${extraConfigureArg2}</configureArg>
                     <configureArg>CFLAGS=${cflags}</configureArg>
                     <configureArg>LDFLAGS=${ldflags} ${extraLdflags}</configureArg>
-                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+                    <configureArg>--libdir=${hawtjniBuildDir}/native-build/target/lib</configureArg>
 
                     <configureArg>TOOLCHAIN=${ndkToolchain}</configureArg>
                     <configureArg>TARGET=${androidTriple}</configureArg>
                     <configureArg>API=${androidMinSdkVersion}</configureArg>
-                    <configureArg>AR=${ndkToolchain}/bin/${androidTriple}-ar</configureArg>
+                    <configureArg>AR=${ndkToolchain}/bin/${androidTriple2}-ar</configureArg>
                     <configureArg>CC=${ndkToolchain}/bin/${androidTriple}${androidMinSdkVersion}-clang</configureArg>
-                    <configureArg>AS=${ndkToolchain}/bin/${androidTriple}-as</configureArg>
+                    <configureArg>AS=${ndkToolchain}/bin/${androidTriple2}-as</configureArg>
                     <configureArg>CXX=${ndkToolchain}/bin/${androidTriple}${androidMinSdkVersion}-clang++</configureArg>
-                    <configureArg>LD=${ndkToolchain}/bin/${androidTriple}-ld</configureArg>
-                    <configureArg>RANLIB=${ndkToolchain}/bin/${androidTriple}-ranlib</configureArg>
-                    <configureArg>STRIP=${ndkToolchain}/bin/${androidTriple}-strip</configureArg>
+                    <configureArg>LD=${ndkToolchain}/bin/${androidTriple2}-ld</configureArg>
+                    <configureArg>RANLIB=${ndkToolchain}/bin/${androidTriple2}-ranlib</configureArg>
+                    <configureArg>STRIP=${ndkToolchain}/bin/${androidTriple2}-strip</configureArg>
                   </configureArgs>
+                  <buildDirectory>${hawtjniBuildDir}</buildDirectory>
                 </configuration>
                 <goals>
                   <goal>generate</goal>
@@ -330,9 +339,9 @@
                     <!-- Add the ant tasks from ant-contrib -->
                     <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
-                    <copy todir="${project.build.directory}/android-build/native-libs" includeEmptyDirs="false">
+                    <copy todir="${project.build.directory}/android-build/native-libs/${androidAbi}" includeEmptyDirs="false">
                       <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
-                      <regexpmapper handledirsep="yes" from="^(?:[^/]+\/)*(.*_(.*).so)$" to="\2/\1" />
+                      <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="\1" />
                     </copy>
 
                   </target>
@@ -504,7 +513,7 @@
                       <then>
                         <!-- https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md#building-for-android -->
                         <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
-                          <arg value="-DANDROID_ABI=${quicheTarget}" />
+                          <arg value="-DANDROID_ABI=${androidAbi}" />
                           <arg value="-DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake" />
                           <arg value="-DANDROID_NATIVE_API_LEVEL=${androidNdkVersion}" />
                           <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
@@ -607,7 +616,7 @@
                       <equals arg1="${platform}" arg2="android" />
                       <then>
                         <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                          <arg line='ndk ${cargoTarget} -p ${androidNdkVersion} -- build --features "ffi qlog" --release' />
+                          <arg line="ndk ${cargoTarget} -p ${androidNdkVersion} -- build --features &quot;ffi qlog&quot; --release" />
                           <env key="CFLAGS" value="${extraCflags}" />
                           <env key="CXXFLAGS" value="${extraCxxflags}" />
                           <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />

--- a/pom.xml
+++ b/pom.xml
@@ -277,484 +277,484 @@
           </execution>
         </executions>
       </plugin>
-    <plugin>
-      <artifactId>maven-antrun-plugin</artifactId>
-      <version>1.8</version>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.ant</groupId>
-          <artifactId>ant</artifactId>
-          <version>1.10.9</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.ant</groupId>
-          <artifactId>ant-commons-net</artifactId>
-          <version>1.9.6</version>
-        </dependency>
-        <dependency>
-          <groupId>ant-contrib</groupId>
-          <artifactId>ant-contrib</artifactId>
-          <version>1.0b3</version>
-        </dependency>
-      </dependencies>
-      <executions>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.10.9</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant-commons-net</artifactId>
+            <version>1.9.6</version>
+          </dependency>
+          <dependency>
+            <groupId>ant-contrib</groupId>
+            <artifactId>ant-contrib</artifactId>
+            <version>1.0b3</version>
+          </dependency>
+        </dependencies>
+        <executions>
 
-        <!-- Build the BoringSSL static libs -->
-        <execution>
-          <id>build-boringssl</id>
-          <phase>generate-sources</phase>
-          <goals>
-            <goal>run</goal>
-          </goals>
-          <configuration>
-            <target>
-              <!-- Add the ant tasks from ant-contrib -->
-              <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
-              <property environment="env" />
-              <if>
-                <available file="${boringsslHomeDir}" />
-                <then>
-                  <echo message="BoringSSL was already build, skipping the build step." />
-                </then>
-                <else>
-                  <if>
-                    <available file="${boringsslSourceDir}" />
-                    <then>
-                      <echo message="BoringSSL was already cloned, skipping the clone step." />
-                    </then>
-                    <else>
-                      <echo message="Clone BoringSSL" />
+          <!-- Build the BoringSSL static libs -->
+          <execution>
+            <id>build-boringssl</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <!-- Add the ant tasks from ant-contrib -->
+                <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+                <property environment="env" />
+                <if>
+                  <available file="${boringsslHomeDir}" />
+                  <then>
+                    <echo message="BoringSSL was already build, skipping the build step." />
+                  </then>
+                  <else>
+                    <if>
+                      <available file="${boringsslSourceDir}" />
+                      <then>
+                        <echo message="BoringSSL was already cloned, skipping the clone step." />
+                      </then>
+                      <else>
+                        <echo message="Clone BoringSSL" />
 
-                      <exec executable="git" failonerror="true" dir="${project.build.directory}" resolveexecutable="true">
-                        <arg value="clone" />
-                        <arg value="--branch" />
-                        <arg value="${boringsslBranch}" />
-                        <arg value="${boringsslRepository}" />
-                        <arg value="${boringsslSourceDir}" />
-                      </exec>
-                    </else>
-                  </if>
+                        <exec executable="git" failonerror="true" dir="${project.build.directory}" resolveexecutable="true">
+                          <arg value="clone" />
+                          <arg value="--branch" />
+                          <arg value="${boringsslBranch}" />
+                          <arg value="${boringsslRepository}" />
+                          <arg value="${boringsslSourceDir}" />
+                        </exec>
+                      </else>
+                    </if>
 
-                  <echo message="Building BoringSSL" />
+                    <echo message="Building BoringSSL" />
 
-                  <!-- Use the known SHA of the commit -->
-                  <exec executable="git" failonerror="true" dir="${boringsslSourceDir}" resolveexecutable="true">
-                    <arg value="checkout" />
-                    <arg value="${boringsslCommitSha}" />
-                  </exec>
+                    <!-- Use the known SHA of the commit -->
+                    <exec executable="git" failonerror="true" dir="${boringsslSourceDir}" resolveexecutable="true">
+                      <arg value="checkout" />
+                      <arg value="${boringsslCommitSha}" />
+                    </exec>
 
-                  <mkdir dir="${boringsslBuildDir}" />
-                  <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
-                    <env key="MACOSX_DEPLOYMENT_TARGET" value="${macosxDeploymentTarget}" />
-                    <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
-                    <arg value="-DCMAKE_BUILD_TYPE=Release" />
-                    <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
-                    <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
-                    <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
-                    <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
-                    <arg line="${extraCmakeFlags}" />
-                    <arg value="-GNinja" />
-                    <arg value="${boringsslSourceDir}" />
-                  </exec>
-                  <if>
-                    <!-- may be called ninja-build or ninja -->
-                    <!-- See https://github.com/netty/netty-tcnative/issues/475 -->
-                    <available file="ninja-build" filepath="${env.PATH}" />
-                    <then>
-                      <property name="ninjaExecutable" value="ninja-build" />
-                    </then>
-                    <else>
-                      <property name="ninjaExecutable" value="ninja" />
-                    </else>
-                  </if>
-                  <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
-                    <arg value="crypto" />
-                    <arg value="ssl" />
-                  </exec>
+                    <mkdir dir="${boringsslBuildDir}" />
+                    <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                      <env key="MACOSX_DEPLOYMENT_TARGET" value="${macosxDeploymentTarget}" />
+                      <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
+                      <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                      <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
+                      <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
+                      <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                      <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                      <arg line="${extraCmakeFlags}" />
+                      <arg value="-GNinja" />
+                      <arg value="${boringsslSourceDir}" />
+                    </exec>
+                    <if>
+                      <!-- may be called ninja-build or ninja -->
+                      <!-- See https://github.com/netty/netty-tcnative/issues/475 -->
+                      <available file="ninja-build" filepath="${env.PATH}" />
+                      <then>
+                        <property name="ninjaExecutable" value="ninja-build" />
+                      </then>
+                      <else>
+                        <property name="ninjaExecutable" value="ninja" />
+                      </else>
+                    </if>
+                    <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                      <arg value="crypto" />
+                      <arg value="ssl" />
+                    </exec>
 
-                  <!-- Only copy the libs and header files we need -->
-                  <mkdir dir="${boringsslHomeBuildDir}" />
-                  <copy file="${boringsslBuildDir}/ssl/${libssl}" todir="${boringsslHomeBuildDir}" verbose="true" />
-                  <copy file="${boringsslBuildDir}/crypto/${libcrypto}" todir="${boringsslHomeBuildDir}" verbose="true" />
-                  <copy todir="${boringsslHomeIncludeDir}" verbose="true">
-                    <fileset dir="${boringsslSourceDir}/include" />
-                  </copy>
-                </else>
-              </if>
-            </target>
-          </configuration>
-        </execution>
-        <!-- Build the Quiche static lib -->
-        <execution>
-          <id>build-quiche</id>
-          <phase>generate-sources</phase>
-          <goals>
-             <goal>run</goal>
-          </goals>
-          <configuration>
-            <target>
-              <!-- Add the ant tasks from ant-contrib -->
-              <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
-              <property environment="env" />
-              <if>
-                <available file="${quicheHomeDir}" />
-                <then>
-                  <echo message="Quiche was already build, skipping the build step." />
-                </then>
+                    <!-- Only copy the libs and header files we need -->
+                    <mkdir dir="${boringsslHomeBuildDir}" />
+                    <copy file="${boringsslBuildDir}/ssl/${libssl}" todir="${boringsslHomeBuildDir}" verbose="true" />
+                    <copy file="${boringsslBuildDir}/crypto/${libcrypto}" todir="${boringsslHomeBuildDir}" verbose="true" />
+                    <copy todir="${boringsslHomeIncludeDir}" verbose="true">
+                      <fileset dir="${boringsslSourceDir}/include" />
+                    </copy>
+                  </else>
+                </if>
+              </target>
+            </configuration>
+          </execution>
+          <!-- Build the Quiche static lib -->
+          <execution>
+            <id>build-quiche</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <!-- Add the ant tasks from ant-contrib -->
+                <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+                <property environment="env" />
+                <if>
+                  <available file="${quicheHomeDir}" />
+                  <then>
+                    <echo message="Quiche was already build, skipping the build step." />
+                  </then>
 
-                <else>
-                  <if>
-                    <available file="${quicheSourceDir}" />
-                    <then>
-                      <echo message="Quiche was already cloned, skipping the clone step." />
-                    </then>
-                    <else>
-                      <echo message="Clone Quiche" />
+                  <else>
+                    <if>
+                      <available file="${quicheSourceDir}" />
+                      <then>
+                        <echo message="Quiche was already cloned, skipping the clone step." />
+                      </then>
+                      <else>
+                        <echo message="Clone Quiche" />
 
-                      <exec executable="git" failonerror="true" dir="${project.build.directory}" resolveexecutable="true">
-                        <arg value="clone" />
-                        <arg value="--recursive" />
-                        <arg value="--branch" />
-                        <arg value="${quicheBranch}" />
-                        <arg value="${quicheRepository}" />
-                        <arg value="${quicheSourceDir}" />
-                      </exec>
+                        <exec executable="git" failonerror="true" dir="${project.build.directory}" resolveexecutable="true">
+                          <arg value="clone" />
+                          <arg value="--recursive" />
+                          <arg value="--branch" />
+                          <arg value="${quicheBranch}" />
+                          <arg value="${quicheRepository}" />
+                          <arg value="${quicheSourceDir}" />
+                        </exec>
 
-                      <!-- Use the known SHA of the commit -->
-                      <exec executable="git" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                        <arg value="checkout" />
-                        <arg value="${quicheCommitSha}" />
-                      </exec>
-                    </else>
-                  </if>
-                  <echo message="Building Quiche" />
-                  <if>
-                    <equals arg1="${os.detected.name}" arg2="windows" />
-                    <then>
-                      <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                        <arg line="build --features &quot;ffi qlog&quot; --release" />
-                        <arg value="${cargoTarget}" />
-                        <!-- See https://github.com/cloudflare/quiche/blob/0.7.0/src/build.rs#L73 -->
-                        <env key="DEBUG" value="true" />
-                        <env key="OPT_LEVEL" value="3" />
-                        <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
-                      </exec>
-                    </then>
-                    <elseif>
-                     <equals arg1="${crossCompile}" arg2="true" />
+                        <!-- Use the known SHA of the commit -->
+                        <exec executable="git" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
+                          <arg value="checkout" />
+                          <arg value="${quicheCommitSha}" />
+                        </exec>
+                      </else>
+                    </if>
+                    <echo message="Building Quiche" />
+                    <if>
+                      <equals arg1="${os.detected.name}" arg2="windows" />
                       <then>
                         <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
                           <arg line="build --features &quot;ffi qlog&quot; --release" />
                           <arg value="${cargoTarget}" />
+                          <!-- See https://github.com/cloudflare/quiche/blob/0.7.0/src/build.rs#L73 -->
+                          <env key="DEBUG" value="true" />
+                          <env key="OPT_LEVEL" value="3" />
+                          <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
+                        </exec>
+                      </then>
+                      <elseif>
+                        <equals arg1="${crossCompile}" arg2="true" />
+                        <then>
+                          <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
+                            <arg line="build --features &quot;ffi qlog&quot; --release" />
+                            <arg value="${cargoTarget}" />
+                            <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
+                            <!-- Lets enable frame-pointers so we can profile better -->
+                            <env key="RUSTFLAGS" value="-Cforce-frame-pointers=yes" />
+                            <env key="TARGET_CC" value="aarch64-none-linux-gnu-gcc" />
+                          </exec>
+                        </then>
+                      </elseif>
+                      <else>
+                        <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
+                          <arg line="build --features &quot;ffi qlog&quot; --release" />
+                          <env key="CFLAGS" value="${extraCflags}" />
+                          <env key="CXXFLAGS" value="${extraCxxflags}" />
                           <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
                           <!-- Lets enable frame-pointers so we can profile better -->
                           <env key="RUSTFLAGS" value="-Cforce-frame-pointers=yes" />
-                          <env key="TARGET_CC" value="aarch64-none-linux-gnu-gcc" />
                         </exec>
-                      </then>
-                    </elseif>
-                    <else>
-                      <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                        <arg line="build --features &quot;ffi qlog&quot; --release" />
-                        <env key="CFLAGS" value="${extraCflags}" />
-                        <env key="CXXFLAGS" value="${extraCxxflags}" />
-                        <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
-                        <!-- Lets enable frame-pointers so we can profile better -->
-                        <env key="RUSTFLAGS" value="-Cforce-frame-pointers=yes" />
-                      </exec>
-                    </else>
-                  </if>
-                  <!-- Only copy the libs and header files we need -->
-                  <mkdir dir="${quicheHomeDir}" />
-                  <copy file="${quicheBuildDir}/${libquiche}" todir="${quicheHomeBuildDir}/" />
-                  <copy todir="${quicheHomeIncludeDir}">
-                    <fileset dir="${quicheSourceDir}/include" />
-                  </copy>
-                </else>
-              </if>
-            </target>
-          </configuration>
-        </execution>
-        <execution>
-          <id>copy-src</id>
-          <phase>generate-sources</phase>
-          <goals>
-            <goal>run</goal>
-          </goals>
-          <configuration>
-            <target>
-              <!-- Copy all of the c code -->
-              <delete dir="${generatedSourcesDir}" quiet="true" />
-              <copy todir="${generatedSourcesDir}/c">
-                <fileset dir="${project.basedir}/src/main/c" />
-              </copy>
+                      </else>
+                    </if>
+                    <!-- Only copy the libs and header files we need -->
+                    <mkdir dir="${quicheHomeDir}" />
+                    <copy file="${quicheBuildDir}/${libquiche}" todir="${quicheHomeBuildDir}/" />
+                    <copy todir="${quicheHomeIncludeDir}">
+                      <fileset dir="${quicheSourceDir}/include" />
+                    </copy>
+                  </else>
+                </if>
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-src</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <!-- Copy all of the c code -->
+                <delete dir="${generatedSourcesDir}" quiet="true" />
+                <copy todir="${generatedSourcesDir}/c">
+                  <fileset dir="${project.basedir}/src/main/c" />
+                </copy>
 
-              <copy todir="${generatedSourcesDir}/c">
-                <fileset dir="${jniUtilIncludeDir}" />
-              </copy>
-            </target>
-          </configuration>
-        </execution>
+                <copy todir="${generatedSourcesDir}/c">
+                  <fileset dir="${jniUtilIncludeDir}" />
+                </copy>
+              </target>
+            </configuration>
+          </execution>
 
-        <execution>
-          <!-- Adjust our template and copy it over so it can be used when compiling on windows -->
-          <id>setup-template</id>
-          <phase>generate-sources</phase>
-          <goals>
-            <goal>run</goal>
-          </goals>
-          <configuration>
-            <target>
-              <!-- Add the ant tasks from ant-contrib -->
-              <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
-              <property environment="env" />
-              <!-- Convert the paths to windows format -->
-              <pathconvert property="boringsslHomeIncludeWindowsDir" targetos="windows">
-                <path location="${boringsslHomeIncludeDir}" />
-              </pathconvert>
-              <pathconvert property="quicheHomeIncludeWindowsDir" targetos="windows">
-                <path location="${quicheHomeIncludeDir}" />
-              </pathconvert>
-              <pathconvert property="boringsslHomeBuildWindowsDir" targetos="windows">
-                <path location="${boringsslHomeBuildDir}" />
-              </pathconvert>
-              <pathconvert property="quicheHomeBuildWindowsDir" targetos="windows">
-                <path location="${quicheHomeBuildDir}" />
-              </pathconvert>
+          <execution>
+            <!-- Adjust our template and copy it over so it can be used when compiling on windows -->
+            <id>setup-template</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <!-- Add the ant tasks from ant-contrib -->
+                <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+                <property environment="env" />
+                <!-- Convert the paths to windows format -->
+                <pathconvert property="boringsslHomeIncludeWindowsDir" targetos="windows">
+                  <path location="${boringsslHomeIncludeDir}" />
+                </pathconvert>
+                <pathconvert property="quicheHomeIncludeWindowsDir" targetos="windows">
+                  <path location="${quicheHomeIncludeDir}" />
+                </pathconvert>
+                <pathconvert property="boringsslHomeBuildWindowsDir" targetos="windows">
+                  <path location="${boringsslHomeBuildDir}" />
+                </pathconvert>
+                <pathconvert property="quicheHomeBuildWindowsDir" targetos="windows">
+                  <path location="${quicheHomeBuildDir}" />
+                </pathconvert>
 
-              <!-- Copy and filter the template MSVC project -->
-              <filter token="BORINGSSL_INCLUDE_DIR" value="${boringsslHomeIncludeWindowsDir}" />
-              <filter token="QUICHE_INCLUDE_DIR" value="${quicheHomeIncludeWindowsDir}" />
-              <filter token="BORINGSSL_LIB_DIR" value="${boringsslHomeBuildWindowsDir}" />
-              <filter token="QUICHE_LIB_DIR" value="${quicheHomeBuildWindowsDir}" />
-              <filter token="QUICHE_LIB" value="${libquiche}" />
-              <filter token="CRYPTO_LIB" value="${libcrypto}" />
-              <filter token="SSL_LIB" value="${libssl}" />
+                <!-- Copy and filter the template MSVC project -->
+                <filter token="BORINGSSL_INCLUDE_DIR" value="${boringsslHomeIncludeWindowsDir}" />
+                <filter token="QUICHE_INCLUDE_DIR" value="${quicheHomeIncludeWindowsDir}" />
+                <filter token="BORINGSSL_LIB_DIR" value="${boringsslHomeBuildWindowsDir}" />
+                <filter token="QUICHE_LIB_DIR" value="${quicheHomeBuildWindowsDir}" />
+                <filter token="QUICHE_LIB" value="${libquiche}" />
+                <filter token="CRYPTO_LIB" value="${libcrypto}" />
+                <filter token="SSL_LIB" value="${libssl}" />
 
-              <copy file="src/main/native-package/vs2010.custom.props.template" tofile="${templateDir}/vs2010.custom.props" filtering="true" overwrite="true" verbose="true" />
-            </target>
-          </configuration>
-        </execution>
+                <copy file="src/main/native-package/vs2010.custom.props.template" tofile="${templateDir}/vs2010.custom.props" filtering="true" overwrite="true" verbose="true" />
+              </target>
+            </configuration>
+          </execution>
 
-        <!-- Copy the native lib that was generated and the license material for attribution -->
-        <execution>
-          <id>copy-native-lib-and-license</id>
-          <phase>process-test-resources</phase>
-          <goals>
-            <goal>run</goal>
-          </goals>
-          <configuration>
-            <target>
-              <!-- Add the ant tasks from ant-contrib -->
-              <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+          <!-- Copy the native lib that was generated and the license material for attribution -->
+          <execution>
+            <id>copy-native-lib-and-license</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <!-- Add the ant tasks from ant-contrib -->
+                <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
-              <copy todir="${project.build.outputDirectory}" includeEmptyDirs="false">
-                <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
-                <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
-              </copy>
+                <copy todir="${project.build.outputDirectory}" includeEmptyDirs="false">
+                  <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
+                  <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
+                </copy>
 
-              <!-- Copy license material for attribution-->
-              <copy file="NOTICE.txt" todir="${project.build.outputDirectory}/META-INF/" />
-              <copy file="LICENSE.txt" todir="${project.build.outputDirectory}/META-INF/" />
-              <copy todir="${project.build.outputDirectory}/META-INF/license">
-                <fileset dir="license" />
-              </copy>
+                <!-- Copy license material for attribution-->
+                <copy file="NOTICE.txt" todir="${project.build.outputDirectory}/META-INF/" />
+                <copy file="LICENSE.txt" todir="${project.build.outputDirectory}/META-INF/" />
+                <copy todir="${project.build.outputDirectory}/META-INF/license">
+                  <fileset dir="license" />
+                </copy>
 
-            </target>
-          </configuration>
-        </execution>
-      </executions>
-    </plugin>
-    <plugin>
-      <artifactId>maven-compiler-plugin</artifactId>
-      <version>3.8.0</version>
-      <configuration>
-        <compilerVersion>1.8</compilerVersion>
-        <fork>true</fork>
-        <source>1.8</source>
-        <target>1.8</target>
-        <debug>true</debug>
-        <optimize>true</optimize>
-        <showDeprecation>true</showDeprecation>
-        <showWarnings>true</showWarnings>
-        <compilerArgument>-Xlint:-options</compilerArgument>
-        <meminitial>256m</meminitial>
-        <maxmem>1024m</maxmem>
-        <excludes>
-          <exclude>**/package-info.java</exclude>
-        </excludes>
-      </configuration>
-    </plugin>
-    <plugin>
-      <artifactId>maven-checkstyle-plugin</artifactId>
-      <version>3.1.0</version>
-      <executions>
-        <execution>
-          <id>check-style</id>
-          <goals>
-            <goal>check</goal>
-          </goals>
-          <phase>validate</phase>
-          <configuration>
-            <consoleOutput>true</consoleOutput>
-            <logViolationsToConsole>true</logViolationsToConsole>
-            <failsOnError>true</failsOnError>
-            <failOnViolation>true</failOnViolation>
-            <configLocation>io/netty/checkstyle.xml</configLocation>
-            <sourceDirectories>
-              <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
-              <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
-            </sourceDirectories>
-          </configuration>
-          <inherited>false</inherited>
-        </execution>
-      </executions>
-      <dependencies>
-        <dependency>
-          <groupId>com.puppycrawl.tools</groupId>
-          <artifactId>checkstyle</artifactId>
-          <version>8.29</version>
-        </dependency>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-build-common</artifactId>
-          <version>${netty.build.version}</version>
-        </dependency>
-      </dependencies>
-    </plugin>
-    <plugin>
-      <artifactId>maven-surefire-plugin</artifactId>
-      <version>2.22.1</version>
-      <configuration>
-        <includes>
-          <include>**/*Test*.java</include>
-        </includes>
-        <excludes>
-          <exclude>**/Abstract*</exclude>
-        </excludes>
-        <runOrder>random</runOrder>
-        <systemPropertyVariables>
-          <logback.configurationFile>src/test/resources/logback-test.xml</logback.configurationFile>
-          <logLevel>info</logLevel>
-        </systemPropertyVariables>
-        <properties>
-          <property>
-            <name>listener</name>
-            <value>io.netty.build.junit.TimedOutTestsListener</value>
-          </property>
-        </properties>
-        <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
-        <trimStackTrace>false</trimStackTrace>
-        <argLine>${test.argLine}</argLine>
-      </configuration>
-    </plugin>
-    <!-- always produce osgi bundles -->
-    <plugin>
-      <groupId>org.apache.felix</groupId>
-      <artifactId>maven-bundle-plugin</artifactId>
-      <version>2.5.4</version>
-      <executions>
-        <execution>
-          <id>generate-manifest</id>
-          <phase>process-classes</phase>
-          <goals>
-            <goal>manifest</goal>
-          </goals>
-          <configuration>
-            <supportedProjectTypes>
-              <supportedProjectType>jar</supportedProjectType>
-              <supportedProjectType>bundle</supportedProjectType>
-            </supportedProjectTypes>
-            <instructions>
-              <Export-Package>${project.groupId}.*</Export-Package>
-              <Bundle-NativeCode>${bundleNativeCode}</Bundle-NativeCode>
-              <BoringSSL-Revision>${boringsslCommitSha}</BoringSSL-Revision>
-              <BoringSSL-Branch>${boringsslBranch}</BoringSSL-Branch>
-              <Quiche-Revision>${quicheCommitSha}</Quiche-Revision>
-              <Quiche-Branch>${quicheBranch}</Quiche-Branch>
-            </instructions>
-          </configuration>
-        </execution>
-      </executions>
-    </plugin>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <compilerVersion>1.8</compilerVersion>
+          <fork>true</fork>
+          <source>1.8</source>
+          <target>1.8</target>
+          <debug>true</debug>
+          <optimize>true</optimize>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
+          <compilerArgument>-Xlint:-options</compilerArgument>
+          <meminitial>256m</meminitial>
+          <maxmem>1024m</maxmem>
+          <excludes>
+            <exclude>**/package-info.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>check-style</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <consoleOutput>true</consoleOutput>
+              <logViolationsToConsole>true</logViolationsToConsole>
+              <failsOnError>true</failsOnError>
+              <failOnViolation>true</failOnViolation>
+              <configLocation>io/netty/checkstyle.xml</configLocation>
+              <sourceDirectories>
+                <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+              </sourceDirectories>
+            </configuration>
+            <inherited>false</inherited>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>8.29</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-build-common</artifactId>
+            <version>${netty.build.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.1</version>
+        <configuration>
+          <includes>
+            <include>**/*Test*.java</include>
+          </includes>
+          <excludes>
+            <exclude>**/Abstract*</exclude>
+          </excludes>
+          <runOrder>random</runOrder>
+          <systemPropertyVariables>
+            <logback.configurationFile>src/test/resources/logback-test.xml</logback.configurationFile>
+            <logLevel>info</logLevel>
+          </systemPropertyVariables>
+          <properties>
+            <property>
+              <name>listener</name>
+              <value>io.netty.build.junit.TimedOutTestsListener</value>
+            </property>
+          </properties>
+          <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
+          <trimStackTrace>false</trimStackTrace>
+          <argLine>${test.argLine}</argLine>
+        </configuration>
+        </plugin>
+      <!-- always produce osgi bundles -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.5.4</version>
+        <executions>
+          <execution>
+            <id>generate-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <supportedProjectTypes>
+                <supportedProjectType>jar</supportedProjectType>
+                <supportedProjectType>bundle</supportedProjectType>
+              </supportedProjectTypes>
+              <instructions>
+                <Export-Package>${project.groupId}.*</Export-Package>
+                <Bundle-NativeCode>${bundleNativeCode}</Bundle-NativeCode>
+                <BoringSSL-Revision>${boringsslCommitSha}</BoringSSL-Revision>
+                <BoringSSL-Branch>${boringsslBranch}</BoringSSL-Branch>
+                <Quiche-Revision>${quicheCommitSha}</Quiche-Revision>
+                <Quiche-Branch>${quicheBranch}</Quiche-Branch>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
-    <plugin>
-      <artifactId>maven-source-plugin</artifactId>
-      <version>3.2.0</version>
-      <!-- Eclipse-related OSGi manifests
-            See https://github.com/netty/netty/issues/3886
-            More information: https://rajakannappan.blogspot.ie/2010/03/automating-eclipse-source-bundle.html -->
-      <configuration>
-        <archive>
-          <manifestEntries>
-            <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
-            <Bundle-Name>${project.name}</Bundle-Name>
-            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}.source</Bundle-SymbolicName>
-            <Bundle-Vendor>${project.organization.name}</Bundle-Vendor>
-            <Bundle-Version>${parsedVersion.osgiVersion}</Bundle-Version>
-            <Eclipse-SourceBundle>${project.groupId}.${project.artifactId};version="${parsedVersion.osgiVersion}";roots:="."</Eclipse-SourceBundle>
-          </manifestEntries>
-        </archive>
-      </configuration>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.0</version>
+        <!-- Eclipse-related OSGi manifests
+              See https://github.com/netty/netty/issues/3886
+              More information: https://rajakannappan.blogspot.ie/2010/03/automating-eclipse-source-bundle.html -->
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+              <Bundle-Name>${project.name}</Bundle-Name>
+              <Bundle-SymbolicName>${project.groupId}.${project.artifactId}.source</Bundle-SymbolicName>
+              <Bundle-Vendor>${project.organization.name}</Bundle-Vendor>
+              <Bundle-Version>${parsedVersion.osgiVersion}</Bundle-Version>
+              <Eclipse-SourceBundle>${project.groupId}.${project.artifactId};version="${parsedVersion.osgiVersion}";roots:="."</Eclipse-SourceBundle>
+            </manifestEntries>
+          </archive>
+        </configuration>
 
-      <executions>
-        <execution>
-          <id>attach-sources</id>
-          <phase>prepare-package</phase>
-          <goals>
-            <goal>jar-no-fork</goal>
-          </goals>
-        </execution>
-        <execution>
-          <id>attach-test-sources</id>
-          <phase>prepare-package</phase>
-          <goals>
-            <goal>test-jar-no-fork</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-    <plugin>
-      <artifactId>maven-javadoc-plugin</artifactId>
-      <version>2.10.4</version>
-      <configuration>
-        <detectOfflineLinks>false</detectOfflineLinks>
-        <breakiterator>true</breakiterator>
-        <version>false</version>
-        <author>false</author>
-        <keywords>true</keywords>
-        <source>8</source>
-      </configuration>
-    </plugin>
-    <plugin>
-      <artifactId>maven-deploy-plugin</artifactId>
-      <version>2.8.2</version>
-      <configuration>
-        <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
-      </configuration>
-    </plugin>
-    <plugin>
-      <artifactId>maven-release-plugin</artifactId>
-      <version>2.5.3</version>
-      <configuration>
-        <useReleaseProfile>false</useReleaseProfile>
-        <arguments>-P restricted-release,sonatype-oss-release,full</arguments>
-        <autoVersionSubmodules>true</autoVersionSubmodules>
-        <allowTimestampedSnapshots>false</allowTimestampedSnapshots>
-        <tagNameFormat>${project.artifactId}-@{project.version}</tagNameFormat>
-      </configuration>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.maven.scm</groupId>
-          <artifactId>maven-scm-api</artifactId>
-          <version>1.9.4</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.maven.scm</groupId>
-          <artifactId>maven-scm-provider-gitexe</artifactId>
-          <version>1.9.4</version>
-        </dependency>
-      </dependencies>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>attach-test-sources</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>test-jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.4</version>
+        <configuration>
+          <detectOfflineLinks>false</detectOfflineLinks>
+          <breakiterator>true</breakiterator>
+          <version>false</version>
+          <author>false</author>
+          <keywords>true</keywords>
+          <source>8</source>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+        <configuration>
+          <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5.3</version>
+        <configuration>
+          <useReleaseProfile>false</useReleaseProfile>
+          <arguments>-P restricted-release,sonatype-oss-release,full</arguments>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <allowTimestampedSnapshots>false</allowTimestampedSnapshots>
+          <tagNameFormat>${project.artifactId}-@{project.version}</tagNameFormat>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-api</artifactId>
+            <version>1.9.4</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-gitexe</artifactId>
+            <version>1.9.4</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.fusesource.hawtjni</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
         <cflags>-std=c99 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3 -I${quicheHomeIncludeDir} -I${boringsslHomeIncludeDir}</cflags>
         <bundleNativeCode>META-INF/native/${jniLibName}.dll;osname=android;processor=${androidAbi}</bundleNativeCode>
         <ndkToolchain>${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64</ndkToolchain>
-        <extraLdflags>-Wl,-soname=${jniLibName}.so -Wl,--strip-debug -Wl,--exclude-libs,ALL</extraLdflags>
+        <extraLdflags>-Wl,-soname=${jniLibName}.so -Wl,--strip-debug -Wl,--exclude-libs,ALL -lm</extraLdflags>
 
         <extraConfigureArg>--host=${androidTriple}</extraConfigureArg>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <androidTriple>aarch64-linux-android</androidTriple>
         <quicheTarget>${androidAbi}</quicheTarget>
         <cargoTarget>--target=${quicheTarget}</cargoTarget>
-        <quicheBuildDir>${quicheSourceDir}/target/${androidTriple}/release</quicheBuildDir>
+        <quicheBuildDir>${quicheSourceDir}/target/${quicheTarget}/release</quicheBuildDir>
         <extraCflags>-O3 -fno-omit-frame-pointer</extraCflags>
         <extraCxxflags>-O3 -fno-omit-frame-pointer</extraCxxflags>
         <!-- On *nix, add ASM flags to disable executable stack -->
@@ -623,6 +623,14 @@
                 <filter token="SSL_LIB" value="${libssl}" />
 
                 <copy file="src/main/native-package/vs2010.custom.props.template" tofile="${templateDir}/vs2010.custom.props" filtering="true" overwrite="true" verbose="true" />
+
+                <!-- Copy custom.m4 to fix building library without version-suffix on Android -->
+                <if>
+                  <equals arg1="${platform}" arg2="android" />
+                  <then>
+                    <copy file="src/main/native-package/m4/custom.m4.android.template" tofile="${templateDir}/m4/custom.m4" filtering="true" overwrite="true" verbose="true" />
+                  </then>
+                </if>
               </target>
             </configuration>
           </execution>
@@ -862,37 +870,12 @@
               <windowsCustomProps>true</windowsCustomProps>
               <windowsPlatformToolset>v140</windowsPlatformToolset>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
-            </configuration>
-            <goals>
-              <goal>generate</goal>
-              <!--<goal>build</goal>-->
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.fusesource.hawtjni</groupId>
-        <artifactId>hawtjni-maven-plugin</artifactId>
-        <version>1.18</version>
-        <executions>
-          <execution>
-            <id>build-native-lib</id>
-            <configuration>
-              <name>${jniLibName}-${project.version}</name>
-              <nativeSourceDirectory>${generatedSourcesDir}</nativeSourceDirectory>
-              <customPackageDirectory>${templateDir}</customPackageDirectory>
-              <windowsBuildTool>msbuild</windowsBuildTool>
-              <windowsCustomProps>true</windowsCustomProps>
-              <windowsPlatformToolset>v140</windowsPlatformToolset>
-              <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <configureArgs>
                 <configureArg>${extraConfigureArg}</configureArg>
                 <configureArg>${extraConfigureArg2}</configureArg>
                 <configureArg>CFLAGS=${cflags}</configureArg>
                 <configureArg>LDFLAGS=${ldflags} ${extraLdflags}</configureArg>
                 <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
-
-                <configureArg></configureArg>
 
                 <configureArg>TOOLCHAIN=${ndkToolchain}</configureArg>
                 <configureArg>TARGET=${androidTriple}</configureArg>
@@ -907,7 +890,7 @@
               </configureArgs>
             </configuration>
             <goals>
-              <!--<goal>generate</goal>-->
+              <goal>generate</goal>
               <goal>build</goal>
             </goals>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <artifactId>netty-incubator-codec-quic</artifactId>
   <version>0.0.16.Final-SNAPSHOT</version>
   <name>Netty/Incubator/Codec/Quic</name>
-  <packaging>jar</packaging>
+  <packaging>${packaging.type}</packaging>
   <url>https://netty.io/</url>
   <description>
     Netty is an asynchronous event-driven network application framework for
@@ -70,6 +70,7 @@
     <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
     <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
     <skipTests>false</skipTests>
+    <packaging.type>jar</packaging.type>
     <netty.version>4.1.65.Final</netty.version>
     <netty.build.version>29</netty.build.version>
     <junit.version>5.7.0</junit.version>
@@ -203,6 +204,7 @@
         </property>
       </activation>
       <properties>
+        <packaging.type>aar</packaging.type>
         <skipTests>true</skipTests>
         <platform>android</platform>
         <androidNdkVersion>21</androidNdkVersion>
@@ -212,7 +214,7 @@
         <androidTriple>aarch64-linux-android</androidTriple>
         <quicheTarget>${androidAbi}</quicheTarget>
         <cargoTarget>--target=${quicheTarget}</cargoTarget>
-        <quicheBuildDir>${quicheSourceDir}/target/${quicheTarget}/release</quicheBuildDir>
+        <quicheBuildDir>${quicheSourceDir}/target/${androidTriple}/release</quicheBuildDir>
         <extraCflags>-O3 -fno-omit-frame-pointer</extraCflags>
         <extraCxxflags>-O3 -fno-omit-frame-pointer</extraCxxflags>
         <!-- On *nix, add ASM flags to disable executable stack -->
@@ -228,23 +230,118 @@
         <jniLibName>netty_quiche_${platform}-${quicheTarget}</jniLibName>
         <jni.classifier>${platform}-${quicheTarget}</jni.classifier>
         <cflags>-std=c99 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3 -I${quicheHomeIncludeDir} -I${boringsslHomeIncludeDir}</cflags>
-        <bundleNativeCode>META-INF/native/${jniLibName}.dll;osname=android;processor=${os.detected.arch}</bundleNativeCode> <!-- TODO -->
+        <bundleNativeCode>META-INF/native/${jniLibName}.dll;osname=android;processor=${androidAbi}</bundleNativeCode>
         <ndkToolchain>${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64</ndkToolchain>
         <extraLdflags>-Wl,-soname=${jniLibName}.so -Wl,--strip-debug -Wl,--exclude-libs,ALL</extraLdflags>
 
         <extraConfigureArg>--host=${androidTriple}</extraConfigureArg>
-
-        <!--<extraConfigureArg>${extraConfigureArg} TOOLCHAIN=${ndkToolchain}</extraConfigureArg>
-        <extraConfigureArg>${extraConfigureArg} TARGET=${androidTriple}</extraConfigureArg>
-        <extraConfigureArg>${extraConfigureArg} API=${androidMinSdkVersion}</extraConfigureArg>
-        <extraConfigureArg>${extraConfigureArg} AR=${ndkToolchain}/bin/${androidTriple}-ar</extraConfigureArg>
-        <extraConfigureArg>${extraConfigureArg} CC=${ndkToolchain}/bin/${androidTriple}${androidMinSdkVersion}-clang</extraConfigureArg>
-        <extraConfigureArg>${extraConfigureArg} AS=${ndkToolchain}/bin/${androidTriple}-as</extraConfigureArg>
-        <extraConfigureArg>${extraConfigureArg} CXX=${ndkToolchain}/bin/${androidTriple}${androidMinSdkVersion}-clang++</extraConfigureArg>
-        <extraConfigureArg>${extraConfigureArg} LD=${ndkToolchain}/bin/${androidTriple}-ld</extraConfigureArg>
-        <extraConfigureArg>${extraConfigureArg} RANLIB=${ndkToolchain}/bin/${androidTriple}-ranlib</extraConfigureArg>
-        <extraConfigureArg>${extraConfigureArg} STRIP=${ndkToolchain}/bin/${androidTriple}-strip</extraConfigureArg>-->
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.fusesource.hawtjni</groupId>
+            <artifactId>hawtjni-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-native-lib</id>
+                <configuration>
+                  <configureArgs>
+                    <configureArg>${extraConfigureArg}</configureArg>
+                    <configureArg>${extraConfigureArg2}</configureArg>
+                    <configureArg>CFLAGS=${cflags}</configureArg>
+                    <configureArg>LDFLAGS=${ldflags} ${extraLdflags}</configureArg>
+                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+
+                    <configureArg>TOOLCHAIN=${ndkToolchain}</configureArg>
+                    <configureArg>TARGET=${androidTriple}</configureArg>
+                    <configureArg>API=${androidMinSdkVersion}</configureArg>
+                    <configureArg>AR=${ndkToolchain}/bin/${androidTriple}-ar</configureArg>
+                    <configureArg>CC=${ndkToolchain}/bin/${androidTriple}${androidMinSdkVersion}-clang</configureArg>
+                    <configureArg>AS=${ndkToolchain}/bin/${androidTriple}-as</configureArg>
+                    <configureArg>CXX=${ndkToolchain}/bin/${androidTriple}${androidMinSdkVersion}-clang++</configureArg>
+                    <configureArg>LD=${ndkToolchain}/bin/${androidTriple}-ld</configureArg>
+                    <configureArg>RANLIB=${ndkToolchain}/bin/${androidTriple}-ranlib</configureArg>
+                    <configureArg>STRIP=${ndkToolchain}/bin/${androidTriple}-strip</configureArg>
+                  </configureArgs>
+                </configuration>
+                <goals>
+                  <goal>generate</goal>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>native-jar</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-manifest</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <!-- Copy the native lib that was generated and the license material for attribution -->
+            <executions>
+              <execution>
+                <id>copy-android-native-lib</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                    <filter token="JAVA_MODULE_NAME" value="${javaModuleName}" />
+                    <filter token="MIN_SDK_VERSION" value="${androidMinSdkVersion}" />
+
+                    <copy file="src/main/AndroidManifest.xml" todir="${project.build.directory}/android-build/" filtering="true" />
+
+                  </target>
+                </configuration>
+              </execution>
+              <!-- Copy the native lib that was generated and the license material for attribution -->
+              <execution>
+                <id>copy-native-lib-and-license</id>
+                <phase>none</phase>
+              </execution>
+              <!-- Copy the native android lib that was generated and the license material for attribution -->
+              <execution>
+                <id>copy-android-native-libs</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                    <copy todir="${project.build.directory}/android-build/native-libs" includeEmptyDirs="false">
+                      <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
+                      <regexpmapper handledirsep="yes" from="^(?:[^/]+\/)*(.*_(.*).so)$" to="\2/\1" />
+                    </copy>
+
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>linux-aarch64</id>
@@ -876,17 +973,6 @@
                 <configureArg>CFLAGS=${cflags}</configureArg>
                 <configureArg>LDFLAGS=${ldflags} ${extraLdflags}</configureArg>
                 <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
-
-                <configureArg>TOOLCHAIN=${ndkToolchain}</configureArg>
-                <configureArg>TARGET=${androidTriple}</configureArg>
-                <configureArg>API=${androidMinSdkVersion}</configureArg>
-                <configureArg>AR=${ndkToolchain}/bin/${androidTriple}-ar</configureArg>
-                <configureArg>CC=${ndkToolchain}/bin/${androidTriple}${androidMinSdkVersion}-clang</configureArg>
-                <configureArg>AS=${ndkToolchain}/bin/${androidTriple}-as</configureArg>
-                <configureArg>CXX=${ndkToolchain}/bin/${androidTriple}${androidMinSdkVersion}-clang++</configureArg>
-                <configureArg>LD=${ndkToolchain}/bin/${androidTriple}-ld</configureArg>
-                <configureArg>RANLIB=${ndkToolchain}/bin/${androidTriple}-ranlib</configureArg>
-                <configureArg>STRIP=${ndkToolchain}/bin/${androidTriple}-strip</configureArg>
               </configureArgs>
             </configuration>
             <goals>
@@ -931,6 +1017,28 @@
               </archive>
               <classifier>${jni.classifier}</classifier>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.simpligility.maven.plugins</groupId>
+        <artifactId>android-maven-plugin</artifactId>
+        <version>4.6.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <sdk>
+            <platform>${androidMinSdkVersion}</platform>
+          </sdk>
+          <androidManifestFile>${project.build.directory}/android-build/AndroidManifest.xml</androidManifestFile>
+          <nativeLibrariesDirectory>${project.build.directory}/android-build/native-libs</nativeLibrariesDirectory>
+          <classesJarExcludes>
+            <exclude>META-INF</exclude>
+          </classesJarExcludes>
+          <classifier>${jni.classifier}</classifier>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,9 @@
         <os>
           <family>linux</family>
         </os>
+        <property>
+          <name>!android</name>
+        </property>
       </activation>
       <properties>
         <extraCflags>-O3 -fno-omit-frame-pointer</extraCflags>
@@ -187,6 +190,60 @@
         <libquiche>libquiche.a</libquiche>
         <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL -Wl,-lrt</extraLdflags>
         <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=${os.detected.arch}</bundleNativeCode>
+      </properties>
+    </profile>
+    <profile>
+      <id>android</id>
+      <activation>
+        <os>
+          <family>linux</family>
+        </os>
+        <property>
+          <name>android</name>
+        </property>
+      </activation>
+      <properties>
+        <skipTests>true</skipTests>
+        <platform>android</platform>
+        <androidNdkVersion>21</androidNdkVersion>
+        <androidMinSdkVersion>21</androidMinSdkVersion>
+        <!-- https://developer.android.com/ndk/guides/other_build_systems -->
+        <androidAbi>arm64-v8a</androidAbi>
+        <androidTriple>aarch64-linux-android</androidTriple>
+        <quicheTarget>${androidAbi}</quicheTarget>
+        <cargoTarget>--target=${quicheTarget}</cargoTarget>
+        <quicheBuildDir>${quicheSourceDir}/target/${androidTriple}/release</quicheBuildDir>
+        <extraCflags>-O3 -fno-omit-frame-pointer</extraCflags>
+        <extraCxxflags>-O3 -fno-omit-frame-pointer</extraCxxflags>
+        <!-- On *nix, add ASM flags to disable executable stack -->
+        <cmakeAsmFlags>-Wa,--noexecstack</cmakeAsmFlags>
+        <cmakeCFlags>${extraCflags} -DOPENSSL_C11_ATOMIC</cmakeCFlags>
+        <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
+        <cmakeCxxFlags>${extraCxxflags} -DOPENSSL_C11_ATOMIC -Wno-error=shadow -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS</cmakeCxxFlags>
+        <libssl>libssl.a</libssl>
+        <libcrypto>libcrypto.a</libcrypto>
+        <libquiche>libquiche.a</libquiche>
+
+        <!-- https://developer.android.com/ndk/guides/other_build_systems -->
+        <jniLibName>netty_quiche_${platform}-${quicheTarget}</jniLibName>
+        <jni.classifier>${platform}-${quicheTarget}</jni.classifier>
+        <cflags>-std=c99 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3 -I${quicheHomeIncludeDir} -I${boringsslHomeIncludeDir}</cflags>
+        <bundleNativeCode>META-INF/native/${jniLibName}.dll;osname=android;processor=${os.detected.arch}</bundleNativeCode> <!-- TODO -->
+        <ndkToolchain>${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64</ndkToolchain>
+        <extraLdflags>-Wl,-soname=${jniLibName}.so -Wl,--strip-debug -Wl,--exclude-libs,ALL</extraLdflags>
+
+        <extraConfigureArg>--host=${androidTriple}</extraConfigureArg>
+
+        <!--<extraConfigureArg>${extraConfigureArg} TOOLCHAIN=${ndkToolchain}</extraConfigureArg>
+        <extraConfigureArg>${extraConfigureArg} TARGET=${androidTriple}</extraConfigureArg>
+        <extraConfigureArg>${extraConfigureArg} API=${androidMinSdkVersion}</extraConfigureArg>
+        <extraConfigureArg>${extraConfigureArg} AR=${ndkToolchain}/bin/${androidTriple}-ar</extraConfigureArg>
+        <extraConfigureArg>${extraConfigureArg} CC=${ndkToolchain}/bin/${androidTriple}${androidMinSdkVersion}-clang</extraConfigureArg>
+        <extraConfigureArg>${extraConfigureArg} AS=${ndkToolchain}/bin/${androidTriple}-as</extraConfigureArg>
+        <extraConfigureArg>${extraConfigureArg} CXX=${ndkToolchain}/bin/${androidTriple}${androidMinSdkVersion}-clang++</extraConfigureArg>
+        <extraConfigureArg>${extraConfigureArg} LD=${ndkToolchain}/bin/${androidTriple}-ld</extraConfigureArg>
+        <extraConfigureArg>${extraConfigureArg} RANLIB=${ndkToolchain}/bin/${androidTriple}-ranlib</extraConfigureArg>
+        <extraConfigureArg>${extraConfigureArg} STRIP=${ndkToolchain}/bin/${androidTriple}-strip</extraConfigureArg>-->
       </properties>
     </profile>
     <profile>
@@ -344,22 +401,43 @@
                     </exec>
 
                     <mkdir dir="${boringsslBuildDir}" />
-                    <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
-                      <env key="MACOSX_DEPLOYMENT_TARGET" value="${macosxDeploymentTarget}" />
-                      <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
-                      <arg value="-DCMAKE_BUILD_TYPE=Release" />
-                      <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
-                      <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
-                      <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
-                      <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
-                      <arg line="${extraCmakeFlags}" />
-                      <arg value="-GNinja" />
-                      <arg value="${boringsslSourceDir}" />
-                    </exec>
+
+                    <if>
+                      <equals arg1="${platform}" arg2="android" />
+                      <then>
+                        <!-- https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md#building-for-android -->
+                        <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                          <arg value="-DANDROID_ABI=${quicheTarget}" />
+                          <arg value="-DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake" />
+                          <arg value="-DANDROID_NATIVE_API_LEVEL=${androidNdkVersion}" />
+                          <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
+                          <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                          <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
+                          <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
+                          <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                          <arg value="-GNinja" />
+                          <arg value="${boringsslSourceDir}" />
+                        </exec>
+                      </then>
+                      <else>
+                        <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                          <env key="MACOSX_DEPLOYMENT_TARGET" value="${macosxDeploymentTarget}" />
+                          <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
+                          <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                          <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
+                          <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
+                          <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                          <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                          <arg line="${extraCmakeFlags}" />
+                          <arg value="-GNinja" />
+                          <arg value="${boringsslSourceDir}" />
+                        </exec>
+                      </else>
+                    </if>
                     <if>
                       <!-- may be called ninja-build or ninja -->
                       <!-- See https://github.com/netty/netty-tcnative/issues/475 -->
-                      <available file="ninja-build" filepath="${env.PATH}" />
+                      <available file="ninja-build" filepath="${PATH}" />
                       <then>
                         <property name="ninjaExecutable" value="ninja-build" />
                       </then>
@@ -429,39 +507,52 @@
                     </if>
                     <echo message="Building Quiche" />
                     <if>
-                      <equals arg1="${os.detected.name}" arg2="windows" />
+                      <equals arg1="${platform}" arg2="android" />
                       <then>
                         <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                          <arg line="build --features &quot;ffi qlog&quot; --release" />
-                          <arg value="${cargoTarget}" />
-                          <!-- See https://github.com/cloudflare/quiche/blob/0.7.0/src/build.rs#L73 -->
-                          <env key="DEBUG" value="true" />
-                          <env key="OPT_LEVEL" value="3" />
-                          <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
-                        </exec>
-                      </then>
-                      <elseif>
-                        <equals arg1="${crossCompile}" arg2="true" />
-                        <then>
-                          <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                            <arg line="build --features &quot;ffi qlog&quot; --release" />
-                            <arg value="${cargoTarget}" />
-                            <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
-                            <!-- Lets enable frame-pointers so we can profile better -->
-                            <env key="RUSTFLAGS" value="-Cforce-frame-pointers=yes" />
-                            <env key="TARGET_CC" value="aarch64-none-linux-gnu-gcc" />
-                          </exec>
-                        </then>
-                      </elseif>
-                      <else>
-                        <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                          <arg line="build --features &quot;ffi qlog&quot; --release" />
+                          <arg line='ndk ${cargoTarget} -p ${androidNdkVersion} -- build --features "ffi qlog" --release' />
                           <env key="CFLAGS" value="${extraCflags}" />
                           <env key="CXXFLAGS" value="${extraCxxflags}" />
                           <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
-                          <!-- Lets enable frame-pointers so we can profile better -->
-                          <env key="RUSTFLAGS" value="-Cforce-frame-pointers=yes" />
                         </exec>
+                      </then>
+                      <else>
+                        <if>
+                          <equals arg1="${os.detected.name}" arg2="windows" />
+                          <then>
+                            <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
+                              <arg line="build --features &quot;ffi qlog&quot; --release" />
+                              <arg value="${cargoTarget}" />
+                              <!-- See https://github.com/cloudflare/quiche/blob/0.7.0/src/build.rs#L73 -->
+                              <env key="DEBUG" value="true" />
+                              <env key="OPT_LEVEL" value="3" />
+                              <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
+                            </exec>
+                          </then>
+                          <elseif>
+                            <equals arg1="${crossCompile}" arg2="true" />
+                            <then>
+                              <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
+                                <arg line="build --features &quot;ffi qlog&quot; --release" />
+                                <arg value="${cargoTarget}" />
+                                <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
+                                <!-- Lets enable frame-pointers so we can profile better -->
+                                <env key="RUSTFLAGS" value="-Cforce-frame-pointers=yes" />
+                                <env key="TARGET_CC" value="aarch64-none-linux-gnu-gcc" />
+                              </exec>
+                            </then>
+                          </elseif>
+                          <else>
+                            <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
+                              <arg line="build --features &quot;ffi qlog&quot; --release" />
+                              <env key="CFLAGS" value="${extraCflags}" />
+                              <env key="CXXFLAGS" value="${extraCxxflags}" />
+                              <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
+                              <!-- Lets enable frame-pointers so we can profile better -->
+                              <env key="RUSTFLAGS" value="-Cforce-frame-pointers=yes" />
+                            </exec>
+                          </else>
+                        </if>
                       </else>
                     </if>
                     <!-- Only copy the libs and header files we need -->
@@ -762,9 +853,32 @@
         <version>1.18</version>
         <executions>
           <execution>
-            <id>build-native-lib</id>
+            <id>generate-native-lib</id>
             <configuration>
               <name>${jniLibName}</name>
+              <nativeSourceDirectory>${generatedSourcesDir}</nativeSourceDirectory>
+              <customPackageDirectory>${templateDir}</customPackageDirectory>
+              <windowsBuildTool>msbuild</windowsBuildTool>
+              <windowsCustomProps>true</windowsCustomProps>
+              <windowsPlatformToolset>v140</windowsPlatformToolset>
+              <libDirectory>${nativeLibOnlyDir}</libDirectory>
+            </configuration>
+            <goals>
+              <goal>generate</goal>
+              <!--<goal>build</goal>-->
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.fusesource.hawtjni</groupId>
+        <artifactId>hawtjni-maven-plugin</artifactId>
+        <version>1.18</version>
+        <executions>
+          <execution>
+            <id>build-native-lib</id>
+            <configuration>
+              <name>${jniLibName}-${project.version}</name>
               <nativeSourceDirectory>${generatedSourcesDir}</nativeSourceDirectory>
               <customPackageDirectory>${templateDir}</customPackageDirectory>
               <windowsBuildTool>msbuild</windowsBuildTool>
@@ -777,10 +891,23 @@
                 <configureArg>CFLAGS=${cflags}</configureArg>
                 <configureArg>LDFLAGS=${ldflags} ${extraLdflags}</configureArg>
                 <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+
+                <configureArg></configureArg>
+
+                <configureArg>TOOLCHAIN=${ndkToolchain}</configureArg>
+                <configureArg>TARGET=${androidTriple}</configureArg>
+                <configureArg>API=${androidMinSdkVersion}</configureArg>
+                <configureArg>AR=${ndkToolchain}/bin/${androidTriple}-ar</configureArg>
+                <configureArg>CC=${ndkToolchain}/bin/${androidTriple}${androidMinSdkVersion}-clang</configureArg>
+                <configureArg>AS=${ndkToolchain}/bin/${androidTriple}-as</configureArg>
+                <configureArg>CXX=${ndkToolchain}/bin/${androidTriple}${androidMinSdkVersion}-clang++</configureArg>
+                <configureArg>LD=${ndkToolchain}/bin/${androidTriple}-ld</configureArg>
+                <configureArg>RANLIB=${ndkToolchain}/bin/${androidTriple}-ranlib</configureArg>
+                <configureArg>STRIP=${ndkToolchain}/bin/${androidTriple}-strip</configureArg>
               </configureArgs>
             </configuration>
             <goals>
-              <goal>generate</goal>
+              <!--<goal>generate</goal>-->
               <goal>build</goal>
             </goals>
           </execution>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<!--
+  ~ Copyright 2021 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="@JAVA_MODULE_NAME@" android:versionCode="1" android:versionName="1.0">
+  <uses-sdk android:minSdkVersion="@MIN_SDK_VERSION@" />
+</manifest>

--- a/src/main/c/netty_quic_boringssl.c
+++ b/src/main/c/netty_quic_boringssl.c
@@ -789,7 +789,7 @@ jint netty_boringssl_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
 
 
     NETTY_JNI_UTIL_LOAD_CLASS(env, byteArrayClass, "[B", done);
-    NETTY_JNI_UTIL_LOAD_CLASS(env, stringClass, "Ljava/lang/String;", done);
+    NETTY_JNI_UTIL_LOAD_CLASS(env, stringClass, "java/lang/String", done);
 
     NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLCertificateCallback", name, done);
     NETTY_JNI_UTIL_LOAD_CLASS(env, certificateCallbackClass, name, done);

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -65,9 +65,14 @@ final class Quiche {
 
     private static void loadNativeLibrary() {
         // This needs to be kept in sync with what is defined in netty_quic_quiche.c
-        String libName = "netty_quiche" + '_' + PlatformDependent.normalizedOs()
-                + '_' + PlatformDependent.normalizedArch();
+        String libName = "netty_quiche";
         ClassLoader cl = PlatformDependent.getClassLoader(Quiche.class);
+
+        if (!PlatformDependent.isAndroid()) {
+            libName += '_' + PlatformDependent.normalizedOs()
+                    + '_' + PlatformDependent.normalizedArch();
+        }
+
         try {
             NativeLibraryLoader.load(libName, cl);
         } catch (UnsatisfiedLinkError e) {

--- a/src/main/native-package/m4/custom.m4.android.template
+++ b/src/main/native-package/m4/custom.m4.android.template
@@ -1,0 +1,24 @@
+dnl
+dnl  Copyright 2020 The Netty Project
+dnl
+dnl  The Netty Project licenses this file to you under the Apache License,
+dnl  version 2.0 (the "License"); you may not use this file except in compliance
+dnl  with the License. You may obtain a copy of the License at:
+dnl
+dnl    https://www.apache.org/licenses/LICENSE-2.0
+dnl
+dnl  Unless required by applicable law or agreed to in writing, software
+dnl  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+dnl  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+dnl  License for the specific language governing permissions and limitations
+dnl  under the License.
+
+AC_DEFUN([CUSTOM_M4_SETUP],
+[
+
+    # When using the android toolchain, by default it only builds a library with a version-suffix.
+    # This way we create a symlink without the version-suffix, so hawtjni can find the library and copy it to the output destination
+    # This sets the "library_names_spec" variable in libtool to the same value as when building for linux
+    _LT_TAGVAR(library_names_spec, )="\${libname}\${release}\${shared_ext}\$versuffix \${libname}\${release}\${shared_ext}\$major \$libname\${shared_ext}"
+
+])

--- a/src/main/native-package/m4/custom.m4.android.template
+++ b/src/main/native-package/m4/custom.m4.android.template
@@ -1,5 +1,5 @@
 dnl
-dnl  Copyright 2020 The Netty Project
+dnl  Copyright 2021 The Netty Project
 dnl
 dnl  The Netty Project licenses this file to you under the Apache License,
 dnl  version 2.0 (the "License"); you may not use this file except in compliance


### PR DESCRIPTION
This PR builds and packs a .aar library for Android that contains native libraries for the currently [supported ABIs](https://developer.android.com/ndk/guides/abis#gradle). An .aar library is like a .jar library, specifically for Android, that also supports native-libraries. More on the aar file structure [here](https://developer.android.com/studio/projects/android-library.html#aar-contents).

I also added a GitHub workflow as example to build the library. A sample workflow run and the resulting .aar library attached as artifact can be found [here](https://github.com/JBou/netty-incubator-codec-quic/actions/runs/695594000).

The minimum Android API level is 21. It's tied to the minAPI of quiche.
Note that on API 21-23 you have to enable [Java 8+ API desugaring support](https://developer.android.com/studio/write/java8-support#library-desugaring), otherwise the app will crash, it won't find a lambda class. On Android API Level >=24, Java 8 features used in netty-incubator-codec-quic (like lambdas) are supported and it's working without enabling desugaring.

I made a sample application [here](https://github.com/JBou/netty-quic-demo) to test this out. It includes the sample server and client code from the [example package](https://github.com/netty/netty-incubator-codec-quic/tree/main/src/test/java/io/netty/incubator/codec/quic/example) and a simple Android client.
~~Currently, when sending messages from the Android client to the server works perfectly fine, but when receiving messages from the server on the Android client the app crashes with a native exception. The GitHub issue can be found [here](https://github.com/netty/netty-incubator-codec-quic/issues/243). It needs to be fixed to make this implementation work, but currently I don't know if the problem is caused by netty or quiche or some android specific problem. I would kindly ask your help to solve it, because I'm new to C/native programming and still had a lot to learn and fix to make this library cross-compile for Android.~~

I changed the library name on Android to netty_quiche.so, because most of the times an Android phone supports multiple architectures and falls back to other architectures, so the name needs to be the same. Secondly, I needed to change it because the PlatformDependent class returned `netty_quiche_linux_aarch_64` on Android.

We should check if the `extraCflags`, `extraCxxflags`, `cmakeAsmFlags`, `cmakeCFlags`, `cmakeCxxFlags`, `cflags`, `extraLdflags` are correct. I'm not quite familiar with the flags.

I'm looking forward to fix this crash and make this PR work. I'm sure there are still some things to change before merging this, just let me know. 
Making `QUIC` available as transport protocol for Netty on Android would be a great step forward, especially because it has some great features that are useful on mobile networks and mobile devices (such as [connection migration](https://tools.ietf.org/id/draft-tan-quic-connection-migration-00.html#name-connection-migration), ...). Thanks for all of your hard work on this framework and I hope I can contribute something back to the community with this addition.