### PR TITLE
Use QUIC v1 by default

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -50,7 +50,8 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     private int localConnIdLength;
     private Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider;
     private FlushStrategy flushStrategy = FlushStrategy.DEFAULT;
-    private int version;
+    // package-private for testing only
+    int version;
 
     QuicCodecBuilder(boolean server) {
         Quic.ensureAvailability();

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -54,10 +54,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
 
     QuicCodecBuilder(boolean server) {
         Quic.ensureAvailability();
-        // Use draft29 for now until v1 is really ready to use by default.
-        //
-        // See https://mailarchive.ietf.org/arch/msg/quic/i7CdtRA-iskuTftpEpMXMrB0FSY/
-        this.version = 0xff00_001d;
+        this.version = Quiche.QUICHE_PROTOCOL_VERSION;
         this.localConnIdLength = Quiche.QUICHE_MAX_CONN_ID_LEN;
         this.server = server;
     }

--- a/src/test/java/io/netty/incubator/codec/quic/QuicheQuicCodecTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicheQuicCodecTest.java
@@ -36,6 +36,12 @@ public abstract class QuicheQuicCodecTest<B extends QuicCodecBuilder<B>> extends
     protected abstract B newCodecBuilder();
 
     @Test
+    public void testDefaultVersionIsV1() {
+        B builder = newCodecBuilder();
+        assertEquals(0x0000_0001, builder.version);
+    }
+
+    @Test
     public void testFlushStrategyUsedWithBytes() {
         testFlushStrategy(true);
     }


### PR DESCRIPTION
Motivation:

Now that QUIC was released we can use v1 as default.

Modifications:

Use v1

Result:

Use final QUIC version as default