### PR TITLE
Add bouncycastle as test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -919,5 +919,12 @@
       <version>2.22.1</version>
       <scope>test</scope>
     </dependency>
+    <!-- Also include bouncycastle so we can use SelfSignedCertificate even on more recent JDKs during testing -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.68</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Motivation:

To be able to use SelfSignedCertificate we need to have bouncycastle on the classpath when using more recent JDK versions.

Modifications:

Add bouncycastle as test dependency

Result:

Can also run testsuite on more recent JDK versions