### PR TITLE
Allow to access the SSLEngine for a QuicChannel

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
+import javax.net.ssl.SSLEngine;
 import java.net.SocketAddress;
 
 /**
@@ -147,6 +148,13 @@ public interface QuicChannel extends Channel {
      */
     @Override
     QuicChannelConfig config();
+
+    /**
+     * Returns the used {@link SSLEngine} or {@code null} if none is used (yet).
+     *
+     * @return the engine.
+     */
+    SSLEngine sslEngine();
 
     /**
      * Returns the number of streams that can be created before stream creation will fail

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -42,6 +42,7 @@ import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import javax.net.ssl.SSLEngine;
 import java.io.File;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
@@ -50,9 +51,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.AlreadyConnectedException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ConnectionPendingException;
-import java.util.ArrayDeque;
 import java.util.Map;
-import java.util.Queue;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -111,7 +110,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private final TimeoutHandler timeoutHandler = new TimeoutHandler();
     private final InetSocketAddress remote;
 
-    private QuicheQuicConnection connection;
+    private volatile QuicheQuicConnection connection;
     private boolean inFireChannelReadCompleteQueue;
     private boolean fireChannelReadCompletePending;
     private ByteBuf finBuffer;
@@ -177,6 +176,15 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                                        Map.Entry<AttributeKey<?>, Object>[] streamAttrsArray) {
         return new QuicheQuicChannel(parent, true, key, remote, supportsDatagram,
                 streamHandler, streamOptionsArray, streamAttrsArray);
+    }
+
+    @Override
+    public SSLEngine sslEngine() {
+        QuicheQuicConnection connection = this.connection;
+        if (connection == null) {
+            return null;
+        }
+        return connection.engine();
     }
 
     @Override

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -181,10 +181,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     @Override
     public SSLEngine sslEngine() {
         QuicheQuicConnection connection = this.connection;
-        if (connection == null) {
-            return null;
-        }
-        return connection.engine();
+        return connection == null ? null : connection.engine();
     }
 
     @Override

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
@@ -19,10 +19,12 @@ import io.netty.util.ReferenceCounted;
 
 final class QuicheQuicConnection {
     private final ReferenceCounted refCnt;
+    private final QuicheQuicSslEngine engine;
     private long connection;
 
-    QuicheQuicConnection(long connection, ReferenceCounted refCnt) {
+    QuicheQuicConnection(long connection, QuicheQuicSslEngine engine, ReferenceCounted refCnt) {
         this.connection = connection;
+        this.engine = engine;
         this.refCnt = refCnt;
     }
 
@@ -37,6 +39,10 @@ final class QuicheQuicConnection {
                 connection = -1;
             }
         }
+    }
+
+    QuicheQuicSslEngine engine() {
+        return engine;
     }
 
     long address() {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
@@ -169,7 +169,7 @@ final class QuicheQuicSslContext extends QuicSslContext {
             return null;
         }
         // The connection will call nativeSslContext.release() once it is freed.
-        return new QuicheQuicConnection(connection, nativeSslContext);
+        return new QuicheQuicConnection(connection, engine, nativeSslContext);
     }
 
     @Override

--- a/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -285,6 +285,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             stream.writeAndFlush(Unpooled.directBuffer().writeZero(numBytes)).sync();
             clientLatch.await();
 
+            assertEquals(QuicTestUtils.PROTOS[0], quicChannel.sslEngine().getApplicationProtocol());
             stream.close().sync();
             quicChannel.close().sync();
             ChannelFuture closeFuture = quicChannel.closeFuture().await();


### PR DESCRIPTION
Motivation:

We should allow to access the SSLEngine for a QuicChannel as it may contain interesting infos for the user like the application protocol / ciphers etc

Modifications:

- Add sslEngine() method to QuicChannel
- Adjust testcase to check if we can access the engine and if it contains the application protocol

Result:

Be able to access the engine