### PR TITLE
Add support for SNI

### DIFF
--- a/src/main/c/netty_quic_boringssl.c
+++ b/src/main/c/netty_quic_boringssl.c
@@ -43,12 +43,16 @@ static jmethodID certificateCallbackMethod = NULL;
 static jclass handshakeCompleteCallbackClass = NULL;
 static jmethodID handshakeCompleteCallbackMethod = NULL;
 
+static jclass servernameCallbackClass = NULL;
+static jmethodID servernameCallbackMethod = NULL;
+
 static jclass byteArrayClass = NULL;
 static jclass stringClass = NULL;
 
 static int handshakeCompleteCallbackIdx = -1;
 static int verifyCallbackIdx = -1;
 static int certificateCallbackIdx = -1;
+static int servernameCallbackIdx = -1;
 static int alpn_data_idx = -1;
 static int crypto_buffer_pool_idx = -1;
 
@@ -507,10 +511,62 @@ void quic_SSL_info_callback(const SSL *ssl, int type, int value) {
                  (jlong) ssl, session_id, cipher, version, peerCert, certChain, creationTime, timeout, alpnSelected);
     }
 }
-static jlong netty_boringssl_SSLContext_new0(JNIEnv* env, jclass clazz, jboolean server, jbyteArray alpn_protos, jobject handshakeCompleteCallback, jobject certificateCallback, jobject verifyCallback, jint verifyMode, jobjectArray subjectNames) {
+
+int quic_tlsext_servername_callback(SSL *ssl, int *out_alert, void *arg) {
+    int type = SSL_get_servername_type(ssl);
+    if (type == TLSEXT_NAMETYPE_host_name) {
+        SSL_CTX* ctx = SSL_get_SSL_CTX((SSL*) ssl);
+        jobject servernameCallback = SSL_CTX_get_ex_data(ctx, servernameCallbackIdx);
+        if (servernameCallback == NULL) {
+            // No SNI should be used
+            return SSL_TLSEXT_ERR_NOACK;
+        }
+        const char *name = SSL_get_servername(ssl, type);
+        if (name == NULL) {
+            // No SNI should be used
+            return SSL_TLSEXT_ERR_NOACK;
+        }
+        JNIEnv *e = NULL;
+        if (quic_get_java_env(&e) != JNI_OK) {
+            // There is something serious wrong just fail the SSL in a fatal way.
+            return SSL_TLSEXT_ERR_ALERT_FATAL;
+        }
+
+        jstring servername = (*e)->NewStringUTF(e, name);
+        if (servername == NULL) {
+            // There is something serious wrong just fail the SSL in a fatal way.
+            return SSL_TLSEXT_ERR_ALERT_FATAL;
+        }
+
+        jlong result = (*e)->CallLongMethod(e, servernameCallback, servernameCallbackMethod,
+                 (jlong) ssl, servername);
+
+        if ((*e)->ExceptionCheck(e) == JNI_TRUE) {
+            // Some exception was thrown. Let's fail.
+            (*e)->ExceptionClear(e);
+            return SSL_TLSEXT_ERR_ALERT_FATAL;
+        }
+        if (result < 0) {
+            // If we returned a negative number we want to fail.
+            return SSL_TLSEXT_ERR_ALERT_FATAL;
+        }
+
+        // Change the ctx to the one that was returned.
+        SSL_CTX* newCtx = SSL_set_SSL_CTX(ssl, (SSL_CTX*) result);
+        if (newCtx == NULL) {
+            // Setting the SSL_CTX failed.
+            return SSL_TLSEXT_ERR_ALERT_FATAL;
+        }
+        return SSL_TLSEXT_ERR_OK;
+    }
+    return SSL_TLSEXT_ERR_NOACK;
+}
+
+static jlong netty_boringssl_SSLContext_new0(JNIEnv* env, jclass clazz, jboolean server, jbyteArray alpn_protos, jobject handshakeCompleteCallback, jobject certificateCallback, jobject verifyCallback, jobject servernameCallback, jint verifyMode, jobjectArray subjectNames) {
     jobject handshakeCompleteCallbackRef = NULL;
     jobject certificateCallbackRef = NULL;
     jobject verifyCallbackRef = NULL;
+    jobject servernameCallbackRef = NULL;
 
     if ((handshakeCompleteCallbackRef = (*env)->NewGlobalRef(env, handshakeCompleteCallback)) == NULL) {
         goto error;
@@ -522,6 +578,12 @@ static jlong netty_boringssl_SSLContext_new0(JNIEnv* env, jclass clazz, jboolean
 
     if ((verifyCallbackRef = (*env)->NewGlobalRef(env, verifyCallback)) == NULL) {
         goto error;
+    }
+
+    if (servernameCallback != NULL) {
+        if ((servernameCallbackRef = (*env)->NewGlobalRef(env, servernameCallback)) == NULL) {
+            goto error;
+        }
     }
 
     SSL_CTX *ctx = SSL_CTX_new(TLS_with_buffers_method());
@@ -546,6 +608,10 @@ static jlong netty_boringssl_SSLContext_new0(JNIEnv* env, jclass clazz, jboolean
     SSL_CTX_set_ex_data(ctx, certificateCallbackIdx, certificateCallbackRef);
     SSL_CTX_set_cert_cb(ctx, quic_certificate_cb, certificateCallbackRef);
 
+    if (servernameCallbackRef != NULL) {
+        SSL_CTX_set_ex_data(ctx, servernameCallbackIdx, servernameCallbackRef);
+        SSL_CTX_set_tlsext_servername_callback(ctx, quic_tlsext_servername_callback);
+    }
     // Use a pool for our certificates so we can share these across connections.
     SSL_CTX_set_ex_data(ctx, crypto_buffer_pool_idx, CRYPTO_BUFFER_POOL_new());
 
@@ -599,6 +665,11 @@ static void netty_boringssl_SSLContext_free(JNIEnv* env, jclass clazz, jlong ctx
     jobject certificateCallbackRef = SSL_CTX_get_ex_data(ssl_ctx, certificateCallbackIdx);
     if (certificateCallbackRef != NULL) {
         (*env)->DeleteLocalRef(env, certificateCallbackRef);
+    }
+
+    jobject servernameCallbackRef = SSL_CTX_get_ex_data(ssl_ctx, servernameCallbackIdx);
+    if (servernameCallbackRef != NULL) {
+        (*env)->DeleteLocalRef(env, servernameCallbackRef);
     }
 
     alpn_data* data = SSL_CTX_get_ex_data(ssl_ctx, alpn_data_idx);
@@ -741,7 +812,7 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
 
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 static const JNINativeMethod fixed_method_table[] = {
-  { "SSLContext_new0", "(Z[BLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;I[[B)J", (void *) netty_boringssl_SSLContext_new0 },
+  { "SSLContext_new0", "(Z[BLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;I[[B)J", (void *) netty_boringssl_SSLContext_new0 },
   { "SSLContext_free", "(J)V", (void *) netty_boringssl_SSLContext_free },
   { "SSLContext_setSessionCacheTimeout", "(JJ)J", (void *) netty_boringssl_SSLContext_setSessionCacheTimeout },
   { "SSLContext_setSessionCacheSize", "(JJ)J", (void *) netty_boringssl_SSLContext_setSessionCacheSize },
@@ -803,9 +874,15 @@ jint netty_boringssl_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     NETTY_JNI_UTIL_LOAD_CLASS(env, handshakeCompleteCallbackClass, name, done);
     NETTY_JNI_UTIL_GET_METHOD(env, handshakeCompleteCallbackClass, handshakeCompleteCallbackMethod, "handshakeComplete", "(J[BLjava/lang/String;Ljava/lang/String;[B[[BJJ[B)V", done);
 
+    NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLTlsextServernameCallback", name, done);
+    NETTY_JNI_UTIL_LOAD_CLASS(env, servernameCallbackClass, name, done);
+    NETTY_JNI_UTIL_GET_METHOD(env, servernameCallbackClass, servernameCallbackMethod, "selectCtx", "(JLjava/lang/String;)J", done);
+
     verifyCallbackIdx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
     certificateCallbackIdx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
     handshakeCompleteCallbackIdx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+    servernameCallbackIdx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+
     alpn_data_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
     crypto_buffer_pool_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
     ret = NETTY_JNI_UTIL_JNI_VERSION;
@@ -823,7 +900,7 @@ done:
         NETTY_JNI_UTIL_UNLOAD_CLASS(env, certificateCallbackClass);
         NETTY_JNI_UTIL_UNLOAD_CLASS(env, verifyCallbackClass);
         NETTY_JNI_UTIL_UNLOAD_CLASS(env, handshakeCompleteCallbackClass);
-
+        NETTY_JNI_UTIL_UNLOAD_CLASS(env, servernameCallbackClass);
     }
     return ret;
 }
@@ -833,7 +910,7 @@ void netty_boringssl_JNI_OnUnload(JNIEnv* env, const char* packagePrefix) {
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, certificateCallbackClass);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, verifyCallbackClass);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, handshakeCompleteCallbackClass);
-
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, servernameCallbackClass);
 
     netty_jni_util_unregister_natives(env, packagePrefix, STATICALLY_CLASSNAME);
     netty_jni_util_unregister_natives(env, packagePrefix, CLASSNAME);

--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSL.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSL.java
@@ -41,11 +41,12 @@ final class BoringSSL {
                                BoringSSLHandshakeCompleteCallback handshakeCompleteCallback,
                                BoringSSLCertificateCallback certificateCallback,
                                BoringSSLCertificateVerifyCallback verifyCallback,
+                               BoringSSLTlsextServernameCallback servernameCallback,
                                int verifyMode,
                                byte[][] subjectNames) {
         return SSLContext_new0(server, toWireFormat(applicationProtocols),
                 handshakeCompleteCallback,
-                certificateCallback, verifyCallback, verifyMode, subjectNames);
+                certificateCallback, verifyCallback, servernameCallback, verifyMode, subjectNames);
     }
 
     private static byte[] toWireFormat(String[] applicationProtocols) {
@@ -66,7 +67,8 @@ final class BoringSSL {
 
     private static native long SSLContext_new0(boolean server,
                                                byte[] applicationProtocols, Object handshakeCompleteCallback,
-                                               Object certificateCallback, Object verifyCallback, int verifyDepth,
+                                               Object certificateCallback, Object verifyCallback,
+                                               Object servernameCallback, int verifyDepth,
                                                byte[][] subjectNames);
     static native void SSLContext_set_early_data_enabled(long context, boolean enabled);
     static native long SSLContext_setSessionCacheSize(long context, long size);

--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSLTlsextServernameCallback.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSLTlsextServernameCallback.java
@@ -17,8 +17,6 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.util.Mapping;
 
-import javax.net.ssl.SNIHostName;
-
 final class BoringSSLTlsextServernameCallback {
 
     private final QuicheQuicSslEngineMap engineMap;
@@ -38,9 +36,8 @@ final class BoringSSLTlsextServernameCallback {
             return -1;
         }
 
-        QuicSslContext context = mapping.map(new SNIHostName(serverName).getAsciiName());
+        QuicSslContext context = mapping.map(serverName);
         if (context == null) {
-            // TODO: Maybe return some explicit error code ?
             return -1;
         }
         return engine.moveTo((QuicheQuicSslContext) context);

--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSLTlsextServernameCallback.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSLTlsextServernameCallback.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.util.Mapping;
+
+import javax.net.ssl.SNIHostName;
+
+final class BoringSSLTlsextServernameCallback {
+
+    private final QuicheQuicSslEngineMap engineMap;
+    private final Mapping<? super String, ? extends QuicSslContext> mapping;
+
+    BoringSSLTlsextServernameCallback(QuicheQuicSslEngineMap engineMap,
+                                      Mapping<? super String, ? extends QuicSslContext> mapping) {
+        this.engineMap = engineMap;
+        this.mapping = mapping;
+    }
+
+    @SuppressWarnings("unused")
+    long selectCtx(long ssl, String serverName) {
+        final QuicheQuicSslEngine engine = engineMap.get(ssl);
+        if (engine == null) {
+            // May be null if it was destroyed in the meantime.
+            return -1;
+        }
+
+        QuicSslContext context = mapping.map(new SNIHostName(serverName).getAsciiName());
+        if (context == null) {
+            // TODO: Maybe return some explicit error code ?
+            return -1;
+        }
+        return engine.moveTo((QuicheQuicSslContext) context);
+    }
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
@@ -40,11 +40,18 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  */
 public final class QuicSslContextBuilder {
 
-    private static final X509ExtendedKeyManager DUMMY_KEYMANAGER = new X509ExtendedKeyManager() {
+    /**
+     * Special {@link X509ExtendedKeyManager} implementation which will just fail the certificate selection.
+     * This is used as a "dummy" implementation when SNI is used as we should always select an other
+     * {@link QuicSslContext} based on the provided hostname.
+     */
+    private static final X509ExtendedKeyManager SNI_KEYMANAGER = new X509ExtendedKeyManager() {
+        private final X509Certificate[] emptyCerts = new X509Certificate[0];
+        private final String[] emptyStrings = new String[0];
 
         @Override
         public String[] getClientAliases(String keyType, Principal[] issuers) {
-            return new String[0];
+            return emptyStrings;
         }
 
         @Override
@@ -54,7 +61,7 @@ public final class QuicSslContextBuilder {
 
         @Override
         public String[] getServerAliases(String keyType, Principal[] issuers) {
-            return new String[0];
+            return emptyStrings;
         }
 
         @Override
@@ -64,7 +71,7 @@ public final class QuicSslContextBuilder {
 
         @Override
         public X509Certificate[] getCertificateChain(String alias) {
-            return new X509Certificate[0];
+            return emptyCerts;
         }
 
         @Override
@@ -140,7 +147,7 @@ public final class QuicSslContextBuilder {
      *                  to create the {@link Mapping}.
      */
     public static QuicSslContext buildForServerWithSni(Mapping<? super String, ? extends QuicSslContext> mapping) {
-        return forServer(DUMMY_KEYMANAGER, null).sni(mapping).build();
+        return forServer(SNI_KEYMANAGER, null).sni(mapping).build();
     }
 
     private final boolean forServer;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import java.util.function.LongFunction;
 
 final class QuicheQuicSslEngine extends QuicSslEngine {
-    private final QuicheQuicSslContext ctx;
+    QuicheQuicSslContext ctx;
     private final String peerHost;
     private final int peerPort;
     private final QuicheQuicSslSession session = new QuicheQuicSslSession();
@@ -51,6 +51,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
     private boolean handshakeFinished;
     private String applicationProtocol;
     final String tlsHostName;
+    volatile QuicheQuicConnection connection;
 
     QuicheQuicSslEngine(QuicheQuicSslContext ctx, String peerHost, int peerPort) {
         this.ctx = ctx;
@@ -64,6 +65,13 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
         } else {
             tlsHostName = null;
         }
+    }
+
+    long moveTo(QuicheQuicSslContext ctx) {
+        // First of remove the engine from its previous QuicheQuicSslContext.
+        this.ctx.remove(this);
+        this.ctx = ctx;
+        return ctx.add(this);
     }
 
     QuicheQuicConnection createConnection(LongFunction<Long> connectionCreator) {


### PR DESCRIPTION
Motivation:

Sometimes it is useful to be able to support different QuicSslContext for different hostnames. For this we should add support for SNI on the server side

Modifications:

- Add support for SNI by adding another builder method on QuicSslContextBuilder
- Add all needed JNI code
- Add unit test

Result:

Be able to use SNI