### PR TITLE
We should support X509TrustManager

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateVerifyCallback.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateVerifyCallback.java
@@ -18,6 +18,7 @@ package io.netty.incubator.codec.quic;
 import io.netty.handler.ssl.OpenSslCertificateException;
 
 import javax.net.ssl.X509ExtendedTrustManager;
+import javax.net.ssl.X509TrustManager;
 import java.security.cert.CertPathValidatorException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
@@ -26,10 +27,22 @@ import java.security.cert.X509Certificate;
 
 final class BoringSSLCertificateVerifyCallback {
 
-    private final QuicheQuicSslEngineMap engineMap;
-    private final X509ExtendedTrustManager manager;
+    private static final boolean TRY_USING_EXTENDED_TRUST_MANAGER;
+    static {
+        boolean tryUsingExtendedTrustManager;
+        try {
+            Class.forName(BoringSSLCertificateVerifyCallback.class.getName());
+            tryUsingExtendedTrustManager = true;
+        } catch (Throwable cause) {
+            tryUsingExtendedTrustManager = false;
+        }
+        TRY_USING_EXTENDED_TRUST_MANAGER = tryUsingExtendedTrustManager;
+    }
 
-    BoringSSLCertificateVerifyCallback(QuicheQuicSslEngineMap engineMap, X509ExtendedTrustManager manager) {
+    private final QuicheQuicSslEngineMap engineMap;
+    private final X509TrustManager manager;
+
+    BoringSSLCertificateVerifyCallback(QuicheQuicSslEngineMap engineMap, X509TrustManager manager) {
         this.engineMap = engineMap;
         this.manager = manager;
     }
@@ -50,9 +63,17 @@ final class BoringSSLCertificateVerifyCallback {
         X509Certificate[] peerCerts = BoringSSL.certificates(x509);
         try {
             if (engine.getUseClientMode()) {
-                manager.checkServerTrusted(peerCerts, authAlgorithm, engine);
+                if (TRY_USING_EXTENDED_TRUST_MANAGER && manager instanceof X509ExtendedTrustManager) {
+                    ((X509ExtendedTrustManager) manager).checkServerTrusted(peerCerts, authAlgorithm, engine);
+                } else {
+                    manager.checkServerTrusted(peerCerts, authAlgorithm);
+                }
             } else {
-                manager.checkClientTrusted(peerCerts, authAlgorithm, engine);
+                if (TRY_USING_EXTENDED_TRUST_MANAGER && manager instanceof X509ExtendedTrustManager) {
+                    ((X509ExtendedTrustManager) manager).checkClientTrusted(peerCerts, authAlgorithm, engine);
+                } else {
+                    manager.checkClientTrusted(peerCerts, authAlgorithm);
+                }
             }
             return BoringSSL.X509_V_OK;
         } catch (Throwable cause) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
@@ -30,7 +30,7 @@ import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedKeyManager;
-import javax.net.ssl.X509ExtendedTrustManager;
+import javax.net.ssl.X509TrustManager;
 import java.io.File;
 import java.io.IOException;
 import java.security.InvalidAlgorithmParameterException;
@@ -71,7 +71,7 @@ final class QuicheQuicSslContext extends QuicSslContext {
         Quic.ensureAvailability();
         this.server = server;
         this.clientAuth = server ? checkNotNull(clientAuth, "clientAuth") : ClientAuth.NONE;
-        final X509ExtendedTrustManager trustManager;
+        final X509TrustManager trustManager;
         if (trustManagerFactory == null) {
             try {
                 trustManagerFactory =
@@ -117,10 +117,10 @@ final class QuicheQuicSslContext extends QuicSslContext {
         throw new IllegalArgumentException("No X509ExtendedKeyManager included");
     }
 
-    private static X509ExtendedTrustManager chooseTrustManager(TrustManagerFactory trustManagerFactory) {
+    private static X509TrustManager chooseTrustManager(TrustManagerFactory trustManagerFactory) {
         for (TrustManager manager: trustManagerFactory.getTrustManagers()) {
-            if (manager instanceof X509ExtendedTrustManager) {
-                return (X509ExtendedTrustManager) manager;
+            if (manager instanceof X509TrustManager) {
+                return (X509TrustManager) manager;
             }
         }
         throw new IllegalArgumentException("No X509ExtendedTrustManager included");


### PR DESCRIPTION
Motivation:

There is not need to require X509ExtendedTrustManager. This also will help for android support of older versions.

Modifications:

- Don't require X509ExtendedTrustManager
- Add unit test

Result:

More flexible