### PR TITLE
Update code to use the new network-path aware API of quiche

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>92e9561501a3a5ab179115675dca25f8b0feb185</quicheCommitSha>
+    <quicheCommitSha>6d070ed8694216806f3ce689d71ceb7ad76d425e</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -18,6 +18,16 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif // _WIN32
+
 #include <quiche.h>
 #include "netty_jni_util.h"
 #include "netty_quic_boringssl.h"
@@ -44,6 +54,97 @@ extern char* strdup(const char*);
 jint quic_get_java_env(JNIEnv **env)
 {
     return (*global_vm)->GetEnv(global_vm, (void **)env, NETTY_JNI_UTIL_JNI_VERSION);
+}
+
+static jint netty_quiche_afInet(JNIEnv* env, jclass clazz) {
+    return AF_INET;
+}
+
+static jint netty_quiche_afInet6(JNIEnv* env, jclass clazz) {
+    return AF_INET6;
+}
+
+static jint netty_quiche_sizeofSockaddrIn(JNIEnv* env, jclass clazz) {
+    return sizeof(struct sockaddr_in);
+}
+
+static jint netty_quiche_sizeofSockaddrIn6(JNIEnv* env, jclass clazz) {
+    return sizeof(struct sockaddr_in6);
+}
+
+static jint netty_quiche_sockaddrInOffsetofSinFamily(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in, sin_family);
+}
+
+static jint netty_quiche_sockaddrInOffsetofSinPort(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in, sin_port);
+}
+
+static jint netty_quiche_sockaddrInOffsetofSinAddr(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in, sin_addr);
+}
+
+static jint netty_quiche_inAddressOffsetofSAddr(JNIEnv* env, jclass clazz) {
+    return offsetof(struct in_addr, s_addr);
+}
+
+static jint netty_quiche_sockaddrIn6OffsetofSin6Family(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in6, sin6_family);
+}
+
+static jint netty_quiche_sockaddrIn6OffsetofSin6Port(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in6, sin6_port);
+}
+
+static jint netty_quiche_sockaddrIn6OffsetofSin6Flowinfo(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in6, sin6_flowinfo);
+}
+
+static jint netty_quiche_sockaddrIn6OffsetofSin6Addr(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in6, sin6_addr);
+}
+
+static jint netty_quiche_sockaddrIn6OffsetofSin6ScopeId(JNIEnv* env, jclass clazz) {
+    return offsetof(struct sockaddr_in6, sin6_scope_id);
+}
+
+static jint netty_quiche_in6AddressOffsetofS6Addr(JNIEnv* env, jclass clazz) {
+    return offsetof(struct in6_addr, s6_addr);
+}
+
+static jint netty_quiche_sizeofSockaddrStorage(JNIEnv* env, jclass clazz) {
+    return sizeof(struct sockaddr_storage);
+}
+static jint netty_quiche_sizeofSizeT(JNIEnv* env, jclass clazz) {
+    return sizeof(size_t);
+}
+
+static jint netty_quiche_sizeofSocklenT(JNIEnv* env, jclass clazz) {
+    return sizeof(socklen_t);
+}
+
+static jint netty_quicheRecvInfoOffsetofFrom(JNIEnv* env, jclass clazz) {
+    return offsetof(quiche_recv_info, from);
+}
+
+static jint netty_quicheRecvInfoOffsetofFromLen(JNIEnv* env, jclass clazz) {
+    return offsetof(quiche_recv_info, from_len);
+}
+
+static jint netty_sizeofQuicheRecvInfo(JNIEnv* env, jclass clazz) {
+    return sizeof(quiche_recv_info);
+}
+
+static jint netty_quicheSendInfoOffsetofTo(JNIEnv* env, jclass clazz) {
+    return offsetof(quiche_send_info, to);
+}
+
+static jint netty_quicheSendInfoOffsetofToLen(JNIEnv* env, jclass clazz) {
+    return offsetof(quiche_send_info, to_len);
+}
+
+static jint netty_sizeofQuicheSendInfo(JNIEnv* env, jclass clazz) {
+    return sizeof(quiche_send_info);
 }
 
 static jint netty_quiche_max_conn_id_len(JNIEnv* env, jclass clazz) {
@@ -176,13 +277,15 @@ static jint netty_quiche_retry(JNIEnv* env, jclass clazz, jlong scid, jint scid_
                                (uint32_t) version, (uint8_t *) out, (size_t) out_len);
 }
 
