### PR TITLE
Update to latest quiche sha

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <libssl>libssl.a</libssl>
         <libcrypto>libcrypto.a</libcrypto>
         <libquiche>libquiche.a</libquiche>
-        <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL</extraLdflags>
+        <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL -Wl,-lrt</extraLdflags>
         <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=${os.detected.arch}</bundleNativeCode>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>6d070ed8694216806f3ce689d71ceb7ad76d425e</quicheCommitSha>
+    <quicheCommitSha>7eb57c4fc608932acc76c3ee2759c2e41e51d566</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />
-    <cflags>-std=c99 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3 -I${quicheHomeIncludeDir} -I${boringsslHomeIncludeDir}</cflags>
+    <cflags>-std=gnu99 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3 -I${quicheHomeIncludeDir} -I${boringsslHomeIncludeDir}</cflags>
     <ldflags>-L${quicheHomeBuildDir} -lquiche -L${boringsslHomeBuildDir} -lssl -lcrypto</ldflags>
     <extraCmakeFlags />
     <extraCflags />

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <libssl>libssl.a</libssl>
         <libcrypto>libcrypto.a</libcrypto>
         <libquiche>libquiche.a</libquiche>
-        <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL -lrt</extraLdflags>
+        <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL</extraLdflags>
         <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=${os.detected.arch}</bundleNativeCode>
       </properties>
     </profile>
@@ -202,7 +202,7 @@
         <libssl>libssl.a</libssl>
         <libcrypto>libcrypto.a</libcrypto>
         <libquiche>libquiche.a</libquiche>
-        <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL -lrt</extraLdflags>
+        <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL</extraLdflags>
         <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=aarch_64</bundleNativeCode>
         <jniLibName>netty_quiche_linux_aarch_64</jniLibName>
         <jni.classifier>linux-aarch_64</jni.classifier>

--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -53,9 +53,6 @@ static jobject   quiche_logger;
 static JavaVM     *global_vm = NULL;
 static char* staticPackagePrefix = NULL;
 
-// Add extern declaration to let it compile with -std=c99 
-extern char* strdup(const char*);
-
 jint quic_get_java_env(JNIEnv **env)
 {
     return (*global_vm)->GetEnv(global_vm, (void **)env, NETTY_JNI_UTIL_JNI_VERSION);

--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -22,11 +22,16 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
+// This needs to be included for quiche_recv_info and quiche_send_info structs.
+#include <time.h>
 #else
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+// This needs to be included for quiche_recv_info and quiche_send_info structs.
+#include <sys/time.h>
 #endif // _WIN32
+
 
 #include <quiche.h>
 #include "netty_jni_util.h"

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
@@ -47,6 +47,8 @@ final class QuicheQuicConnection {
         // TODO: Maybe cache these per thread as we only use them temporary within a limited scope.
         infoBuffer = Quiche.allocateNativeOrder(QUICHE_SEND_INFOS_OFFSET +
                 2 * Quiche.SIZEOF_QUICHE_SEND_INFO);
+        // Let's memset the memory.
+        infoBuffer.setZero(0, infoBuffer.capacity());
     }
 
     void free() {


### PR DESCRIPTION
Motivation:

We should update to the latest quiche sha to consume fixes

Modifications:

Update to cf2a08757c942d13f15a5a22aa7ea9ef50309cbe

Result:

Use latest quiche commit