### PR TITLE
Use cache for .m2/repository during workflow run

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,6 +17,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Caching of maven dependencies
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: build-linux-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            build-linux-x86_64-maven-cache-
+
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
@@ -46,13 +54,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Caching of maven dependencies
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: build-linux-aarch64-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            build-linux-aarch64-maven-cache-
+
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
         with:
-          key: build-linux-x86_64-docker-cache-{hash}
+          key: build-linux-aarch64-docker-cache-{hash}
           restore-keys: |
-            build-linux-x86_64-docker-cache-
+            build-linux-aarch64-docker-cache-
 
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.centos-7.yaml build
@@ -100,14 +116,11 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v2
-        env:
-          cache-name: build-cache-windows-m2-repository
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: windows-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
+            windows-x86_64-maven-cache-
 
       - name: Build project
         run: mvn --file pom.xml clean package

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -27,16 +27,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Cache .m2/repository
+      # Caching of maven dependencies
       - uses: actions/cache@v2
-        env:
-          cache-name: staging-${{ matrix.setup }}-cache-m2-repository
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-staging-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: stage-snapshot-${{ matrix.setup }}-maven-cache-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-staging-${{ env.cache-name }}-
-            ${{ runner.os }}-staging-
+            stage-snapshot-${{ matrix.setup }}-maven-cache-
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
@@ -96,16 +93,13 @@ jobs:
         with:
           args: install ninja nasm
 
-      # Cache .m2/repository
+      # Caching of maven dependencies
       - uses: actions/cache@v2
-        env:
-          cache-name: staging-cache-windows-m2-repository
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: stage-snapshot-windows-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
+            stage-snapshot-windows-x86_64-maven-cache-
 
       - name: Stage snapshots to local staging directory
         run: mvn --file pom.xml clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true
@@ -129,16 +123,13 @@ jobs:
         with:
           java-version: 8
 
-      # Cache .m2/repository
+      # Caching of maven dependencies
       - uses: actions/cache@v2
-        env:
-          cache-name: deploy-staging-cache-m2-repository
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-deploy-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: deploy-staged-snapshots-maven-cache-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-deploy-${{ env.cache-name }}-
-            ${{ runner.os }}-deploy-
+            deploy-staged-snapshots-maven-cache-
 
       # Setup some env to re-use later.
       - name: Prepare enviroment variables

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -14,6 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Caching of maven dependencies
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: pr-linux-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            pr-linux-x86_64-maven-cache-
+
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
@@ -53,13 +61,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Caching of maven dependencies
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: pr-linux-aarch64-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            pr-linux-aarch64-maven-cache-
+
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
         with:
-          key: pr-linux-x86_64-docker-cache-{hash}
+          key: pr-linux-aarch64-docker-cache-{hash}
           restore-keys: |
-            pr-linux-x86_64-docker-cache-
+            pr-linux-aarch64-docker-cache-
 
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.centos-7.yaml build
@@ -107,15 +123,13 @@ jobs:
           args: install ninja nasm
 
       # Cache .m2/repository
+      # Caching of maven dependencies
       - uses: actions/cache@v2
-        env:
-          cache-name: pr-cache-windows-m2-repository
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: pr-windows-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
+            pr-windows-x86_64-maven-cache-
 
       - name: Build project
         run: mvn --file pom.xml clean package

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -28,16 +28,13 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
 
-      # Cache .m2/repository
+      # Caching of maven dependencies
       - uses: actions/cache@v2
-        env:
-          cache-name: release-cache-m2-repository
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: prepare-release-maven-cache-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-pr-${{ env.cache-name }}-
-            ${{ runner.os }}-pr-
+            prepare-release-maven-cache-
 
       - name: Prepare release with Maven
         run: |
@@ -93,6 +90,14 @@ jobs:
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+
+      # Caching of maven dependencies
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: staging-${{ matrix.setup }}-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            staging-${{ matrix.setup }}-maven-cache-
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
@@ -196,16 +201,13 @@ jobs:
         with:
           args: install ninja nasm
 
-      # Cache .m2/repository
+      # Caching of maven dependencies
       - uses: actions/cache@v2
-        env:
-          cache-name: staging-cache-windows-m2-repository
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: stage-release-windows-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
+            stage-release-windows-x86_64-maven-cache-
 
       - uses: s4u/maven-settings-action@v2.2.0
         with:
