### PR TITLE
Add methods to QuicChannel that allows to query if a connection was t…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>e805323103afc584259be54d38c804dec7888bd6</quicheCommitSha>
+    <quicheCommitSha>e9f59a55f5b56999d0e609a73aa8f1b450878a0c</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/src/main/c/netty_quic_quiche.c
+++ b/src/main/c/netty_quic_quiche.c
@@ -395,6 +395,10 @@ static jboolean netty_quiche_conn_is_closed(JNIEnv* env, jclass clazz, jlong con
     return quiche_conn_is_closed((quiche_conn *) conn) == true ? JNI_TRUE : JNI_FALSE;
 }
 
+static jboolean netty_quiche_conn_is_timed_out(JNIEnv* env, jclass clazz, jlong conn) {
+    return quiche_conn_is_timed_out((quiche_conn *) conn) == true ? JNI_TRUE : JNI_FALSE;
+}
+
 static jlongArray netty_quiche_conn_stats(JNIEnv* env, jclass clazz, jlong conn) {
     quiche_stats stats = {0,0,0,0,0,0};
     quiche_conn_stats((quiche_conn *) conn, &stats);
@@ -697,6 +701,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_is_established", "(J)Z", (void *) netty_quiche_conn_is_established },
   { "quiche_conn_is_in_early_data", "(J)Z", (void *) netty_quiche_conn_is_in_early_data },
   { "quiche_conn_is_closed", "(J)Z", (void *) netty_quiche_conn_is_closed },
+  { "quiche_conn_is_timed_out", "(J)Z", (void *) netty_quiche_conn_is_timed_out },
   { "quiche_conn_stats", "(J)[J", (void *) netty_quiche_conn_stats },
   { "quiche_conn_timeout_as_nanos", "(J)J", (void *) netty_quiche_conn_timeout_as_nanos },
   { "quiche_conn_on_timeout", "(J)V", (void *) netty_quiche_conn_on_timeout },

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -166,9 +166,9 @@ public interface QuicChannel extends Channel {
     long peerAllowedStreams(QuicStreamType type);
 
     /**
-     * Returns {@code true} if the connection was closed because of the idle timeout.
+     * Returns {@code true} if the connection was closed because of idle timeout.
      *
-     * @return {@code true} if the connection was closed because of the idle timeout, {@code false}.
+     * @return {@code true} if the connection was closed because of idle timeout, {@code false}.
      */
     boolean isTimedOut();
 

--- a/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -166,6 +166,13 @@ public interface QuicChannel extends Channel {
     long peerAllowedStreams(QuicStreamType type);
 
     /**
+     * Returns {@code true} if the connection was closed because of the idle timeout.
+     *
+     * @return {@code true} if the connection was closed because of the idle timeout, {@code false}.
+     */
+    boolean isTimedOut();
+
+    /**
      * Creates a stream that is using this {@link QuicChannel} and notifies the {@link Future} once done.
      * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} automatically.

--- a/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -384,6 +384,13 @@ final class Quiche {
 
     /**
      * See
+     * <a href="https://github.com/cloudflare/quiche/blob/
+     * e9f59a55f5b56999d0e609a73aa8f1b450878a0c/include/quiche.h#L384">quiche_conn_is_timed_out</a>.
+     */
+    static native boolean quiche_conn_is_timed_out(long connAddr);
+
+    /**
+     * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L361">quiche_conn_stats</a>.
      * The implementation relies on all fields of
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L340">quiche_stats</a> being numerical.

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -133,6 +133,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private static final int OPEN = 1;
     private static final int ACTIVE = 2;
     private volatile int state;
+    private volatile boolean timedOut;
     private volatile String traceId;
     private volatile QuicheQuicConnection connection;
     private volatile QuicConnectionAddress remoteIdAddr;
@@ -178,6 +179,11 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                                        Map.Entry<AttributeKey<?>, Object>[] streamAttrsArray) {
         return new QuicheQuicChannel(parent, true, key, remote, supportsDatagram,
                 streamHandler, streamOptionsArray, streamAttrsArray);
+    }
+
+    @Override
+    public boolean isTimedOut() {
+        return timedOut;
     }
 
     @Override
@@ -333,6 +339,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             }
             connection = null;
             state = CLOSED;
+            timedOut = Quiche.quiche_conn_is_timed_out(conn.address());
 
             closeStreams();
 


### PR DESCRIPTION
…imed out

Motivation:

Sometimes we would like to know if a connection was closed because of a timeout. This was not possible.

Modifications:

Add isTimedOut() method which allows to query if the connection was closed because of the idle time out

Result:

Be able to know if a connection is closed because of the idle timeout