### PR TITLE
Use draft29 as default quic version as v1 is not released yet

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -54,7 +54,10 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
 
     QuicCodecBuilder(boolean server) {
         Quic.ensureAvailability();
-        this.version = Quiche.QUICHE_PROTOCOL_VERSION;
+        // Use draft29 for now until v1 is really ready to use by default.
+        //
+        // See https://mailarchive.ietf.org/arch/msg/quic/i7CdtRA-iskuTftpEpMXMrB0FSY/
+        this.version = 0xff00_001d;
         this.localConnIdLength = Quiche.QUICHE_MAX_CONN_ID_LEN;
         this.server = server;
     }


### PR DESCRIPTION
Motivation:

We should not use v1 as default version as it was not released yet.

Modifications:

Use draft29 as default quic version

Result:

Use a "released" quic version by default