### PR TITLE
Allow to access source and destination ids

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>0a08fd78134dc35351ce773f143015ed12f53ae1</quicheCommitSha>
+    <quicheCommitSha>3ed9202a0089e7b599214552c807626c678e1aea</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -190,20 +190,40 @@ static jlong netty_quiche_conn_new_with_tls(JNIEnv* env, jclass clazz, jlong sci
     return (jlong) conn;
 }
 
+static jbyteArray to_byte_array(JNIEnv* env, const uint8_t* bytes, size_t len) {
+    if (bytes == NULL || len == 0) {
+        return NULL;
+    }
+     jbyteArray array = (*env)->NewByteArray(env, len);
+     if (array == NULL) {
+        return NULL;
+     }
+     (*env)->SetByteArrayRegion(env,array, 0, len, (jbyte*) bytes);
+     return array;
+}
+
 static jbyteArray netty_quiche_conn_trace_id(JNIEnv* env, jclass clazz, jlong conn) {
     const uint8_t *trace_id = NULL;
     size_t trace_id_len = 0;
 
     quiche_conn_trace_id((quiche_conn *) conn, &trace_id, &trace_id_len);
-    if (trace_id == NULL || trace_id_len == 0) {
-        return NULL;
-    }
-     jbyteArray array = (*env)->NewByteArray(env, trace_id_len);
-     if (array == NULL) {
-        return NULL;
-     }
-     (*env)->SetByteArrayRegion(env,array, 0, trace_id_len, (jbyte*) trace_id);
-     return array;
+    return to_byte_array(env, trace_id, trace_id_len);
+}
+
+static jbyteArray netty_quiche_conn_source_id(JNIEnv* env, jclass clazz, jlong conn) {
+    const uint8_t *id = NULL;
+    size_t len = 0;
+
+    quiche_conn_source_id((quiche_conn *) conn, &id, &len);
+    return to_byte_array(env, id, len);
+}
+
+static jbyteArray netty_quiche_conn_destination_id(JNIEnv* env, jclass clazz, jlong conn) {
+    const uint8_t *id = NULL;
+    size_t len = 0;
+
+    quiche_conn_destination_id((quiche_conn *) conn, &id, &len);
+    return to_byte_array(env, id, len);
 }
 
 static jint netty_quiche_conn_recv(JNIEnv* env, jclass clazz, jlong conn, jlong buf, jint buf_len) {
@@ -488,6 +508,8 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_retry", "(JIJIJIJIIJI)I", (void *) netty_quiche_retry },
   { "quiche_conn_set_qlog_path", "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z", (void *) netty_quiche_conn_set_qlog_path },
   { "quiche_conn_trace_id", "(J)[B", (void *) netty_quiche_conn_trace_id },
+  { "quiche_conn_source_id", "(J)[B", (void *) netty_quiche_conn_source_id },
+  { "quiche_conn_destination_id", "(J)[B", (void *) netty_quiche_conn_destination_id },
   { "quiche_conn_new_with_tls", "(JIJIJJZ)J", (void *) netty_quiche_conn_new_with_tls },
   { "quiche_conn_recv", "(JJI)I", (void *) netty_quiche_conn_recv },
   { "quiche_conn_send", "(JJI)I", (void *) netty_quiche_conn_send },

--- a/src/main/java/io/netty/incubator/codec/quic/QuicConnectionAddress.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicConnectionAddress.java
@@ -28,10 +28,14 @@ public final class QuicConnectionAddress extends SocketAddress {
      * Special {@link QuicConnectionAddress} that should be used when the connection address should be generated
      * and choosen on the fly.
      */
-    public static final QuicConnectionAddress EPHEMERAL = new QuicConnectionAddress(null, false);
+    public static final QuicConnectionAddress EPHEMERAL = new QuicConnectionAddress((ByteBuffer) null, false);
 
     // Accessed by QuicheQuicheChannel
     final ByteBuffer connId;
+
+    QuicConnectionAddress(byte[] connId, boolean clone) {
+        this(ByteBuffer.wrap(clone ? connId.clone() : connId), false);
+    }
 
     /**
      * Create a new instance

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -276,6 +276,9 @@ final class Quiche {
      */
     static native byte[] quiche_conn_trace_id(long connAddr);
 
+    static native byte[] quiche_conn_source_id(long connAddr);
+
+    static native byte[] quiche_conn_destination_id(long connAddr);
     /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L258">quiche_conn_stream_recv</a>.
      */

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -424,12 +424,14 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
     @Override
     protected SocketAddress localAddress0() {
-        return parent().localAddress();
+        QuicheQuicConnection connection = this.connection;
+        return connection == null ? null : connection.sourceId();
     }
 
     @Override
     protected SocketAddress remoteAddress0() {
-        return remote;
+        QuicheQuicConnection connection = this.connection;
+        return connection == null ? null : connection.destinationId();
     }
 
     @Override
@@ -491,24 +493,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         if (msg instanceof ByteBuf) {
             return msg;
         }
-        if (msg instanceof DatagramPacket) {
-            DatagramPacket packet = (DatagramPacket) msg;
-            if (remote == null) {
-                if (packet.recipient() == null) {
-                    return extractBuffer(packet);
-                }
-            } else if (remote.equals(packet.recipient())) {
-                return extractBuffer(packet);
-            }
-            throw new UnsupportedOperationException("DatagramPacket recipient is not valid");
-        }
         throw new UnsupportedOperationException("Unsupported message type: " + StringUtil.simpleClassName(msg));
-    }
-
-    private static ByteBuf extractBuffer(DatagramPacket packet) {
-        ByteBuf content = packet.content().retain();
-        packet.release();
-        return content;
     }
 
     @Override

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
@@ -30,8 +30,6 @@ final class QuicheQuicConnection {
         this.refCnt = refCnt;
     }
 
-    // This should not need to be synchronized as it will either be called from the EventLoop thread or
-    // the finalizer (in which case there can't be concurrent access here).
     void free() {
         boolean release = false;
         synchronized (this) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
@@ -17,6 +17,8 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.util.ReferenceCounted;
 
+import java.util.function.Supplier;
+
 final class QuicheQuicConnection {
     private final ReferenceCounted refCnt;
     private final QuicheQuicSslEngine engine;
@@ -31,14 +33,39 @@ final class QuicheQuicConnection {
     // This should not need to be synchronized as it will either be called from the EventLoop thread or
     // the finalizer (in which case there can't be concurrent access here).
     void free() {
-        if (connection != -1) {
-            try {
-                Quiche.quiche_conn_free(connection);
-                refCnt.release();
-            } finally {
-                connection = -1;
+        boolean release = false;
+        synchronized (this) {
+            if (connection != -1) {
+                try {
+                    Quiche.quiche_conn_free(connection);
+                    release = true;
+                } finally {
+                    connection = -1;
+                }
             }
         }
+        if (release) {
+            refCnt.release();
+        }
+    }
+
+    QuicConnectionAddress sourceId() {
+        return connectionId(() -> Quiche.quiche_conn_source_id(connection));
+    }
+
+    QuicConnectionAddress destinationId() {
+        return connectionId(() -> Quiche.quiche_conn_destination_id(connection));
+    }
+
+    QuicConnectionAddress connectionId(Supplier<byte[]> idSupplier) {
+        final byte[] id;
+        synchronized (this) {
+            if (connection == -1) {
+                return null;
+            }
+            id = idSupplier.get();
+        }
+        return id == null ? null : new QuicConnectionAddress(id);
     }
 
     QuicheQuicSslEngine engine() {

--- a/src/test/java/io/netty/incubator/codec/quic/QuicChannelDatagramTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicChannelDatagramTest.java
@@ -50,25 +50,15 @@ public class QuicChannelDatagramTest extends AbstractQuicTest {
 
     @Test
     public void testDatagramFlushInChannelRead() throws Throwable {
-        testDatagram(false, false);
+        testDatagram(false);
     }
 
     @Test
     public void testDatagramFlushInChannelReadComplete() throws Throwable {
-        testDatagram(true, false);
+        testDatagram(true);
     }
 
-    @Test
-    public void testDatagramFlushInChannelReadWriteDatagramPacket() throws Throwable {
-        testDatagram(false, true);
-    }
-
-    @Test
-    public void testDatagramFlushInChannelReadCompleteWriteDatagramPacket() throws Throwable {
-        testDatagram(true, true);
-    }
-
-    private void testDatagram(boolean flushInReadComplete, boolean writeDatagramPacket) throws Throwable {
+    private void testDatagram(boolean flushInReadComplete) throws Throwable {
         AtomicReference<QuicDatagramExtensionEvent> serverEventRef = new AtomicReference<>();
 
         Channel server = QuicTestUtils.newServer(QuicTestUtils.newQuicServerBuilder()
@@ -79,16 +69,10 @@ public class QuicChannelDatagramTest extends AbstractQuicTest {
             public void channelRead(ChannelHandlerContext ctx, Object msg) {
                 if (msg instanceof ByteBuf) {
                     final ChannelFuture future;
-                    final Object message;
-                    if (writeDatagramPacket) {
-                        message = new DatagramPacket((ByteBuf) msg, (InetSocketAddress) ctx.channel().remoteAddress());
-                    } else {
-                        message = msg;
-                    }
                     if (!flushInReadComplete) {
-                        future = ctx.writeAndFlush(message);
+                        future = ctx.writeAndFlush(msg);
                     } else {
-                        future = ctx.write(message);
+                        future = ctx.write(msg);
                     }
                     future.addListener(ChannelFutureListener.CLOSE);
                 } else {


### PR DESCRIPTION
Motivation:

Often it is useful to be able to access the source and connection ids

Modifications:

- QuicChannel.localAddress() and remoteAddress() return the ids
- Only support ByteBuf when using the Datagram extension

Result:

Be able to access the ids