### PR TITLE
Preload classes before calling native OnLoad function to prevent clas…

### DIFF
--- a/src/main/c/netty_quic_boringssl.c
+++ b/src/main/c/netty_quic_boringssl.c
@@ -759,6 +759,8 @@ static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(
 
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Quiche to reflect that.
 jint netty_boringssl_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     int staticallyRegistered = 0;

--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -558,6 +558,8 @@ error:
 
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Quiche to reflect that.
 static jint netty_quiche_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     int staticallyRegistered = 0;


### PR DESCRIPTION
…sloader deadlock

Motivation:

It turns out it is quite easy to cause a classloader deadlock in more recent java updates if you cause classloading while you are in native code. Because of this we should just workaround this issue by pre-load all the classes that needs to be accessed in the OnLoad function.

Modifications:

- Preload all classes that would otherwise be loaded by native OnLoad functions.

Result:

Workaround for #11209 and https://bugs.openjdk.java.net/browse/JDK-8266310