### PR TITLE
Do not close streams that receive a STOP_SENDING frame.

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -816,7 +816,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                                     if (capacity == Quiche.QUICHE_ERR_STREAM_STOPPED) {
                                         // Streams that received STOP_SENDING and no longer writable
                                         // but should be not closed.
-                                        break;
+                                        continue;
                                     }
                                     if (!Quiche.quiche_conn_stream_finished(connAddr, streamId)) {
                                         // Only fire an exception if the error was not caused because the stream is

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -813,6 +813,11 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                             if (streamChannel != null) {
                                 int capacity = Quiche.quiche_conn_stream_capacity(connAddr, streamId);
                                 if (capacity < 0) {
+                                    if (capacity == Quiche.QUICHE_ERR_STREAM_STOPPED) {
+                                        // Streams that received STOP_SENDING and no longer writable
+                                        // but should be not closed.
+                                        break;
+                                    }
                                     if (!Quiche.quiche_conn_stream_finished(connAddr, streamId)) {
                                         // Only fire an exception if the error was not caused because the stream is
                                         // considered finished.


### PR DESCRIPTION
Motivation:

When a stream receives a STOP_SENDING frame, it should be able to keep receiving data.

Modification:

Update QuicheQuicChannel.handleWritableStreams() to handle Quiche.QUICHE_ERR_STREAM_STOPPED
differently from other errors, and ignore it instead of throwing an exception and closing the stream.

Result:

Stream no longer gets closed and can receive more data.