### PR TITLE
Use MAVEN_OPTS to setup timeouts for dependency downloads

### DIFF
--- a/.github/scripts/release_rollback.sh
+++ b/.github/scripts/release_rollback.sh
@@ -10,5 +10,5 @@ TAG=$(grep scm.tag= "$1" | cut -d'=' -f2)
 git remote set-url origin git@github.com:"$2".git
 git fetch
 git checkout "$3"
-mvn -B --file pom.xml release:rollback
+./mvnw -B --file pom.xml release:rollback
 git push origin :"$TAG"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   build-linux-x86_64:
     runs-on: ubuntu-latest
@@ -123,7 +126,7 @@ jobs:
             windows-x86_64-maven-cache-
 
       - name: Build project
-        run: mvn --file pom.xml -Pci clean package
+        run: mvn --file pom.xml clean package
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   stage-snapshot-linux:
     runs-on: ubuntu-latest
@@ -120,7 +123,7 @@ jobs:
             }]
 
       - name: Stage snapshots to local staging directory
-        run: mvn --file pom.xml -Pci clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true
+        run: mvn --file pom.xml clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true
 
       - name: Upload local staging directory
         uses: actions/upload-artifact@v2
@@ -187,4 +190,4 @@ jobs:
             }]
 
       - name: Deploy local staged artifacts
-        run: mvn -B --file pom.xml -Pci org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$LOCAL_STAGING_DIR
+        run: ./mvnw -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$LOCAL_STAGING_DIR

--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -4,6 +4,10 @@ on:
     workflows: [ "Build PR" ]
     types:
       - completed
+
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   tests-linux-x86_64:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   build-linux-x86_64:
     runs-on: ubuntu-latest
@@ -132,7 +135,7 @@ jobs:
             pr-windows-x86_64-maven-cache-
 
       - name: Build project
-        run: mvn --file pom.xml -Pci clean package
+        run: mvn --file pom.xml clean package
 
       - name: Upload Test Results
         if: always()

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -4,6 +4,9 @@ on:
   # Releases can only be triggered via the action tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   prepare-release:
     runs-on: ubuntu-18.04
@@ -38,8 +41,8 @@ jobs:
 
       - name: Prepare release with Maven
         run: |
-          mvn -DpreparationGoals=clean release:prepare -B --file pom.xml -Pci -DskipTests=true
-          mvn clean
+          ./mvnw -DpreparationGoals=clean release:prepare -B --file pom.xml -DskipTests=true
+          ./mvnw clean
 
       - name: Checkout tag
         run: ./.github/scripts/release_checkout_tag.sh release.properties
@@ -220,7 +223,7 @@ jobs:
 
       - name: Stage release to local staging directory
         working-directory: prepare-release-workspace
-        run: mvn --file pom.xml -Pci clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true -D'checkstyle.skip=true'
+        run: mvn --file pom.xml clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true -D'checkstyle.skip=true'
 
       - name: Upload local staging directory
         uses: actions/upload-artifact@v2
@@ -245,6 +248,9 @@ jobs:
         with:
           name: prepare-release-workspace
           path: ./prepare-release-workspace/
+
+      - name: Adjust mvnw permissions
+        run: chmod 755 ./prepare-release-workspace/mvnw
 
       - name: Set up JDK 8
         uses: actions/setup-java@v1
@@ -308,7 +314,7 @@ jobs:
       - name: Deploy local staged artifacts
         working-directory: ./prepare-release-workspace/
         # If we don't want to close the repository we can add -DskipStagingRepositoryClose=true
-        run: mvn -B --file pom.xml -Pci org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/home/runner/local-staging -DskipStagingRepositoryClose=true
+        run: ./mvnw -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/home/runner/local-staging -DskipStagingRepositoryClose=true
 
       - name: Rollback release on failure
         working-directory: ./prepare-release-workspace/

--- a/.github/workflows/ci-verify-load.yml
+++ b/.github/workflows/ci-verify-load.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   install-jars-linux-aarch64:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,9 @@ on:
   schedule:
     - cron: '33 2 * * 4'
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   analyze:
     name: Analyze
@@ -75,7 +78,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool make tar cmake perl ninja-build git cargo
 
     - name: Build project
-      run: ./mvnw -Pci clean package -DskipTests=true
+      run: ./mvnw clean package -DskipTests=true
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,9 +1,0 @@
-<settings>
-  <servers>
-    <server>
-      <id>sonatype-nexus-snapshots</id>
-      <username>${env.SANOTYPE_USER}</username>
-      <password>${env.SANOTYPE_PASSWORD}</password>
-    </server>
-  </servers>
-</settings>

--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -11,6 +11,11 @@ services:
   common: &common
     image: netty-codec-quic-centos6:default
     depends_on: [runtime-setup]
