### PR TITLE
Update comments to point to rfc9000

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicPacketType.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicPacketType.java
@@ -17,7 +17,7 @@ package io.netty.incubator.codec.quic;
 
 /**
  * The type of the
- * <a href="https://www.ietf.org/archive/id/draft-ietf-quic-transport-32.html#name-packets-and-frames">QUIC packet</a>.
+ * <a href="https://quicwg.org/base-drafts/rfc9000.html#name-packets-and-frames">QUIC packet</a>.
  */
 public enum QuicPacketType {
     /**

--- a/src/main/java/io/netty/incubator/codec/quic/QuicStreamIdGenerator.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicStreamIdGenerator.java
@@ -23,7 +23,7 @@ final class QuicStreamIdGenerator {
     private long nextUnidirectionalStreamId;
 
     QuicStreamIdGenerator(boolean server) {
-        // See https://tools.ietf.org/html/draft-ietf-quic-transport-32#section-2.1
+        // See https://quicwg.org/base-drafts/rfc9000.html#name-stream-types-and-identifier
         nextBidirectionalStreamId = server ? 1 : 0;
         nextUnidirectionalStreamId = server ? 3 : 2;
     }


### PR DESCRIPTION
Motivation:

We should use links that point to rfc9000 now

Modifications:

Let's use the new rfc9000 urls

Result:

Cleanup