### PR TITLE
Add QuicConnectionCloseEvent to be able to inspect why the remote pee…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicClosedChannelException.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicClosedChannelException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import java.nio.channels.ClosedChannelException;
+
+/**
+ * Special {@link QuicClosedChannelException} which also provides extra info if the close was a result of a
+ * {@link QuicConnectionCloseEvent} that was triggered by the remote peer.
+ */
+public final class QuicClosedChannelException extends ClosedChannelException {
+
+    private final QuicConnectionCloseEvent event;
+
+    QuicClosedChannelException(QuicConnectionCloseEvent event) {
+        this.event = event;
+    }
+
+    /**
+     * Returns the {@link QuicConnectionCloseEvent} that caused the closure or {@code null} if none was received.
+     *
+     * @return the event.
+     */
+    public QuicConnectionCloseEvent event() {
+        return event;
+    }
+}

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicClosedChannelException.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicClosedChannelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2023 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionCloseEvent.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionCloseEvent.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import java.util.Arrays;
+
+/**
+ * Event that is generated if the remote peer sends a
+ * <a href="https://www.rfc-editor.org/rfc/rfc9000#name-connection_close-frames">CLOSE_CONNECTION frame</a>.
+ * This allows to inspect the various details of the cause of the close.
+ */
+public final class QuicConnectionCloseEvent implements QuicEvent {
+
+    final boolean applicationClose;
+    final int error;
+    final byte[] reason;
+
+    QuicConnectionCloseEvent(boolean applicationClose, int error, byte[] reason) {
+        this.applicationClose = applicationClose;
+        this.error = error;
+        this.reason = reason;
+    }
+
+    /**
+     * Return {@code true} if this was an application close, {@code false} otherwise.
+     *
+     * @return  if this is an application close.
+     */
+    public boolean isApplicationClose() {
+        return applicationClose;
+    }
+
+    /**
+     * Return the error that was provided for the close.
+     *
+     * @return the error.
+     */
+    public int error() {
+        return error;
+    }
+
+    /**
+     * Returns {@code true} if a <a href="https://www.rfc-editor.org/rfc/rfc9001#section-4.8">TLS error</a>
+     * is contained.
+     * @return {@code true} if this is an {@code TLS error}, {@code false} otherwise.
+     */
+    public boolean isTlsError() {
+        return !applicationClose && error >= 0x0100;
+    }
+
+    /**
+     * Returns the reason for the close, which may be empty if no reason was given as part of the close.
+     *
+     * @return  the reason.
+     */
+    public byte[] reason() {
+        return reason.clone();
+    }
+
+    @Override
+    public String toString() {
+        return "QuicConnectionCloseEvent{" +
+                "applicationClose=" + applicationClose +
+                ", error=" + error +
+                ", reason=" + Arrays.toString(reason) +
+                '}';
+    }
+
+    /**
+     * Extract the contained {@code TLS error} from the {@code QUIC error}. If the given {@code QUIC error} does not
+     * contain a {@code TLS error} it will return {@code -1}.
+     *
+     * @param error the {@code QUIC error}
+     * @return      the {@code TLS error} or {@code -1} if there was no {@code TLS error} contained.
+     */
+    public static int extractTlsError(int error) {
+        int tlsError = error - 0x0100;
+        if (tlsError < 0) {
+            return -1;
+        }
+        return tlsError;
+    }
+}

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionCloseEvent.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionCloseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2023 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -335,6 +335,16 @@ final class Quiche {
      */
     static native void quiche_conn_free(long connAddr);
 
+    static QuicConnectionCloseEvent quiche_conn_peer_error(long connAddr) {
+        Object[] error =  quiche_conn_peer_error0(connAddr);
+        if (error == null) {
+            return null;
+        }
+        return new QuicConnectionCloseEvent((Boolean) error[0], (Integer) error[1], (byte[]) error[2]);
+    }
+
+    private static native Object[] quiche_conn_peer_error0(long connAddr);
+
     /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.7.0/include/quiche.h#L330">
      *     quiche_conn_peer_streams_left_bidi</a>.

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -712,9 +712,18 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         Channel channel = QuicTestUtils.newClient(QuicTestUtils.newQuicClientBuilder(executor,
                 QuicSslContextBuilder.forClient()
                         .trustManager(InsecureTrustManagerFactory.INSTANCE).applicationProtocols("protocol").build()));
+        AtomicReference<QuicConnectionCloseEvent> closeEventRef = new AtomicReference<>();
         try {
             Throwable cause = QuicChannel.newBootstrap(channel)
-                    .handler(new ChannelInboundHandlerAdapter())
+                    .handler(new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                            if (evt instanceof QuicConnectionCloseEvent) {
+                                closeEventRef.set((QuicConnectionCloseEvent) evt);
+                            }
+                            super.userEventTriggered(ctx, evt);
+                        }
+                    })
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
                     .connect()
@@ -722,6 +731,13 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             assertThat(cause, Matchers.instanceOf(ClosedChannelException.class));
             latch.await();
             eventLatch.await();
+            QuicConnectionCloseEvent closeEvent = closeEventRef.get();
+            assertNotNull(closeEvent);
+            assertTrue(closeEvent.isTlsError());
+            // 120 is the ALPN error.
+            // See https://datatracker.ietf.org/doc/html/rfc8446#section-6
+            assertEquals(120, QuicConnectionCloseEvent.extractTlsError(closeEvent.error()));
+            assertEquals(closeEvent, ((QuicClosedChannelException) cause).event());
         } finally {
             server.close().sync();
             // Close the parent Datagram channel as well.


### PR DESCRIPTION
…r closed the connection

Motivation:

It is useful to understand why a remote peer might have closed the connection. We didnt allow to inspect this.

Modifications:

- Introduce QuicConnectionCloseEvent
- Introduce QuicClosedChannelException
- Adjust unit test to make use of QuicConnectionCloseEvent.

Result:

Be able to better understand why a connection was closed