### PR TITLE
Implement QuicStreamChannel.bytesBeforeUnwritable()

### DIFF
--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -303,6 +303,14 @@ static jlong netty_quiche_conn_readable(JNIEnv* env, jclass clazz, jlong conn) {
     return (jlong) iter;
 }
 
+static jlong netty_quiche_conn_writable(JNIEnv* env, jclass clazz, jlong conn) {
+    quiche_stream_iter* iter = quiche_conn_writable((quiche_conn *) conn);
+    if (iter == NULL) {
+        return -1;
+    }
+    return (jlong) iter;
+}
+
 static void netty_quiche_stream_iter_free(JNIEnv* env, jclass clazz, jlong iter) {
     quiche_stream_iter_free((quiche_stream_iter*) iter);
 }
@@ -500,6 +508,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_timeout_as_nanos", "(J)J", (void *) netty_quiche_conn_timeout_as_nanos },
   { "quiche_conn_on_timeout", "(J)V", (void *) netty_quiche_conn_on_timeout },
   { "quiche_conn_readable", "(J)J", (void *) netty_quiche_conn_readable },
+  { "quiche_conn_writable", "(J)J", (void *) netty_quiche_conn_writable },
   { "quiche_stream_iter_free", "(J)V", (void *) netty_quiche_stream_iter_free },
   { "quiche_stream_iter_next", "(J[J)I", (void *) netty_quiche_stream_iter_next },
   { "quiche_conn_dgram_max_writable_len", "(J)I", (void* ) netty_quiche_conn_dgram_max_writable_len },

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -374,6 +374,12 @@ final class Quiche {
 
     /**
      * See
+     * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L285">quiche_conn_writable</a>.
+     */
+    static native long quiche_conn_writable(long connAddr);
+
+    /**
+     * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L329">quiche_stream_iter_next</a>.
      *
      * This method will fill the {@code streamIds} array and return the number of streams that were filled into


### PR DESCRIPTION
Motivation:

Some users may depend on QuicStreamChannel.bytesBeforeUnwritable() to make decisions on how much they will try to write.

Modifications:

- Add implementation of QuicStreamChannel.bytesBeforeUnwritable() by keep track of the stream capacity
- Add unit test

Result:

Be able to depend on QuicStreamChannel.bytesBeforeUnwritable()