@@ -285,6 +287,14 @@ jobs:
       - name: Merge staging repositories
         working-directory: ./prepare-release-workspace/
         run: bash ./.github/scripts/merge_local_staging.sh /home/runner/local-staging/staging ~/windows-x86_64-local-staging/staging ~/linux-aarch64-local-staging/staging ~/linux-x86_64-local-staging/staging
+
+      # Caching of maven dependencies
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: deploy-staged-release-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            deploy-staged-release-maven-cache-
 
       - uses: s4u/maven-settings-action@v2.2.0
         with:

--- a/.github/workflows/ci-verify-load.yml
+++ b/.github/workflows/ci-verify-load.yml
@@ -16,6 +16,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Caching of maven dependencies
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: sinstall-jars-linux-aarch64-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            install-jars-linux-aarch64-maven-cache-
+
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,16 +38,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    # Cache .m2/repository
+    # Caching of maven dependencies
     - uses: actions/cache@v2
-      env:
-        cache-name: ${{ matrix.language }}-cache-m2-repository
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-analyze-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+        key: analyze-${{ matrix.language }}-maven-cache-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-analyze-${{ env.cache-name }}-
-          ${{ runner.os }}-analyze-
+          analyze-${{ matrix.language }}-maven-cache-
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -70,7 +70,3 @@ RUN echo '#define static_assert _Static_assert'  >>  ~/.include/assert.h
 RUN echo 'export C_INCLUDE_PATH="$HOME/.include/"' >>  ~/.bashrc
 # Needed to compile against old glibc
 RUN echo 'export LDFLAGS=-lrt' >>  ~/.bashrc
-
-COPY ./pom.xml $SOURCE_DIR/pom.xml
-WORKDIR $SOURCE_DIR
-RUN /bin/bash -c 'source $HOME/.bashrc && mvn dependency:go-offline surefire:test -ntp && rm -rf target'

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -54,15 +54,9 @@ RUN /root/.cargo/bin/rustup target add aarch64-unknown-linux-gnu
 RUN echo '[target.aarch64-unknown-linux-gnu]' >> /root/.cargo/config
 RUN echo 'linker = "aarch64-none-linux-gnu-gcc"' >> /root/.cargo/config
 
-
 WORKDIR /opt
 RUN curl https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar -xz
 RUN echo 'PATH=/opt/apache-maven-3.6.3/bin/:$PATH' >> ~/.bashrc
 
 # Prepare our own build
 ENV PATH /opt/apache-maven-3.6.3/bin/:$PATH
-
-COPY ./pom.xml $SOURCE_DIR/pom.xml
-WORKDIR $SOURCE_DIR
-RUN /bin/bash -c 'source $HOME/.bashrc && mvn dependency:go-offline surefire:test -ntp && rm -rf target'
-

--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -12,6 +12,7 @@ services:
     image: netty-codec-quic-centos6:default
     depends_on: [runtime-setup]
     volumes:
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated
       - ..:/code:delegated
@@ -21,11 +22,9 @@ services:
     <<: *common
     command: /bin/bash -cl "mvn clean package"
 
-
   build-leak:
     <<: *common
     command: /bin/bash -cl "mvn -Pleak clean package"
-
 
   build-clean:
     <<: *common
@@ -37,6 +36,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ..:/code
 
@@ -46,6 +46,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ..:/code
 
@@ -54,6 +55,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
     command: /bin/bash -cl "mvn clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
@@ -66,7 +68,7 @@ services:
       - GPG_PRIVATE_KEY
     volumes:
       - ~/.ssh:/root/.ssh
-      - ~/.m2:/root/.m2
+      - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
     command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && mvn -B clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated
+      - ~/.m2/repository:/root/.m2/repository
       - ..:/code:delegated
     working_dir: /code
 
@@ -39,6 +40,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
     command: /bin/bash -cl "mvn clean deploy -Plinux-aarch64 -DskipTests"
 
@@ -47,6 +49,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
     command: /bin/bash -cl "mvn -Plinux-aarch64 clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
@@ -60,6 +63,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.m2/settings.xml:/root/.m2/settings.xml
+      - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
     command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && mvn -Plinux-aarch64 clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"


### PR DESCRIPTION
Motivation:

Using the maven repository during build was very flaky recently. Ensure we cache it.

Modifications:

Cache the .m2/repository during workflow run and so reduce the amount of jars we need to download during build.

Result:

Hopefully more stable build