### PR TITLE
Cast in test to be able to run on ealier versions of java

### DIFF
--- a/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -285,7 +285,10 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             stream.writeAndFlush(Unpooled.directBuffer().writeZero(numBytes)).sync();
             clientLatch.await();
 
-            assertEquals(QuicTestUtils.PROTOS[0], quicChannel.sslEngine().getApplicationProtocol());
+            assertEquals(QuicTestUtils.PROTOS[0],
+                    // Just do the cast as getApplicationProtocol() only exists in SSLEngine itself since Java9+ and
+                    // we may run on an earlier version
+                    ((QuicheQuicSslEngine) quicChannel.sslEngine()).getApplicationProtocol());
             stream.close().sync();
             quicChannel.close().sync();
             ChannelFuture closeFuture = quicChannel.closeFuture().await();


### PR DESCRIPTION
Motivation:

SSLEngine.getApplicationProtocol may not exists on earlier versions of java.

Modifications:

Cast to QuicheQuicSslEngine to allow running on older version of java

Result:

Works on older Java8 releases as well