### PR TITLE
Don't use http in urls when possible

### DIFF
--- a/src/main/c/netty_quic.h
+++ b/src/main/c/netty_quic.h
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallback.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallback.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSLHandshakeCompleteCallback.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSLHandshakeCompleteCallback.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT


### PR DESCRIPTION
Motivation:

We should always use https when possible

Modifications:

Use https to point to the license

Result:

Use secure connection