### PR TITLE
Ensure we include hs_err* files when build failed

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -98,7 +98,9 @@ jobs:
         if: ${{ failure() }}
         with:
           name: target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            hs_err*.log
 
   build-windows:
     runs-on: windows-2016
@@ -151,7 +153,9 @@ jobs:
         if: ${{ failure() }}
         with:
           name: build-windows-target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            hs_err*.log
 
   build-android:
     runs-on: ubuntu-latest
@@ -200,4 +204,6 @@ jobs:
         if: ${{ failure() }}
         with:
           name: target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            hs_err*.log

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -155,7 +155,7 @@ jobs:
           name: build-windows-target
           path: |
             **/target/surefire-reports/
-            hs_err*.log
+            **/hs_err*.log
 
   build-android:
     runs-on: ubuntu-latest
@@ -206,4 +206,4 @@ jobs:
           name: target
           path: |
             **/target/surefire-reports/
-            hs_err*.log
+            **/hs_err*.log

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -64,7 +64,9 @@ jobs:
         if: ${{ failure() }}
         with:
           name: target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log
 
   build-linux-aarch64:
     runs-on: ubuntu-latest
@@ -100,7 +102,7 @@ jobs:
           name: target
           path: |
             **/target/surefire-reports/
-            hs_err*.log
+            **/hs_err*.log
 
   build-windows:
     runs-on: windows-2016

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -71,7 +71,9 @@ jobs:
         if: ${{ failure() }}
         with:
           name: target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            hs_err*.log
 
   build-linux-aarch64:
     runs-on: ubuntu-latest
@@ -105,7 +107,9 @@ jobs:
         if: ${{ failure() }}
         with:
           name: target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            hs_err*.log
 
 
   build-pr-windows:
@@ -167,4 +171,6 @@ jobs:
         if: ${{ failure() }}
         with:
           name: build-pr-windows-target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            hs_err*.log

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -73,7 +73,7 @@ jobs:
           name: target
           path: |
             **/target/surefire-reports/
-            hs_err*.log
+            **/hs_err*.log
 
   build-linux-aarch64:
     runs-on: ubuntu-latest
@@ -109,8 +109,7 @@ jobs:
           name: target
           path: |
             **/target/surefire-reports/
-            hs_err*.log
-
+            **/hs_err*.log
 
   build-pr-windows:
     runs-on: windows-2016
@@ -173,4 +172,4 @@ jobs:
           name: build-pr-windows-target
           path: |
             **/target/surefire-reports/
-            hs_err*.log
+            **/hs_err*.log


### PR DESCRIPTION
Motivation:

We the build failed we should ensure we also include hs_err* files as it may have failed due a native crash

Modifications:

Adjust path matching to include hs_err as well

Result:

Easier to debug native crashes