### PR TITLE
Allows use direct buffers when trying to read from a stream

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/DirectIoByteBufAllocator.java
+++ b/src/main/java/io/netty/incubator/codec/quic/DirectIoByteBufAllocator.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+
+final class DirectIoByteBufAllocator implements ByteBufAllocator {
+
+    private final ByteBufAllocator wrapped;
+
+    DirectIoByteBufAllocator(ByteBufAllocator wrapped) {
+        if (wrapped instanceof DirectIoByteBufAllocator) {
+            wrapped = ((DirectIoByteBufAllocator) wrapped).wrapped();
+        }
+        this.wrapped = wrapped;
+    }
+
+    ByteBufAllocator wrapped() {
+        return wrapped;
+    }
+
+    @Override
+    public ByteBuf buffer() {
+        return wrapped.buffer();
+    }
+
+    @Override
+    public ByteBuf buffer(int initialCapacity) {
+        return wrapped.buffer(initialCapacity);
+    }
+
+    @Override
+    public ByteBuf buffer(int initialCapacity, int maxCapacity) {
+        return wrapped.buffer(initialCapacity, maxCapacity);
+    }
+
+    @Override
+    public ByteBuf ioBuffer() {
+        return directBuffer();
+    }
+
+    @Override
+    public ByteBuf ioBuffer(int initialCapacity) {
+        return directBuffer(initialCapacity);
+    }
+
+    @Override
+    public ByteBuf ioBuffer(int initialCapacity, int maxCapacity) {
+        return directBuffer(initialCapacity, maxCapacity);
+    }
+
+    @Override
+    public ByteBuf heapBuffer() {
+        return wrapped.heapBuffer();
+    }
+
+    @Override
+    public ByteBuf heapBuffer(int initialCapacity) {
+        return wrapped.heapBuffer(initialCapacity);
+    }
+
+    @Override
+    public ByteBuf heapBuffer(int initialCapacity, int maxCapacity) {
+        return wrapped.heapBuffer(initialCapacity, maxCapacity);
+    }
+
+    @Override
+    public ByteBuf directBuffer() {
+        return wrapped.directBuffer();
+    }
+
+    @Override
+    public ByteBuf directBuffer(int initialCapacity) {
+        return wrapped.directBuffer(initialCapacity);
+    }
+
+    @Override
+    public ByteBuf directBuffer(int initialCapacity, int maxCapacity) {
+        return wrapped.directBuffer(initialCapacity, maxCapacity);
+    }
+
+    @Override
+    public CompositeByteBuf compositeBuffer() {
+        return wrapped.compositeBuffer();
+    }
+
+    @Override
+    public CompositeByteBuf compositeBuffer(int maxNumComponents) {
+        return wrapped.compositeBuffer(maxNumComponents);
+    }
+
+    @Override
+    public CompositeByteBuf compositeHeapBuffer() {
+        return wrapped.compositeHeapBuffer();
+    }
+
+    @Override
+    public CompositeByteBuf compositeHeapBuffer(int maxNumComponents) {
+        return wrapped.compositeHeapBuffer(maxNumComponents);
+    }
+
+    @Override
+    public CompositeByteBuf compositeDirectBuffer() {
+        return wrapped.compositeDirectBuffer();
+    }
+
+    @Override
+    public CompositeByteBuf compositeDirectBuffer(int maxNumComponents) {
+        return wrapped.compositeDirectBuffer(maxNumComponents);
+    }
+
+    @Override
+    public boolean isDirectBufferPooled() {
+        return wrapped.isDirectBufferPooled();
+    }
+
+    @Override
+    public int calculateNewCapacity(int minNewCapacity, int maxCapacity) {
+        return wrapped.calculateNewCapacity(minNewCapacity, maxCapacity);
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -747,8 +747,10 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
             inRecv = true;
             try {
                 ChannelPipeline pipeline = pipeline();
-                QuicStreamChannelConfig config = config();
-                ByteBufAllocator allocator = config.getAllocator();
+                QuicheQuicStreamChannelConfig config = (QuicheQuicStreamChannelConfig) config();
+                // Directly access the DirectIoByteBufAllocator as we need an direct buffer to read into in all cases
+                // even if there is no Unsafe present and the direct buffer is not pooled.
+                DirectIoByteBufAllocator allocator = config.allocator;
                 @SuppressWarnings("deprecation")
                 RecvByteBufAllocator.Handle allocHandle = this.recvBufAllocHandle();
                 boolean readFrames = config.isReadFrames();

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannelConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannelConfig.java
@@ -29,9 +29,11 @@ final class QuicheQuicStreamChannelConfig extends DefaultChannelConfig implement
     // If you receive a FIN you should still keep the stream open until you write a FIN as well.
     private volatile boolean allowHalfClosure = true;
     private volatile boolean readFrames;
+    volatile DirectIoByteBufAllocator allocator;
 
     QuicheQuicStreamChannelConfig(QuicStreamChannel channel) {
         super(channel);
+        allocator = new DirectIoByteBufAllocator(super.getAllocator());
     }
 
     @Override
@@ -102,7 +104,7 @@ final class QuicheQuicStreamChannelConfig extends DefaultChannelConfig implement
 
     @Override
     public QuicStreamChannelConfig setAllocator(ByteBufAllocator allocator) {
-        super.setAllocator(allocator);
+        this.allocator = new DirectIoByteBufAllocator(allocator);
         return this;
     }
 
@@ -155,6 +157,11 @@ final class QuicheQuicStreamChannelConfig extends DefaultChannelConfig implement
         }
         this.allowHalfClosure = allowHalfClosure;
         return this;
+    }
+
+    @Override
+    public ByteBufAllocator getAllocator() {
+        return allocator.wrapped();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Quiche requires a direct buffer when reading from a stream so we need to ensure no matter what is configured by the user we always use a direct buffer.

Modifications:

- Ensure a direct buffer is always used by wrapping the ByteBufAllocator
- Adjust unit test

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/243