### PR TITLE
Upgrade to junit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <skipTests>false</skipTests>
     <netty.version>4.1.65.Final</netty.version>
     <netty.build.version>29</netty.build.version>
+    <junit.version>5.7.0</junit.version>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <jniLibName>netty_quiche_${os.detected.name}_${os.detected.arch}</jniLibName>
     <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/</jniUtilIncludeDir>
@@ -646,13 +647,6 @@
         <trimStackTrace>false</trimStackTrace>
         <argLine>${test.argLine}</argLine>
       </configuration>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.maven.surefire</groupId>
-          <artifactId>surefire-junit4</artifactId>
-          <version>2.22.1</version>
-        </dependency>
-      </dependencies>
     </plugin>
     <!-- always produce osgi bundles -->
     <plugin>
@@ -882,9 +876,21 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -903,12 +909,6 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.1.7</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.surefire</groupId>
-      <artifactId>surefire-junit4</artifactId>
-      <version>2.22.1</version>
       <scope>test</scope>
     </dependency>
     <!-- Also include bouncycastle so we can use SelfSignedCertificate even on more recent JDKs during testing -->

--- a/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
@@ -16,8 +16,8 @@
 package io.netty.incubator.codec.quic;
 
 import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.rules.Timeout;
 
 public abstract class AbstractQuicTest {
@@ -28,7 +28,7 @@ public abstract class AbstractQuicTest {
     @Rule
     public final Timeout globalTimeout = Timeout.seconds(TEST_GLOBAL_TIMEOUT_VALUE);
 
-    @BeforeClass
+    @BeforeAll
     public static void assumeTrue() {
         Quic.ensureAvailability();
        Assume.assumeTrue(Quic.isAvailable());

--- a/src/test/java/io/netty/incubator/codec/quic/FlushStrategyTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/FlushStrategyTest.java
@@ -15,10 +15,10 @@
  */
 package io.netty.incubator.codec.quic;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FlushStrategyTest {
 

--- a/src/test/java/io/netty/incubator/codec/quic/InsecureQuicTokenHandlerTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/InsecureQuicTokenHandlerTest.java
@@ -17,7 +17,8 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -26,8 +27,9 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class InsecureQuicTokenHandlerTest extends AbstractQuicTest {
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -29,8 +29,9 @@ import io.netty.handler.ssl.util.TrustManagerFactoryWrapper;
 import io.netty.util.concurrent.Future;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
@@ -49,17 +50,19 @@ import java.security.cert.X509Certificate;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class QuicChannelConnectTest extends AbstractQuicTest {
 
-    @Test(timeout = 5000)
+    @Test
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testConnectAndQLog() throws Throwable {
         Path path = Files.createTempFile("qlog", ".quic");
         assertTrue(path.toFile().delete());
@@ -75,7 +78,8 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         });
     }
 
-    @Test(timeout = 5000)
+    @Test
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testConnectAndQLogDir() throws Throwable {
         Path path = Files.createTempDirectory("qlogdir-");
         testQLog(path, p -> {
@@ -406,7 +410,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         }
     }
 
-    @Ignore
+    @Disabled
     @Test
     public void testALPNProtocolMissmatch() throws Throwable {
         CountDownLatch latch = new CountDownLatch(1);

--- a/src/test/java/io/netty/incubator/codec/quic/QuicChannelDatagramTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicChannelDatagramTest.java
@@ -23,11 +23,10 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.util.Random;
@@ -35,9 +34,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QuicChannelDatagramTest extends AbstractQuicTest {
 
@@ -257,12 +256,12 @@ public class QuicChannelDatagramTest extends AbstractQuicTest {
                 // Let's add some sleep in between as this is UDP so we may loose some data otherwise.
                 Thread.sleep(50);
             }
-            assertTrue("Server received: " + serverReadCount.get() +
-                            ", Client received: " + clientReadCount.get(), serverPromise.await(3000));
+            assertTrue(serverPromise.await(3000), "Server received: " + serverReadCount.get() +
+                    ", Client received: " + clientReadCount.get());
             serverPromise.sync();
 
-            assertTrue("Server received: " + serverReadCount.get() +
-                            ", Client received: " + clientReadCount.get(), clientPromise.await(3000));
+            assertTrue(clientPromise.await(3000), "Server received: " + serverReadCount.get() +
+                    ", Client received: " + clientReadCount.get());
             ByteBuf buffer = clientPromise.get();
             ByteBuf expected = Unpooled.wrappedBuffer(data);
             assertEquals(expected, buffer);

--- a/src/test/java/io/netty/incubator/codec/quic/QuicConnectionAddressTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicConnectionAddressTest.java
@@ -15,24 +15,25 @@
  */
 package io.netty.incubator.codec.quic;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class QuicConnectionAddressTest extends AbstractQuicTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testNullByteArray() {
-        new QuicConnectionAddress((byte[]) null);
+        assertThrows(NullPointerException.class, () -> new QuicConnectionAddress((byte[]) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testNullByteBuffer() {
-        new QuicConnectionAddress((ByteBuffer) null);
+        assertThrows(NullPointerException.class, () -> new QuicConnectionAddress((ByteBuffer) null));
     }
 
     @Test

--- a/src/test/java/io/netty/incubator/codec/quic/QuicConnectionIdGeneratorTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicConnectionIdGeneratorTest.java
@@ -15,15 +15,16 @@
  */
 package io.netty.incubator.codec.quic;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class QuicConnectionIdGeneratorTest extends AbstractQuicTest {
 
@@ -51,15 +52,16 @@ public class QuicConnectionIdGeneratorTest extends AbstractQuicTest {
         assertNotEquals(id, id2);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testThrowsIfInputTooBig() {
         QuicConnectionIdGenerator idGenerator = QuicConnectionIdGenerator.randomGenerator();
-        idGenerator.newId(Integer.MAX_VALUE);
+        assertThrows(IllegalArgumentException.class, () -> idGenerator.newId(Integer.MAX_VALUE));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testThrowsIfInputTooBig2() {
         QuicConnectionIdGenerator idGenerator = QuicConnectionIdGenerator.randomGenerator();
-        idGenerator.newId(ByteBuffer.wrap(new byte[8]), Integer.MAX_VALUE);
+        assertThrows(IllegalArgumentException.class, () ->
+                idGenerator.newId(ByteBuffer.wrap(new byte[8]), Integer.MAX_VALUE));
     }
 }

--- a/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
@@ -23,15 +23,15 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class QuicConnectionStatsTest extends AbstractQuicTest {
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicPacketTypeTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicPacketTypeTest.java
@@ -15,9 +15,10 @@
  */
 package io.netty.incubator.codec.quic;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class QuicPacketTypeTest extends AbstractQuicTest {
 
@@ -28,8 +29,8 @@ public class QuicPacketTypeTest extends AbstractQuicTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testOfInvalidType() {
-        QuicPacketType.of((byte) -1);
+        assertThrows(IllegalArgumentException.class, () -> QuicPacketType.of((byte) -1));
     }
 }

--- a/src/test/java/io/netty/incubator/codec/quic/QuicReadableTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicReadableTest.java
@@ -20,7 +20,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
@@ -25,7 +25,7 @@ import io.netty.util.ReferenceCountUtil;
 
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
@@ -16,18 +16,16 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.util.AttributeKey;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class QuicStreamChannelCreationTest extends AbstractQuicTest {
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
@@ -20,13 +20,14 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public class QuicStreamFrameTest extends AbstractQuicTest {
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamHalfClosureTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamHalfClosureTest.java
@@ -23,13 +23,13 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QuicStreamHalfClosureTest extends AbstractQuicTest {
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamIdGeneratorTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamIdGeneratorTest.java
@@ -15,9 +15,9 @@
  */
 package io.netty.incubator.codec.quic;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class QuicStreamIdGeneratorTest extends AbstractQuicTest {
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
@@ -23,14 +23,14 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import org.hamcrest.CoreMatchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class QuicStreamLimitTest extends AbstractQuicTest {
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
@@ -23,13 +23,14 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public class QuicStreamTypeTest extends AbstractQuicTest {
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicTest.java
@@ -23,10 +23,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QuicTest extends AbstractQuicTest {
 

--- a/src/test/java/io/netty/incubator/codec/quic/QuicWritableTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicWritableTest.java
@@ -23,16 +23,18 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QuicWritableTest extends AbstractQuicTest {
 
@@ -148,7 +150,8 @@ public class QuicWritableTest extends AbstractQuicTest {
         }
     }
 
-    @Test(timeout = 5000)
+    @Test
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testBytesUntilUnwritable() throws Throwable  {
         Promise<Void> writePromise = ImmediateEventExecutor.INSTANCE.newPromise();
         final AtomicReference<Throwable> serverErrorRef = new AtomicReference<>();

--- a/src/test/java/io/netty/incubator/codec/quic/QuicheQuicCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicheQuicCodecTest.java
@@ -21,15 +21,15 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.DatagramPacket;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class QuicheQuicCodecTest<B extends QuicCodecBuilder<B>> extends AbstractQuicTest {
 


### PR DESCRIPTION
Motivation:

JUnit 5 is more expressive, extensible, and composable in many ways, and it's better able to run tests in parallel.

Modifications:

Use JUnit 5 in tests

Result:

Use JUnit 5