### PR TITLE
QuicheQuicStreamChannel should override toString(), hashCode() and eq…

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -67,8 +67,6 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     private boolean inWriteQueued;
     private boolean finReceived;
     private boolean finSent;
-    private boolean strValActive;
-    private String strVal;
 
     private volatile boolean registered;
     private volatile boolean writable = true;
@@ -388,42 +386,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
 
     @Override
     public String toString() {
-        boolean active = isActive();
-        if (strValActive == active && strVal != null) {
-            return strVal;
-        }
-
-        SocketAddress remoteAddr = remoteAddress();
-        SocketAddress localAddr = localAddress();
-        if (remoteAddr != null) {
-            StringBuilder buf = new StringBuilder(96)
-                    .append("[id: 0x")
-                    .append(id.asShortText())
-                    .append(", L:")
-                    .append(localAddr)
-                    .append(active? " - " : " ! ")
-                    .append("R:")
-                    .append(remoteAddr)
-                    .append(']');
-            strVal = buf.toString();
-        } else if (localAddr != null) {
-            StringBuilder buf = new StringBuilder(64)
-                    .append("[id: 0x")
-                    .append(id.asShortText())
-                    .append(", L:")
-                    .append(localAddr)
-                    .append(']');
-            strVal = buf.toString();
-        } else {
-            StringBuilder buf = new StringBuilder(16)
-                    .append("[id: 0x")
-                    .append(id.asShortText())
-                    .append(']');
-            strVal = buf.toString();
-        }
-
-        strValActive = active;
-        return strVal;
+        return "[id: 0x" + id.asShortText() + ", " + address + "]";
     }
 
     /**

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -67,6 +67,8 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     private boolean inWriteQueued;
     private boolean finReceived;
     private boolean finSent;
+    private boolean strValActive;
+    private String strVal;
 
     private volatile boolean registered;
     private volatile boolean writable = true;
@@ -365,6 +367,63 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     @Override
     public int compareTo(Channel o) {
         return id.compareTo(o.id());
+    }
+
+    /**
+     * Returns the ID of this channel.
+     */
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    /**
+     * Returns {@code true} if and only if the specified object is identical
+     * with this channel (i.e: {@code this == o}).
+     */
+    @Override
+    public boolean equals(Object o) {
+        return this == o;
+    }
+
+    @Override
+    public String toString() {
+        boolean active = isActive();
+        if (strValActive == active && strVal != null) {
+            return strVal;
+        }
+
+        SocketAddress remoteAddr = remoteAddress();
+        SocketAddress localAddr = localAddress();
+        if (remoteAddr != null) {
+            StringBuilder buf = new StringBuilder(96)
+                    .append("[id: 0x")
+                    .append(id.asShortText())
+                    .append(", L:")
+                    .append(localAddr)
+                    .append(active? " - " : " ! ")
+                    .append("R:")
+                    .append(remoteAddr)
+                    .append(']');
+            strVal = buf.toString();
+        } else if (localAddr != null) {
+            StringBuilder buf = new StringBuilder(64)
+                    .append("[id: 0x")
+                    .append(id.asShortText())
+                    .append(", L:")
+                    .append(localAddr)
+                    .append(']');
+            strVal = buf.toString();
+        } else {
+            StringBuilder buf = new StringBuilder(16)
+                    .append("[id: 0x")
+                    .append(id.asShortText())
+                    .append(']');
+            strVal = buf.toString();
+        }
+
+        strValActive = active;
+        return strVal;
     }
 
     /**


### PR DESCRIPTION
…uals(...).

Motivation:

As QuicheQuicStreamChannel does not extend AbstractChannel anymore we should override toString(), hashCode() and equals(...).

Modifications:

Add overrides

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/275