### PR TITLE
Stream might get into a bad state when the reader is slow.

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -396,7 +396,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         assert eventLoop().inEventLoop();
         this.capacity = capacity;
         boolean mayNeedWrite = ((QuicStreamChannelUnsafe) unsafe()).writeQueued();
-        updateWritabilityIfNeeded(capacity > 0);
+        updateWritabilityIfNeeded(this.capacity > 0);
         return mayNeedWrite;
     }
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -396,6 +396,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         assert eventLoop().inEventLoop();
         this.capacity = capacity;
         boolean mayNeedWrite = ((QuicStreamChannelUnsafe) unsafe()).writeQueued();
+        // we need to re-read this.capacity as writeQueued() may update the capacity.
         updateWritabilityIfNeeded(this.capacity > 0);
         return mayNeedWrite;
     }


### PR DESCRIPTION
Motivation:

It is possible for a `QuicheQuicStreamChannel` to get into a bad state when the following
events happen:
  - Stream becomes writable.
  - Connection receives data and `QuicheQuicChannel.handleWritableStreams()` is called.
  - `QuicheQuicStreamChannel.writable()` is called with a positive value.
  - `QuicStreamChannelUnsafe.writeQueued()` causes the capacity to get to 0 and the
    queue becomes non-empty.
  - At the end of `QuicheQuicStreamChannel.writable()`, the stream is set to writable.

From there on, `QuicheQuicStreamChannel.write()` appends data to the queue since it
is not empty.

Modification:

`QuicheQuicStreamChannel.writable()` should use the current capability to decide
if the writability has changed.

Result:

Stream is happier when there is a slow reader.