### PR TITLE
Fix test race introduced by 22dffdf10252e12f1dbec2a0dd7ac73f92695a80

### DIFF
--- a/src/test/java/io/netty/incubator/codec/quic/QuicWritableTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicWritableTest.java
@@ -248,7 +248,6 @@ public class QuicWritableTest extends AbstractQuicTest {
                             clientErrorRef.set(cause);
                         }
                     }).get();
-            assertFalse(writePromise.isDone());
 
             // Let's trigger the reads. This will ensure we will consume the data and the remote peer
             // should be notified that it can write more data.


### PR DESCRIPTION
Motivation:

22dffdf10252e12f1dbec2a0dd7ac73f92695a80 added a testcase which had a race.

Modifications:

Remove the isDone() check as it is racy

Result:

Fix test-failure which can happen due the race