+    environment:
+      - GPG_KEYNAME
+      - GPG_PASSPHRASE
+      - GPG_PRIVATE_KEY
+      - MAVEN_OPTS
     volumes:
       - ~/.m2/repository:/root/.m2/repository
       - ~/.ssh:/root/.ssh:delegated
@@ -20,19 +25,19 @@ services:
 
   build:
     <<: *common
-    command: /bin/bash -cl "mvn -Pci clean package"
+    command: /bin/bash -cl "./mvnw clean package"
 
   build-leak:
     <<: *common
-    command: /bin/bash -cl "mvn -Pleak,ci clean package"
+    command: /bin/bash -cl "./mvnw -Pleak clean package"
 
   build-clean:
     <<: *common
-    command: /bin/bash -cl "mvn -Pci clean package"
+    command: /bin/bash -cl "./mvnw clean package"
 
   deploy:
     <<: *common
-    command: /bin/bash -cl "mvn -Pci clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw clean deploy -DskipTests=true"
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
@@ -42,7 +47,7 @@ services:
 
   deploy-clean:
     <<: *common
-    command: /bin/bash -cl "mvn -Pci clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw clean deploy -DskipTests=true"
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
@@ -59,27 +64,20 @@ services:
       - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "mvn -Pci clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
 
   stage-release:
     <<: *common
-    environment:
-      - GPG_KEYNAME
-      - GPG_PASSPHRASE
-      - GPG_PRIVATE_KEY
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && mvn -B -Pci clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 
   shell:
     <<: *common
-    environment:
-      - SONATYPE_USER
-      - SONATYPE_PASSWORD
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -13,6 +13,11 @@ services:
   cross-compile-aarch64-common: &cross-compile-aarch64-common
     image: netty-quic-centos:cross_compile_aarch64
     depends_on: [cross-compile-aarch64-runtime-setup]
+    environment:
+      - GPG_KEYNAME
+      - GPG_PASSPHRASE
+      - GPG_PRIVATE_KEY
+      - MAVEN_OPTS
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated
@@ -33,7 +38,7 @@ services:
 
   cross-compile-aarch64-build:
     <<: *cross-compile-aarch64-common
-    command: /bin/bash -cl "mvn clean package -Pci,linux-aarch64 -DskipTests"
+    command: /bin/bash -cl "./mvnw clean package -Plinux-aarch64 -DskipTests"
 
   cross-compile-aarch64-deploy:
     <<: *cross-compile-aarch64-common
@@ -42,7 +47,7 @@ services:
       - ~/.gnupg:/root/.gnupg
       - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
-    command: /bin/bash -cl "mvn clean deploy -Pci,linux-aarch64 -DskipTests"
+    command: /bin/bash -cl "./mvnw clean deploy -Plinux-aarch64 -DskipTests"
 
   cross-compile-aarch64-stage-snapshot:
     <<: *cross-compile-aarch64-common
@@ -53,21 +58,17 @@ services:
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "mvn -Pci,linux-aarch64 clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -Plinux-aarch64 clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
 
   cross-compile-aarch64-stage-release:
     <<: *cross-compile-aarch64-common
-    environment:
-      - GPG_KEYNAME
-      - GPG_PASSPHRASE
-      - GPG_PRIVATE_KEY
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && mvn -Pci,linux-aarch64 clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -Plinux-aarch64 clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 
   cross-compile-aarch64-install:
     <<: *cross-compile-aarch64-common
@@ -76,4 +77,4 @@ services:
       - ~/.gnupg:/root/.gnupg
       - ~/.m2:/root/.m2
       - ..:/code
-    command: /bin/bash -cl "mvn clean install -Pci,linux-aarch64 -DskipTests=true"
+    command: /bin/bash -cl "./mvnw clean install -Plinux-aarch64 -DskipTests=true"

--- a/pom.xml
+++ b/pom.xml
@@ -116,14 +116,6 @@
   </properties>
   <profiles>
     <profile>
-      <id>ci</id>
-      <properties>
-        <http.keepAlive>false</http.keepAlive>
-        <maven.wagon.http.pool>false</maven.wagon.http.pool>
-        <maven.wagon.httpconnectionManager.ttlSeconds>120</maven.wagon.httpconnectionManager.ttlSeconds>
-      </properties>
-    </profile>
-    <profile>
       <id>windows</id>
       <activation>
         <os>


### PR DESCRIPTION
Motivation:

Just use MAVEN_OPTS to setup all the timeouts etc for dependency downloads. This way we at least can be sure these are applied.

Modifications:

- Use MAVEN_OPTS
- Remove ci profile
- Remove unused settings.xml file
- Always use ./mvnw

Result:

Build stability improvements