### PR TITLE
Limit the memory to 128MiB when trying to unpack rust

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -103,6 +103,10 @@ jobs:
   build-windows:
     runs-on: windows-2016
     name: windows-x86_64
+    env:
+      # Let's limit the amount of ram that is used to unpack rustup as we saw
+      # failures sometimes due the fact that not enough memory could be reserved.
+      RUSTUP_UNPACK_RAM: 134217728  # Use 128 MiB
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -91,6 +91,10 @@ jobs:
   stage-snapshot-windows-x86_64:
     runs-on: windows-2016
     name: stage-snapshot-windows-x86_64
+    env:
+      # Let's limit the amount of ram that is used to unpack rustup as we saw
+      # failures sometimes due the fact that not enough memory could be reserved.
+      RUSTUP_UNPACK_RAM: 134217728  # Use 128 MiB
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -111,6 +111,10 @@ jobs:
   build-pr-windows:
     runs-on: windows-2016
     name: windows-x86_64 build
+    env:
+      # Let's limit the amount of ram that is used to unpack rustup as we saw
+      # failures sometimes due the fact that not enough memory could be reserved.
+      RUSTUP_UNPACK_RAM: 134217728  # Use 128 MiB
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -168,6 +168,10 @@ jobs:
     runs-on: windows-2016
     name: stage-release-windows-x86_64
     needs: prepare-release
+    env:
+      # Let's limit the amount of ram that is used to unpack rustup as we saw
+      # failures sometimes due the fact that not enough memory could be reserved.
+      RUSTUP_UNPACK_RAM: 134217728  # Use 128 MiB
     steps:
       - name: Download release-workspace
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Motivation:

We sometimes saw failures as we were not able to reserve enough memory to unpack the rust toolchain on windows.

Like:

```
info: using up to 500.0 MiB of RAM to unpack components
info: installing component 'rustfmt'
info: installing component 'cargo'
info: installing component 'rust-std'
info: installing component 'rustc'
memory allocation of 16777216 bytes failed
Error: The process 'C:\Rust\.cargo\bin\rustup.exe' failed with exit code 3221226505
```

Modifications:

Set env to limit to 128MiB

Result:

More stable builds on windows