-static jlong netty_quiche_conn_new_with_tls(JNIEnv* env, jclass clazz, jlong scid, jint scid_len, jlong odcid, jint odcid_len, jlong config, jlong ssl, jboolean isServer) {
+static jlong netty_quiche_conn_new_with_tls(JNIEnv* env, jclass clazz, jlong scid, jint scid_len, jlong odcid, jint odcid_len, jlong peer, jint peer_len, jlong config, jlong ssl, jboolean isServer) {
     const uint8_t * odcid_pointer = NULL;
     if (odcid_len != -1) {
         odcid_pointer = (const uint8_t *) odcid;
     }
+    const struct sockaddr *peer_pointer = (const struct sockaddr*) peer;
     quiche_conn *conn = quiche_conn_new_with_tls((const uint8_t *) scid, (size_t) scid_len,
                                  odcid_pointer, (size_t) odcid_len,
+                                 peer_pointer, (size_t) peer_len,
                                  (quiche_config *) config, (void*) ssl, isServer == JNI_TRUE ? true : false);
     if (conn == NULL) {
         return -1;
@@ -226,12 +329,12 @@ static jbyteArray netty_quiche_conn_destination_id(JNIEnv* env, jclass clazz, jl
     return to_byte_array(env, id, len);
 }
 
-static jint netty_quiche_conn_recv(JNIEnv* env, jclass clazz, jlong conn, jlong buf, jint buf_len) {
-    return (jint) quiche_conn_recv((quiche_conn *) conn, (uint8_t *) buf, (size_t) buf_len);
+static jint netty_quiche_conn_recv(JNIEnv* env, jclass clazz, jlong conn, jlong buf, jint buf_len, jlong info) {
+    return (jint) quiche_conn_recv((quiche_conn *) conn, (uint8_t *) buf, (size_t) buf_len, (quiche_recv_info*) info);
 }
 
-static jint netty_quiche_conn_send(JNIEnv* env, jclass clazz, jlong conn, jlong out, jint out_len) {
-    return (jint) quiche_conn_send((quiche_conn *) conn, (uint8_t *) out, (size_t) out_len);
+static jint netty_quiche_conn_send(JNIEnv* env, jclass clazz, jlong conn, jlong out, jint out_len, jlong info) {
+    return (jint) quiche_conn_send((quiche_conn *) conn, (uint8_t *) out, (size_t) out_len, (quiche_send_info*) info);
 }
 
 static void netty_quiche_conn_free(JNIEnv* env, jclass clazz, jlong conn) {
@@ -476,6 +579,30 @@ static jlong netty_buffer_memory_address(JNIEnv* env, jclass clazz, jobject buff
 
 // JNI Method Registration Table Begin
 static const JNINativeMethod statically_referenced_fixed_method_table[] = {
+  { "afInet", "()I", (void *) netty_quiche_afInet },
+  { "afInet6", "()I", (void *) netty_quiche_afInet6 },
+  { "sizeofSockaddrIn", "()I", (void *) netty_quiche_sizeofSockaddrIn },
+  { "sizeofSockaddrIn6", "()I", (void *) netty_quiche_sizeofSockaddrIn6 },
+  { "sockaddrInOffsetofSinFamily", "()I", (void *) netty_quiche_sockaddrInOffsetofSinFamily },
+  { "sockaddrInOffsetofSinPort", "()I", (void *) netty_quiche_sockaddrInOffsetofSinPort },
+  { "sockaddrInOffsetofSinAddr", "()I", (void *) netty_quiche_sockaddrInOffsetofSinAddr },
+  { "inAddressOffsetofSAddr", "()I", (void *) netty_quiche_inAddressOffsetofSAddr },
+  { "sockaddrIn6OffsetofSin6Family", "()I", (void *) netty_quiche_sockaddrIn6OffsetofSin6Family },
+  { "sockaddrIn6OffsetofSin6Port", "()I", (void *) netty_quiche_sockaddrIn6OffsetofSin6Port },
+  { "sockaddrIn6OffsetofSin6Flowinfo", "()I", (void *) netty_quiche_sockaddrIn6OffsetofSin6Flowinfo },
+  { "sockaddrIn6OffsetofSin6Addr", "()I", (void *) netty_quiche_sockaddrIn6OffsetofSin6Addr },
+  { "sockaddrIn6OffsetofSin6ScopeId", "()I", (void *) netty_quiche_sockaddrIn6OffsetofSin6ScopeId },
+  { "in6AddressOffsetofS6Addr", "()I", (void *) netty_quiche_in6AddressOffsetofS6Addr },
+  { "sizeofSockaddrStorage", "()I", (void *) netty_quiche_sizeofSockaddrStorage },
+  { "sizeofSizeT", "()I", (void *) netty_quiche_sizeofSizeT },
+  { "sizeofSocklenT", "()I", (void *) netty_quiche_sizeofSocklenT },
+  { "quicheRecvInfoOffsetofFrom", "()I", (void *) netty_quicheRecvInfoOffsetofFrom },
+  { "quicheRecvInfoOffsetofFromLen", "()I", (void *) netty_quicheRecvInfoOffsetofFromLen },
+  { "sizeofQuicheRecvInfo", "()I", (void *) netty_sizeofQuicheRecvInfo },
+  { "quicheSendInfoOffsetofTo", "()I", (void *) netty_quicheSendInfoOffsetofTo },
+  { "quicheSendInfoOffsetofToLen", "()I", (void *) netty_quicheSendInfoOffsetofToLen },
+  { "sizeofQuicheSendInfo", "()I", (void *) netty_sizeofQuicheSendInfo },
+
   { "quiche_protocol_version", "()I", (void *) netty_quiche_protocol_version },
   { "quiche_max_conn_id_len", "()I", (void *) netty_quiche_max_conn_id_len },
   { "quiche_shutdown_read", "()I", (void *) netty_quiche_shutdown_read },
@@ -510,9 +637,9 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_trace_id", "(J)[B", (void *) netty_quiche_conn_trace_id },
   { "quiche_conn_source_id", "(J)[B", (void *) netty_quiche_conn_source_id },
   { "quiche_conn_destination_id", "(J)[B", (void *) netty_quiche_conn_destination_id },
-  { "quiche_conn_new_with_tls", "(JIJIJJZ)J", (void *) netty_quiche_conn_new_with_tls },
-  { "quiche_conn_recv", "(JJI)I", (void *) netty_quiche_conn_recv },
-  { "quiche_conn_send", "(JJI)I", (void *) netty_quiche_conn_send },
+  { "quiche_conn_new_with_tls", "(JIJIJIJJZ)J", (void *) netty_quiche_conn_new_with_tls },
+  { "quiche_conn_recv", "(JJIJ)I", (void *) netty_quiche_conn_recv },
+  { "quiche_conn_send", "(JJIJ)I", (void *) netty_quiche_conn_send },
   { "quiche_conn_free", "(J)V", (void *) netty_quiche_conn_free },
   { "quiche_conn_peer_streams_left_bidi", "(J)J", (void *) netty_quiche_conn_peer_streams_left_bidi },
   { "quiche_conn_peer_streams_left_uni", "(J)J", (void *) netty_quiche_conn_peer_streams_left_uni },

--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -576,7 +576,7 @@ static jlong netty_buffer_memory_address(JNIEnv* env, jclass clazz, jobject buff
 }
 
 // Based on https://gist.github.com/kazuho/45eae4f92257daceb73e.
-static jint netty_sockaddr_cmp(jlong addr1, jlong addr2) {
+static jint netty_sockaddr_cmp(JNIEnv* env, jclass clazz,  jlong addr1, jlong addr2) {
     struct sockaddr* x = (struct sockaddr*) addr1;
     struct sockaddr* y = (struct sockaddr*) addr2;
 
@@ -589,6 +589,7 @@ static jint netty_sockaddr_cmp(jlong addr1, jlong addr2) {
     if (x == NULL && y != NULL) {
         return -1;
     }
+
 #define CMP(a, b) if (a != b) return a < b ? -1 : 1
 
     CMP(x->sa_family, y->sa_family);

--- a/src/main/java/io/netty/incubator/codec/quic/QuicConnectionMigrationEvent.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicConnectionMigrationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/src/main/java/io/netty/incubator/codec/quic/QuicConnectionMigrationEvent.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicConnectionMigrationEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import java.net.SocketAddress;
+
+/**
+ * {@link QuicEvent} which is fired when an QUIC connection migration was detected.
+ */
+public final class QuicConnectionMigrationEvent implements QuicEvent {
+
+    private final SocketAddress from;
+    private final SocketAddress to;
+
+    QuicConnectionMigrationEvent(SocketAddress from, SocketAddress to) {
+        this.from = from;
+        this.to = to;
+    }
+
+    /**
+     * The old {@link SocketAddress} of the connection.
+     *
+     * @return the old {@link SocketAddress} of the connection.
+     */
+    SocketAddress from() {
+        return from;
+    }
+
+    /**
+     * The new {@link SocketAddress} of the connection.
+     *
+     * @return the new {@link SocketAddress} of the connection.
+     */
+    SocketAddress to() {
+        return to;
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicConnectionMigrationEvent.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicConnectionMigrationEvent.java
@@ -35,7 +35,7 @@ public final class QuicConnectionMigrationEvent implements QuicEvent {
      *
      * @return the old {@link SocketAddress} of the connection.
      */
-    SocketAddress from() {
+    public SocketAddress from() {
         return from;
     }
 
@@ -44,7 +44,7 @@ public final class QuicConnectionMigrationEvent implements QuicEvent {
      *
      * @return the new {@link SocketAddress} of the connection.
      */
-    SocketAddress to() {
+    public SocketAddress to() {
         return to;
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -76,6 +76,44 @@ final class Quiche {
         }
     }
 
+    static final short AF_INET = (short) QuicheNativeStaticallyReferencedJniMethods.afInet();
+    static final short AF_INET6 = (short) QuicheNativeStaticallyReferencedJniMethods.afInet6();
+    static final int SIZEOF_SOCKADDR_STORAGE = QuicheNativeStaticallyReferencedJniMethods.sizeofSockaddrStorage();
+    static final int SIZEOF_SOCKADDR_IN = QuicheNativeStaticallyReferencedJniMethods.sizeofSockaddrIn();
+    static final int SIZEOF_SOCKADDR_IN6 = QuicheNativeStaticallyReferencedJniMethods.sizeofSockaddrIn6();
+    static final int SOCKADDR_IN_OFFSETOF_SIN_FAMILY =
+            QuicheNativeStaticallyReferencedJniMethods.sockaddrInOffsetofSinFamily();
+    static final int SOCKADDR_IN_OFFSETOF_SIN_PORT =
+            QuicheNativeStaticallyReferencedJniMethods.sockaddrInOffsetofSinPort();
+    static final int SOCKADDR_IN_OFFSETOF_SIN_ADDR =
+            QuicheNativeStaticallyReferencedJniMethods.sockaddrInOffsetofSinAddr();
+    static final int IN_ADDRESS_OFFSETOF_S_ADDR = QuicheNativeStaticallyReferencedJniMethods.inAddressOffsetofSAddr();
+    static final int SOCKADDR_IN6_OFFSETOF_SIN6_FAMILY =
+            QuicheNativeStaticallyReferencedJniMethods.sockaddrIn6OffsetofSin6Family();
+    static final int SOCKADDR_IN6_OFFSETOF_SIN6_PORT =
+            QuicheNativeStaticallyReferencedJniMethods.sockaddrIn6OffsetofSin6Port();
+    static final int SOCKADDR_IN6_OFFSETOF_SIN6_FLOWINFO =
+            QuicheNativeStaticallyReferencedJniMethods.sockaddrIn6OffsetofSin6Flowinfo();
+    static final int SOCKADDR_IN6_OFFSETOF_SIN6_ADDR =
+            QuicheNativeStaticallyReferencedJniMethods.sockaddrIn6OffsetofSin6Addr();
+    static final int SOCKADDR_IN6_OFFSETOF_SIN6_SCOPE_ID =
+            QuicheNativeStaticallyReferencedJniMethods.sockaddrIn6OffsetofSin6ScopeId();
+    static final int IN6_ADDRESS_OFFSETOF_S6_ADDR =
+            QuicheNativeStaticallyReferencedJniMethods.in6AddressOffsetofS6Addr();
+    static final int SIZEOF_SOCKLEN_T = QuicheNativeStaticallyReferencedJniMethods.sizeofSocklenT();
+    static final int SIZEOF_SIZE_T = QuicheNativeStaticallyReferencedJniMethods.sizeofSizeT();
+
+    static final int QUICHE_RECV_INFO_OFFSETOF_FROM =
+            QuicheNativeStaticallyReferencedJniMethods.quicheRecvInfoOffsetofFrom();
+    static final int QUICHE_RECV_INFO_OFFSETOF_FROM_LEN =
+            QuicheNativeStaticallyReferencedJniMethods.quicheRecvInfoOffsetofFromLen();
+    static final int SIZEOF_QUICHE_RECV_INFO = QuicheNativeStaticallyReferencedJniMethods.sizeofQuicheRecvInfo();
+    static final int QUICHE_SEND_INFO_OFFSETOF_TO =
+            QuicheNativeStaticallyReferencedJniMethods.quicheSendInfoOffsetofTo();
+    static final int QUICHE_SEND_INFO_OFFSETOF_TO_LEN =
+            QuicheNativeStaticallyReferencedJniMethods.quicheSendInfoOffsetofToLen();
+    static final int SIZEOF_QUICHE_SEND_INFO = QuicheNativeStaticallyReferencedJniMethods.sizeofQuicheSendInfo();
+
     static final int QUICHE_PROTOCOL_VERSION = QuicheNativeStaticallyReferencedJniMethods.quiche_protocol_version();
     static final int QUICHE_MAX_CONN_ID_LEN = QuicheNativeStaticallyReferencedJniMethods.quiche_max_conn_id_len();
 
@@ -229,6 +267,7 @@ final class Quiche {
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L229">quiche_conn_new_with_tls</a>.
      */
     static native long quiche_conn_new_with_tls(long scidAddr, int scidLen, long odcidAddr, int odcidLen,
+                                                long peerAddr, int peerLen,
                                                 long configAddr, long ssl, boolean isServer);
 
     /**
@@ -240,12 +279,12 @@ final class Quiche {
     /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L249">quiche_conn_recv</a>.
      */
-    static native int quiche_conn_recv(long connAddr, long bufAddr, int bufLen);
+    static native int quiche_conn_recv(long connAddr, long bufAddr, int bufLen, long infoAddr);
 
     /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L262">quiche_conn_send</a>.
      */
-    static native int quiche_conn_send(long connAddr, long outAddr, int outLen);
+    static native int quiche_conn_send(long connAddr, long outAddr, int outLen, long infoAddr);
 
     /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L373">quiche_conn_free</a>.

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -583,6 +583,8 @@ final class Quiche {
 
     private static native long buffer_memory_address(ByteBuffer buffer);
 
+    static native int sockaddr_cmp(long addr, long addr2);
+
     /**
      * Returns the memory address if the {@link ByteBuf}
      */

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheNativeStaticallyReferencedJniMethods.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheNativeStaticallyReferencedJniMethods.java
@@ -41,5 +41,30 @@ final class QuicheNativeStaticallyReferencedJniMethods {
     static native int quiche_cc_reno();
     static native int quiche_cc_cubic();
 
+    static native int quicheRecvInfoOffsetofFrom();
+    static native int quicheRecvInfoOffsetofFromLen();
+    static native int sizeofQuicheRecvInfo();
+    static native int quicheSendInfoOffsetofTo();
+    static native int quicheSendInfoOffsetofToLen();
+    static native int sizeofQuicheSendInfo();
+
+    static native int afInet();
+    static native int afInet6();
+    static native int sizeofSockaddrIn();
+    static native int sizeofSockaddrIn6();
+    static native int sockaddrInOffsetofSinFamily();
+    static native int sockaddrInOffsetofSinPort();
+    static native int sockaddrInOffsetofSinAddr();
+    static native int inAddressOffsetofSAddr();
+    static native int sockaddrIn6OffsetofSin6Family();
+    static native int sockaddrIn6OffsetofSin6Port();
+    static native int sockaddrIn6OffsetofSin6Flowinfo();
+    static native int sockaddrIn6OffsetofSin6Addr();
+    static native int sockaddrIn6OffsetofSin6ScopeId();
+    static native int in6AddressOffsetofS6Addr();
+    static native int sizeofSockaddrStorage();
+    static native int sizeofSocklenT();
+    static native int sizeofSizeT();
+
     private QuicheNativeStaticallyReferencedJniMethods() { }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -890,7 +890,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
             boolean done;
             int writerIndex = out.writerIndex();
-            // TODO: Fix info!
             int written = Quiche.quiche_conn_send(
                     connAddr, Quiche.memoryAddress(out) + writerIndex, out.writableBytes(), sendInfo);
             if (written == 0) {
@@ -1044,7 +1043,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             SegmentedDatagramPacketAllocator segmentedDatagramPacketAllocator =
                     config.getSegmentedDatagramPacketAllocator();
             if (segmentedDatagramPacketAllocator.maxNumSegments() > 0) {
-                packetWasWritten = connectionSendSegments(segmentedDatagramPacketAllocator);
+                packetWasWritten = connectionSendSimple(); // connectionSendSegments(segmentedDatagramPacketAllocator);
             } else {
                 packetWasWritten = connectionSendSimple();
             }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -162,6 +162,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
         this.supportsDatagram = supportsDatagram;
         this.remote = remote;
+
         this.streamHandler = streamHandler;
         this.streamOptionsArray = streamOptionsArray;
         this.streamAttrsArray = streamAttrsArray;
@@ -202,10 +203,13 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
     void attachQuicheConnection(QuicheQuicConnection connection) {
         this.connection = connection;
+
         byte[] traceId = Quiche.quiche_conn_trace_id(connection.address());
         if (traceId != null) {
             this.traceId = new String(traceId);
         }
+
+        connection.initInfoAddresses(remote);
 
         // Setup QLOG if needed.
         QLogConfiguration configuration = config.getQLogConfiguration();

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
@@ -54,7 +54,7 @@ final class QuicheQuicClientCodec extends QuicheQuicCodec {
         final QuicheQuicChannel channel;
         try {
             channel = QuicheQuicChannel.handleConnect(sslEngineProvider, remoteAddress, config.nativeAddress(),
-                    localConnIdLength, config.isDatagramSupported());
+                    localConnIdLength, config.isDatagramSupported(), sockaddrMemory.memoryAddress());
         } catch (Exception e) {
             promise.setFailure(e);
             return;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -32,6 +32,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Queue;
 
+import static io.netty.incubator.codec.quic.Quiche.allocateNativeOrder;
+
 /**
  * Abstract base class for QUIC codecs.
  */
@@ -51,6 +53,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
     protected final QuicheConfig config;
     protected final int localConnIdLength;
+    protected ByteBuf sockaddrMemory;
 
     QuicheQuicCodec(QuicheConfig config, int localConnIdLength, int maxTokenLength, FlushStrategy flushStrategy) {
         this.config = config;
@@ -69,13 +72,14 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) {
+        sockaddrMemory = allocateNativeOrder(Quiche.SIZEOF_SOCKADDR_STORAGE);
         headerParser = new QuicHeaderParser(maxTokenLength, localConnIdLength);
         parserCallback = (sender, recipient, buffer, type, version, scid, dcid, token) -> {
             QuicheQuicChannel channel = quicPacketRead(ctx, sender, recipient,
                     type, version, scid,
                     dcid, token);
             if (channel != null) {
-                channel.recv(buffer);
+                channel.recv(sender, buffer);
                 if (channel.markInFireChannelReadCompleteQueue()) {
                     needsFireChannelReadComplete.add(channel);
                 }
@@ -97,6 +101,9 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
             needsFireChannelReadComplete.clear();
         } finally {
             config.free();
+            if (sockaddrMemory != null) {
+                sockaddrMemory.release();
+            }
             if (headerParser != null) {
                 headerParser.close();
                 headerParser = null;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -53,6 +53,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
     protected final QuicheConfig config;
     protected final int localConnIdLength;
+    // This buffer is used to copy InetSocketAddress to sockaddr_storage and so pass it down the JNI layer.
     protected ByteBuf sockaddrMemory;
 
     QuicheQuicCodec(QuicheConfig config, int localConnIdLength, int maxTokenLength, FlushStrategy flushStrategy) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.ReferenceCounted;
 
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.util.function.Supplier;
 
 final class QuicheQuicConnection {
@@ -27,6 +26,17 @@ final class QuicheQuicConnection {
     private static final int QUICHE_SEND_INFOS_OFFSET = 2 * TOTAL_RECV_INFO_SIZE;
     private final ReferenceCounted refCnt;
     private final QuicheQuicSslEngine engine;
+
+    // This block of memory is used to store the following structs (in this order):
+    // - quiche_recv_info
+    // - sockaddr_storage
+    // - quiche_recv_info
+    // - sockaddr_storage
+    // - quiche_send_info
+    // - quiche_send_info
+    //
+    // We need to have every stored 2 times as we need to check if the last sockaddr has changed between
+    // quiche_conn_recv and quiche_conn_send calls. If this happens we know a QUIC connection migration did happen.
     private final ByteBuf infoBuffer;
     private long connection;
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
@@ -100,6 +100,14 @@ final class QuicheQuicConnection {
         QuicheSendInfo.write(sendInfosAddress + Quiche.SIZEOF_QUICHE_SEND_INFO, address);
     }
 
+    long recvInfoAddress() {
+        return infoBuffer.memoryAddress();
+    }
+
+    long sendInfoAddress() {
+        return sendInfosAddress();
+    }
+
     long nextRecvInfoAddress(long previousRecvInfoAddress) {
         long memoryAddress = infoBuffer.memoryAddress();
         if (memoryAddress == previousRecvInfoAddress) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -211,9 +211,12 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         }
 
         QuicheQuicSslEngine quicSslEngine = (QuicheQuicSslEngine) engine;
-        QuicheQuicConnection connection = quicSslEngine.createConnection(ssl ->
-                Quiche.quiche_conn_new_with_tls(scidAddr, scidLen, ocidAddr, ocidLen,
-                        config.nativeAddress(), ssl, true));
+        QuicheQuicConnection connection = quicSslEngine.createConnection(ssl -> {
+            long peerAddr = sockaddrMemory.memoryAddress();
+            int peerLen = SockaddrIn.write(peerAddr, sender);
+            return Quiche.quiche_conn_new_with_tls(scidAddr, scidLen, ocidAddr, ocidLen, peerAddr, peerLen,
+                    config.nativeAddress(), ssl, true);
+        });
         if (connection  == null) {
             channel.unsafe().closeForcibly();
             LOGGER.debug("quiche_accept failed");

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheRecvInfo.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheRecvInfo.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.util.internal.PlatformDependent;
+
+import java.net.InetSocketAddress;
+
+final class QuicheRecvInfo {
+
+    private QuicheRecvInfo() { }
+
+    static void write(long memory, InetSocketAddress address) {
+        long sockaddr = memory + Quiche.SIZEOF_QUICHE_RECV_INFO;
+        int len = SockaddrIn.write(sockaddr, address);
+        if (Quiche.SIZEOF_SIZE_T == 4) {
+            PlatformDependent.putInt(memory + Quiche.QUICHE_RECV_INFO_OFFSETOF_FROM, (int) sockaddr);
+        } else {
+            PlatformDependent.putLong(memory + Quiche.QUICHE_RECV_INFO_OFFSETOF_FROM, sockaddr);
+        }
+        switch (Quiche.SIZEOF_SOCKLEN_T) {
+            case 1:
+                PlatformDependent.putByte(memory + Quiche.QUICHE_RECV_INFO_OFFSETOF_FROM_LEN, (byte) len);
+                break;
+            case 2:
+                PlatformDependent.putShort(memory + Quiche.QUICHE_RECV_INFO_OFFSETOF_FROM_LEN, (short) len);
+                break;
+            case 4:
+                PlatformDependent.putInt(memory + Quiche.QUICHE_RECV_INFO_OFFSETOF_FROM_LEN, len);
+                break;
+            case 8:
+                PlatformDependent.putLong(memory + Quiche.QUICHE_RECV_INFO_OFFSETOF_FROM_LEN, len);
+                break;
+            default:
+                throw new IllegalStateException();
+        }
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheRecvInfo.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheRecvInfo.java
@@ -48,4 +48,9 @@ final class QuicheRecvInfo {
                 throw new IllegalStateException();
         }
     }
+
+    static boolean isSockAddrSame(long memory, long otherMemory) {
+        return Quiche.sockaddr_cmp(memory + Quiche.SIZEOF_QUICHE_RECV_INFO,
+                otherMemory + Quiche.SIZEOF_QUICHE_RECV_INFO) == 0;
+    }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheRecvInfo.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheRecvInfo.java
@@ -23,6 +23,19 @@ final class QuicheRecvInfo {
 
     private QuicheRecvInfo() { }
 
+    /**
+     * Write the {@link InetSocketAddress} into the {@code quiche_recv_info} struct.
+     *
+     * <pre>
+     * typedef struct {
+     *     struct sockaddr *from;
+     *     socklen_t from_len;
+     * } quiche_recv_info;
+     * </pre>
+     *
+     * @param memory the memory address of {@code quiche_recv_info}.
+     * @param address the {@link InetSocketAddress} to write into {@code quiche_recv_info}.
+     */
     static void write(long memory, InetSocketAddress address) {
         long sockaddr = memory + Quiche.SIZEOF_QUICHE_RECV_INFO;
         int len = SockaddrIn.write(sockaddr, address);
@@ -49,6 +62,11 @@ final class QuicheRecvInfo {
         }
     }
 
+    /**
+     * Return the memory address of the {@code sockaddr} that is contained in {@code quiche_recv_info}.
+     * @param memory the memory address of {@code quiche_recv_info}.
+     * @return the memory address of the {@code sockaddr}.
+     */
     static long sockAddress(long memory) {
         return memory + Quiche.SIZEOF_QUICHE_RECV_INFO;
     }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheRecvInfo.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheRecvInfo.java
@@ -49,8 +49,7 @@ final class QuicheRecvInfo {
         }
     }
 
-    static boolean isSockAddrSame(long memory, long otherMemory) {
-        return Quiche.sockaddr_cmp(memory + Quiche.SIZEOF_QUICHE_RECV_INFO,
-                otherMemory + Quiche.SIZEOF_QUICHE_RECV_INFO) == 0;
+    static long sockAddress(long memory) {
+        return memory + Quiche.SIZEOF_QUICHE_RECV_INFO;
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheSendInfo.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheSendInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.util.concurrent.FastThreadLocal;
+import io.netty.util.internal.PlatformDependent;
+
+import java.net.InetSocketAddress;
+
+import static io.netty.util.internal.PlatformDependent.BIG_ENDIAN_NATIVE_ORDER;
+
+final class QuicheSendInfo {
+
+    private static final FastThreadLocal<byte[]> IPV4_ARRAYS = new FastThreadLocal<byte[]>() {
+        @Override
+        protected byte[] initialValue() {
+            return new byte[SockaddrIn.IPV4_ADDRESS_LENGTH];
+        }
+    };
+
+    private static final FastThreadLocal<byte[]> IPV6_ARRAYS = new FastThreadLocal<byte[]>() {
+        @Override
+        protected byte[] initialValue() {
+            return new byte[SockaddrIn.IPV6_ADDRESS_LENGTH];
+        }
+    };
+
+    private QuicheSendInfo() { }
+
+    static InetSocketAddress read(long memory) {
+        long to = memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO;
+        long len = readLen(memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO_LEN);
+        if (len == Quiche.SIZEOF_SOCKADDR_IN) {
+            return SockaddrIn.readIPv4(to, IPV4_ARRAYS.get());
+        }
+        assert len == Quiche.SIZEOF_SOCKADDR_IN6;
+        return SockaddrIn.readIPv6(to, IPV6_ARRAYS.get(), IPV4_ARRAYS.get());
+    }
+
+    private static long readLen(long address) {
+        switch (Quiche.SIZEOF_SOCKLEN_T) {
+            case 1:
+                return PlatformDependent.getByte(address);
+            case 2:
+                return PlatformDependent.getShort(address);
+            case 4:
+                return PlatformDependent.getInt(address);
+            case 8:
+                return PlatformDependent.getLong(address);
+            default:
+                throw new IllegalStateException();
+        }
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheSendInfo.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheSendInfo.java
@@ -65,6 +65,27 @@ final class QuicheSendInfo {
         }
     }
 
+    static void write(long memory, InetSocketAddress address) {
+        long sockaddr = memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO;
+        int len = SockaddrIn.write(sockaddr, address);
+        switch (Quiche.SIZEOF_SOCKLEN_T) {
+            case 1:
+                PlatformDependent.putByte(memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO_LEN, (byte) len);
+                break;
+            case 2:
+                PlatformDependent.putShort(memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO_LEN, (short) len);
+                break;
+            case 4:
+                PlatformDependent.putInt(memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO_LEN, len);
+                break;
+            case 8:
+                PlatformDependent.putLong(memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO_LEN, len);
+                break;
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
     static long sockAddress(long memory) {
         return memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO;
     }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheSendInfo.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheSendInfo.java
@@ -64,4 +64,9 @@ final class QuicheSendInfo {
                 throw new IllegalStateException();
         }
     }
+
+    static boolean isSockAddrSame(long memory, long otherMemory) {
+        return Quiche.sockaddr_cmp(memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO,
+                otherMemory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO) == 0;
+    }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheSendInfo.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheSendInfo.java
@@ -65,8 +65,7 @@ final class QuicheSendInfo {
         }
     }
 
-    static boolean isSockAddrSame(long memory, long otherMemory) {
-        return Quiche.sockaddr_cmp(memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO,
-                otherMemory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO) == 0;
+    static long sockAddress(long memory) {
+        return memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO;
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheSendInfo.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheSendInfo.java
@@ -20,8 +20,6 @@ import io.netty.util.internal.PlatformDependent;
 
 import java.net.InetSocketAddress;
 
-import static io.netty.util.internal.PlatformDependent.BIG_ENDIAN_NATIVE_ORDER;
-
 final class QuicheSendInfo {
 
     private static final FastThreadLocal<byte[]> IPV4_ARRAYS = new FastThreadLocal<byte[]>() {
@@ -40,6 +38,12 @@ final class QuicheSendInfo {
 
     private QuicheSendInfo() { }
 
+    /**
+     * Read the {@link InetSocketAddress} out of the {@code quiche_send_info} struct.
+     *
+     * @param memory the memory address of {@code quiche_send_info}.
+     * @return the address that was read.
+     */
     static InetSocketAddress read(long memory) {
         long to = memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO;
         long len = readLen(memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO_LEN);
@@ -65,8 +69,22 @@ final class QuicheSendInfo {
         }
     }
 
+    /**
+     * Write the {@link InetSocketAddress} into the {@code quiche_send_info} struct.
+     * <pre>
+     *
+     * typedef struct {
+     *     // The address the packet should be sent to.
+     *     struct sockaddr_storage to;
+     *     socklen_t to_len;
+     * } quiche_send_info;
+     * </pre>
+     *
+     * @param memory the memory address of {@code quiche_send_info}.
+     * @param address the {@link InetSocketAddress} to write into {@code quiche_send_info}.
+     */
     static void write(long memory, InetSocketAddress address) {
-        long sockaddr = memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO;
+        long sockaddr = sockAddress(memory);
         int len = SockaddrIn.write(sockaddr, address);
         switch (Quiche.SIZEOF_SOCKLEN_T) {
             case 1:
@@ -86,6 +104,11 @@ final class QuicheSendInfo {
         }
     }
 
+    /**
+     * Return the memory address of the {@code sockaddr_storage} that is contained in {@code quiche_send_info}.
+     * @param memory the memory address of {@code quiche_send_info}.
+     * @return the memory address of the {@code sockaddr_storage}.
+     */
     static long sockAddress(long memory) {
         return memory + Quiche.QUICHE_SEND_INFO_OFFSETOF_TO;
     }

--- a/src/main/java/io/netty/incubator/codec/quic/SockaddrIn.java
+++ b/src/main/java/io/netty/incubator/codec/quic/SockaddrIn.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.util.internal.PlatformDependent;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import static io.netty.util.internal.PlatformDependent.BIG_ENDIAN_NATIVE_ORDER;
+
+final class SockaddrIn {
+    static final byte[] IPV4_MAPPED_IPV6_PREFIX = {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xff, (byte) 0xff };
+    static final int IPV4_ADDRESS_LENGTH = 4;
+    static final int IPV6_ADDRESS_LENGTH = 16;
+
+    private SockaddrIn() { }
+
+    static int write(long memory, InetSocketAddress address) {
+        InetAddress addr = address.getAddress();
+        return write(addr instanceof Inet6Address, memory, address);
+    }
+
+    static int write(boolean ipv6, long memory, InetSocketAddress address) {
+        if (ipv6) {
+            return SockaddrIn.writeIPv6(memory, address.getAddress(), address.getPort());
+        } else {
+            return SockaddrIn.writeIPv4(memory, address.getAddress(), address.getPort());
+        }
+    }
+
+    /**
+     *
+     * struct sockaddr_in {
+     *      sa_family_t    sin_family; // address family: AF_INET
+     *      in_port_t      sin_port;   // port in network byte order
+     *      struct in_addr sin_addr;   // internet address
+     * };
+     *
+     * // Internet address.
+     * struct in_addr {
+     *     uint32_t       s_addr;     // address in network byte order
+     * };
+     *
+     */
+    static int writeIPv4(long memory, InetAddress address, int port) {
+        PlatformDependent.setMemory(memory, Quiche.SIZEOF_SOCKADDR_IN, (byte) 0);
+
+        PlatformDependent.putShort(memory + Quiche.SOCKADDR_IN_OFFSETOF_SIN_FAMILY, Quiche.AF_INET);
+        PlatformDependent.putShort(memory + Quiche.SOCKADDR_IN_OFFSETOF_SIN_PORT, handleNetworkOrder((short) port));
+        byte[] bytes = address.getAddress();
+        int offset = 0;
+        if (bytes.length == IPV6_ADDRESS_LENGTH) {
+            // IPV6 mapped IPV4 address, we only need the last 4 bytes.
+            offset = IPV4_MAPPED_IPV6_PREFIX.length;
+        }
+        assert bytes.length == offset + 4;
+        PlatformDependent.copyMemory(bytes, offset,
+                memory + Quiche.SOCKADDR_IN_OFFSETOF_SIN_ADDR + Quiche.IN_ADDRESS_OFFSETOF_S_ADDR, 4);
+        return Quiche.SIZEOF_SOCKADDR_IN;
+    }
+
+    /**
+     * struct sockaddr_in6 {
+     *     sa_family_t     sin6_family;   // AF_INET6
+     *     in_port_t       sin6_port;     // port number
+     *     uint32_t        sin6_flowinfo; // IPv6 flow information
+     *     struct in6_addr sin6_addr;     // IPv6 address
+     *     uint32_t        sin6_scope_id; /* Scope ID (new in 2.4)
+     * };
+     *
+     * struct in6_addr {
+     *     unsigned char s6_addr[16];   // IPv6 address
+     * };
+     */
+    static int writeIPv6(long memory, InetAddress address, int port) {
+        PlatformDependent.setMemory(memory, Quiche.SIZEOF_SOCKADDR_IN6, (byte) 0);
+        PlatformDependent.putShort(memory + Quiche.SOCKADDR_IN6_OFFSETOF_SIN6_FAMILY, Quiche.AF_INET6);
+        PlatformDependent.putShort(memory + Quiche.SOCKADDR_IN6_OFFSETOF_SIN6_PORT, handleNetworkOrder((short) port));
+        // Skip sin6_flowinfo as we did memset before
+        byte[] bytes = address.getAddress();
+        if  (bytes.length == IPV4_ADDRESS_LENGTH) {
+            int offset = Quiche.SOCKADDR_IN6_OFFSETOF_SIN6_ADDR + Quiche.IN6_ADDRESS_OFFSETOF_S6_ADDR;
+            PlatformDependent.copyMemory(IPV4_MAPPED_IPV6_PREFIX, 0, memory + offset, IPV4_MAPPED_IPV6_PREFIX.length);
+            PlatformDependent.copyMemory(bytes, 0,
+                    memory + offset + IPV4_MAPPED_IPV6_PREFIX.length, IPV4_ADDRESS_LENGTH);
+            // Skip sin6_scope_id as we did memset before
+        } else {
+            PlatformDependent.copyMemory(
+                    bytes, 0, memory + Quiche.SOCKADDR_IN6_OFFSETOF_SIN6_ADDR + Quiche.IN6_ADDRESS_OFFSETOF_S6_ADDR,
+                    IPV6_ADDRESS_LENGTH);
+            PlatformDependent.putInt(
+                    memory + Quiche.SOCKADDR_IN6_OFFSETOF_SIN6_SCOPE_ID, ((Inet6Address) address).getScopeId());
+        }
+        return Quiche.SIZEOF_SOCKADDR_IN6;
+    }
+
+    static InetSocketAddress readIPv4(long memory, byte[] tmpArray) {
+        assert tmpArray.length == IPV4_ADDRESS_LENGTH;
+        int port = handleNetworkOrder(PlatformDependent.getShort(
+                memory + Quiche.SOCKADDR_IN_OFFSETOF_SIN_PORT)) & 0xFFFF;
+        PlatformDependent.copyMemory(memory + Quiche.SOCKADDR_IN_OFFSETOF_SIN_ADDR + Quiche.IN_ADDRESS_OFFSETOF_S_ADDR,
+                tmpArray, 0, IPV4_ADDRESS_LENGTH);
+        try {
+            return new InetSocketAddress(InetAddress.getByAddress(tmpArray), port);
+        } catch (UnknownHostException ignore) {
+            return null;
+        }
+    }
+
+    static InetSocketAddress readIPv6(long memory, byte[] ipv6Array, byte[] ipv4Array) {
+        assert ipv6Array.length == IPV6_ADDRESS_LENGTH;
+        assert ipv4Array.length == IPV4_ADDRESS_LENGTH;
+
+        int port = handleNetworkOrder(PlatformDependent.getShort(
+                memory + Quiche.SOCKADDR_IN6_OFFSETOF_SIN6_PORT)) & 0xFFFF;
+        PlatformDependent.copyMemory(
+                memory + Quiche.SOCKADDR_IN6_OFFSETOF_SIN6_ADDR + Quiche.IN6_ADDRESS_OFFSETOF_S6_ADDR,
+                ipv6Array, 0, IPV6_ADDRESS_LENGTH);
+        if (PlatformDependent.equals(
+                ipv6Array, 0, IPV4_MAPPED_IPV6_PREFIX, 0, IPV4_MAPPED_IPV6_PREFIX.length)) {
+            System.arraycopy(ipv6Array, IPV4_MAPPED_IPV6_PREFIX.length, ipv4Array, 0, IPV4_ADDRESS_LENGTH);
+            try {
+                return new InetSocketAddress(Inet4Address.getByAddress(ipv4Array), port);
+            } catch (UnknownHostException ignore) {
+                return null;
+            }
+        } else {
+            int scopeId = PlatformDependent.getInt(memory + Quiche.SOCKADDR_IN6_OFFSETOF_SIN6_SCOPE_ID);
+            try {
+                return new InetSocketAddress(Inet6Address.getByAddress(null, ipv6Array, scopeId), port);
+            } catch (UnknownHostException ignore) {
+                return null;
+            }
+        }
+    }
+
+    private static short handleNetworkOrder(short v) {
+        return BIG_ENDIAN_NATIVE_ORDER ? v : Short.reverseBytes(v);
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/SockaddrIn.java
+++ b/src/main/java/io/netty/incubator/codec/quic/SockaddrIn.java
@@ -33,6 +33,10 @@ final class SockaddrIn {
 
     private SockaddrIn() { }
 
+    static int cmp(long memory, long memory2) {
+        return Quiche.sockaddr_cmp(memory, memory2);
+    }
+
     static int write(long memory, InetSocketAddress address) {
         InetAddress addr = address.getAddress();
         return write(addr instanceof Inet6Address, memory, address);

--- a/src/test/java/io/netty/incubator/codec/quic/QuicChannelValidationHandler.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicChannelValidationHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+class QuicChannelValidationHandler extends ChannelInboundHandlerAdapter {
+
+    private volatile Throwable cause;
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof QuicConnectionMigrationEvent) {
+            fail("QuicConnectionMigrationEvent should never happen atm");
+        }
+        super.userEventTriggered(ctx, evt);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        this.cause = cause;
+    }
+
+    void assertState() throws Throwable {
+        if (cause != null) {
+            throw cause;
+        }
+    }
+
+}

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
@@ -34,13 +34,16 @@ public class QuicStreamChannelCreationTest extends AbstractQuicTest {
 
     @Test
     public void testCreateStream() throws Throwable {
-        Channel server = QuicTestUtils.newServer(new ChannelInboundHandlerAdapter(),
+        QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler();
+        Channel server = QuicTestUtils.newServer(serverHandler,
                 new ChannelInboundHandlerAdapter());
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
         Channel channel = QuicTestUtils.newClient();
+        QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
+
         try {
             QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
-                    .handler(new ChannelInboundHandlerAdapter())
+                    .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
                     .connect()
@@ -59,6 +62,9 @@ public class QuicStreamChannelCreationTest extends AbstractQuicTest {
             latch.await();
             stream.close().sync();
             quicChannel.close().sync();
+
+            serverHandler.assertState();
+            clientHandler.assertState();
         } finally {
             server.close().sync();
             // Close the parent Datagram channel as well.
@@ -68,13 +74,16 @@ public class QuicStreamChannelCreationTest extends AbstractQuicTest {
 
     @Test
     public void testCreateStreamViaBootstrap() throws Throwable {
-        Channel server = QuicTestUtils.newServer(new ChannelInboundHandlerAdapter(),
+        QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler();
+        Channel server = QuicTestUtils.newServer(serverHandler,
                 new ChannelInboundHandlerAdapter());
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
         Channel channel = QuicTestUtils.newClient();
+        QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
+
         try {
             QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
-                    .handler(new ChannelInboundHandlerAdapter())
+                    .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
                     .connect()
@@ -96,6 +105,9 @@ public class QuicStreamChannelCreationTest extends AbstractQuicTest {
             latch.await();
             stream.close().sync();
             quicChannel.close().sync();
+
+            serverHandler.assertState();
+            clientHandler.assertState();
         } finally {
             server.close().syncUninterruptibly();
             // Close the parent Datagram channel as well.

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamHalfClosureTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamHalfClosureTest.java
@@ -34,24 +34,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class QuicStreamHalfClosureTest extends AbstractQuicTest {
 
     @Test
-    public void testCloseHalfClosureUnidirectional() throws Exception {
+    public void testCloseHalfClosureUnidirectional() throws Throwable {
         testCloseHalfClosure(QuicStreamType.UNIDIRECTIONAL);
     }
 
     @Test
-    public void testCloseHalfClosureBidirectional() throws Exception {
+    public void testCloseHalfClosureBidirectional() throws Throwable {
         testCloseHalfClosure(QuicStreamType.BIDIRECTIONAL);
     }
 
-    private static void testCloseHalfClosure(QuicStreamType type) throws Exception {
+    private static void testCloseHalfClosure(QuicStreamType type) throws Throwable {
         Channel server = null;
         Channel channel = null;
+        QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler();
+        QuicChannelValidationHandler clientHandler = new StreamCreationHandler(type);
         try {
             StreamHandler handler = new StreamHandler();
-            server = QuicTestUtils.newServer(null, handler);
+            server = QuicTestUtils.newServer(serverHandler, handler);
             channel = QuicTestUtils.newClient();
             QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
-                    .handler(new StreamCreationHandler(type))
+                    .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(server.localAddress())
                     .connect()
@@ -59,13 +61,16 @@ public class QuicStreamHalfClosureTest extends AbstractQuicTest {
 
             handler.assertSequence();
             quicChannel.closeFuture().sync();
+
+            serverHandler.assertState();
+            clientHandler.assertState();
         } finally {
             QuicTestUtils.closeIfNotNull(channel);
             QuicTestUtils.closeIfNotNull(server);
         }
     }
 
-    private static final class StreamCreationHandler extends ChannelInboundHandlerAdapter {
+    private static final class StreamCreationHandler extends QuicChannelValidationHandler {
         private final QuicStreamType type;
 
         StreamCreationHandler(QuicStreamType type) {


### PR DESCRIPTION
Motivation:

Quiche changed its API to be network path aware and so be able to handle connection migration in the future.

Modifications:

- Adjust code to use the new API

Result:

Be able to use the new network-path aware API of quiche