### PR TITLE
Update to use maven 3.8.1

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://downloads.apache.org/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.zip


### PR DESCRIPTION
Motivation:

We use an old version of maven atm.

Modifications:

Update to maven 3.8.1

Result:

Use latest maven release when compiling