### PR TITLE
Allow the user to query which QUIC versions are currently supported

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/Quic.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quic.java
@@ -50,6 +50,16 @@ public final class Quic {
     }
 
     /**
+     * Return if the given QUIC version is supported.
+     *
+     * @param version   the version.
+     * @return          {@code true} if supported, {@code false} otherwise.
+     */
+    public static boolean isVersionSupported(int version) {
+        return isAvailable() && Quiche.quiche_version_is_supported(version);
+    }
+
+    /**
      * Returns {@code true} if and only if the QUIC implementation is usable on the running platform is available.
      *
      * @return {@code true} if this QUIC implementation can be used on the current platform, {@code false} otherwise.

--- a/src/test/java/io/netty/incubator/codec/quic/QuicTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicTest.java
@@ -24,7 +24,9 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class QuicTest extends AbstractQuicTest {
 
@@ -32,6 +34,16 @@ public class QuicTest extends AbstractQuicTest {
     public void test() {
         Quic.ensureAvailability();
         assertNotNull(Quiche.quiche_version());
+    }
+
+    @Test
+    public void testVersionSupported() {
+        // draft-27, draft-28 and draft-29 should be supported.
+        assertTrue(Quic.isVersionSupported(0xff00_001b));
+        assertTrue(Quic.isVersionSupported(0xff00_001c));
+        assertTrue(Quic.isVersionSupported(0xff00_001d));
+        // version 1 is not supported atm.
+        assertFalse(Quic.isVersionSupported(0x0000_0001));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

It is useful to know which QUIC versions are supported. Let's expose a method for the user to check.

Modifications:

- Add method that allows the user to query if a QUIC version is supported
- Add unit tests

Result:

Be able to test if a version is supported