### PR TITLE
Update java version

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-quic-centos6:centos-6-1.8
     build:
       args:
-        java_version : "adopt@1.8.0-272"
+        java_version : "adopt@1.8.0-292"
 
   build:
     image: netty-codec-quic-centos6:centos-6-1.8


### PR DESCRIPTION
Motivation:

We should use the latest java release when building on CI

Modifications:

Update java version

Result:

Use latest release