### PR TITLE
Use correct Test annotation

### DIFF
--- a/src/test/java/io/netty/incubator/codec/quic/QuicTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicTest.java
@@ -17,7 +17,7 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.channel.ChannelOption;
 import io.netty.util.AttributeKey;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION
Motivation:

1a217e40e75b6dd46dfd7e7e2f7038e5e204c63d moved stuff over to junit5 but I missed one annotation

Modifications:

Use correct Test annotation and so switch to junit5 completely

Result:

Run all tests with junit5