### PR TITLE
Only access static field once we ensured we could load the native lib

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -47,7 +47,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     private Boolean disableActiveMigration;
     private Boolean enableHystart;
     private QuicCongestionControlAlgorithm congestionControlAlgorithm;
-    private int localConnIdLength = Quiche.QUICHE_MAX_CONN_ID_LEN;
+    private int localConnIdLength;
     private Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider;
     private FlushStrategy flushStrategy = FlushStrategy.DEFAULT;
     private int version;
@@ -55,6 +55,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     QuicCodecBuilder(boolean server) {
         Quic.ensureAvailability();
         this.version = Quiche.QUICHE_PROTOCOL_VERSION;
+        this.localConnIdLength = Quiche.QUICHE_MAX_CONN_ID_LEN;
         this.server = server;
     }
 


### PR DESCRIPTION
Motivation:

We should only access the static field in Quiche class once we are sure we could load the native library as it depends on a native method call.

Modifications:

Move assignment in the constructor

Result:

Ensure the native lib is loaded before the assign