### PR TITLE
Allow to configure which QUIC version is used

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -16,7 +16,6 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.channel.ChannelHandler;
-import io.netty.util.internal.ObjectUtil;
 
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -51,9 +50,11 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     private int localConnIdLength = Quiche.QUICHE_MAX_CONN_ID_LEN;
     private Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider;
     private FlushStrategy flushStrategy = FlushStrategy.DEFAULT;
+    private int version;
 
     QuicCodecBuilder(boolean server) {
         Quic.ensureAvailability();
+        this.version = Quiche.QUICHE_PROTOCOL_VERSION;
         this.server = server;
     }
 
@@ -78,6 +79,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
         this.localConnIdLength = builder.localConnIdLength;
         this.sslEngineProvider = builder.sslEngineProvider;
         this.flushStrategy = builder.flushStrategy;
+        this.version = builder.version;
     }
 
     /**
@@ -335,6 +337,19 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
         return self();
     }
 
+    /**
+     * Allows to configure the {@code QUIC version} that should be used.
+     *
+     * The default value is the latest supported version by the underlying library.
+     *
+     * @param version the {@code QUIC version} to use.
+     * @return        the instance itself.
+     */
+    public final B version(int version) {
+        this.version = version;
+        return self();
+    }
+
     private Integer recvQueueLen;
     private Integer sendQueueLen;
 
@@ -383,7 +398,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     }
 
     private QuicheConfig createConfig() {
-        return new QuicheConfig(grease,
+        return new QuicheConfig(version, grease,
                 maxIdleTimeout, maxSendUdpPayloadSize, maxRecvUdpPayloadSize, initialMaxData,
                 initialMaxStreamDataBidiLocal, initialMaxStreamDataBidiRemote,
                 initialMaxStreamDataUni, initialMaxStreamsBidi, initialMaxStreamsUni,

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
@@ -19,14 +19,14 @@ final class QuicheConfig {
     private final boolean isDatagramSupported;
     private long config = -1;
 
-    QuicheConfig(Boolean grease, Long maxIdleTimeout, Long maxSendUdpPayloadSize,
+    QuicheConfig(int version, Boolean grease, Long maxIdleTimeout, Long maxSendUdpPayloadSize,
                         Long maxRecvUdpPayloadSize, Long initialMaxData,
                         Long initialMaxStreamDataBidiLocal, Long initialMaxStreamDataBidiRemote,
                         Long initialMaxStreamDataUni, Long initialMaxStreamsBidi, Long initialMaxStreamsUni,
                         Long ackDelayExponent, Long maxAckDelay, Boolean disableActiveMigration, Boolean enableHystart,
                         QuicCongestionControlAlgorithm congestionControlAlgorithm,
                  Integer recvQueueLen, Integer sendQueueLen) {
-        long config = Quiche.quiche_config_new(Quiche.QUICHE_PROTOCOL_VERSION);
+        long config = Quiche.quiche_config_new(version);
         try {
             if (grease != null) {
                 Quiche.quiche_config_grease(config, grease);


### PR DESCRIPTION
Motivation:

We should allow the user to explicit configure the QUIC version that should be used

Modifications:

Add new builder method

Result:

Be able to configure what exact QUIC version is used