### PR TITLE
Half-closed streams do not get closed when a fin is received

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -706,7 +706,8 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                 buffer = frame.content();
             }
 
-            if (!fin && !buffer.isReadable()) {
+            boolean readable = buffer.isReadable();
+            if (!fin && !readable) {
                 return true;
             }
 
@@ -720,7 +721,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                     if (cap >= 0) {
                         capacity = cap;
                     }
-                    if (Quiche.throwIfError(res) || res == 0) {
+                    if (Quiche.throwIfError(res) || (readable && res == 0)) {
                         return false;
                     }
                     sendSomething = true;


### PR DESCRIPTION
Motivation:

Due to a bug in QuicheQuicStreamChannel.write0(), calling shutdownOutput()
on a stream does not set the finSent bit. As a result, the stream does not
get closed if a fin is received from the peer.

Modifications:

Better handle case when we write an empty packet with the fin bit.
Add unit tests

Results:

When a fin is received, QuicheQuicStreamChannel.QuicStreamChannelUnsafe.close() is called.