### PR TITLE
Ensure QuicCodecBuilder's copy constructor copies all fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1233,6 +1233,7 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>3.20.2</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1229,5 +1229,10 @@
       <version>1.68</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.20.2</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -50,6 +50,8 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     private int localConnIdLength;
     private Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider;
     private FlushStrategy flushStrategy = FlushStrategy.DEFAULT;
+    private Integer recvQueueLen;
+    private Integer sendQueueLen;
     // package-private for testing only
     int version;
 
@@ -81,6 +83,8 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
         this.localConnIdLength = builder.localConnIdLength;
         this.sslEngineProvider = builder.sslEngineProvider;
         this.flushStrategy = builder.flushStrategy;
+        this.recvQueueLen = builder.recvQueueLen;
+        this.sendQueueLen = builder.sendQueueLen;
         this.version = builder.version;
     }
 
@@ -351,9 +355,6 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
         this.version = version;
         return self();
     }
-
-    private Integer recvQueueLen;
-    private Integer sendQueueLen;
 
     /**
      * If configured this will enable <a href="https://tools.ietf.org/html/draft-ietf-quic-datagram-01">

--- a/src/test/java/io/netty/incubator/codec/quic/QuicCodecBuilderTest.java
+++ b/src/test/java/io/netty/incubator/codec/quic/QuicCodecBuilderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.channel.ChannelHandler;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QuicCodecBuilderTest {
+
+    @Test
+    void testCopyConstructor() throws IllegalAccessException {
+        TestQuicCodecBuilder original = new TestQuicCodecBuilder();
+        init(original);
+        TestQuicCodecBuilder copy = new TestQuicCodecBuilder(original);
+        assertThat(copy).usingRecursiveComparison().isEqualTo(original);
+    }
+
+    private static void init(TestQuicCodecBuilder builder) throws IllegalAccessException {
+        Field[] fields = builder.getClass().getSuperclass().getDeclaredFields();
+        for (Field field : fields) {
+            modifyField(builder, field);
+        }
+    }
+
+    private static void modifyField(TestQuicCodecBuilder builder, Field field) throws IllegalAccessException {
+        field.setAccessible(true);
+        Class<?> clazz = field.getType();
+        if (Boolean.class == clazz) {
+            field.set(builder, Boolean.TRUE);
+        } else if (Integer.class == clazz) {
+            field.set(builder, Integer.MIN_VALUE);
+        } else if (Long.class == clazz) {
+            field.set(builder, Long.MIN_VALUE);
+        } else if (QuicCongestionControlAlgorithm.class == clazz) {
+            field.set(builder, QuicCongestionControlAlgorithm.CUBIC);
+        } else if (FlushStrategy.class == clazz) {
+            field.set(builder, FlushStrategy.afterNumBytes(10));
+        } else if (Function.class == clazz) {
+            field.set(builder, Function.identity());
+        } else if (boolean.class == clazz) {
+            field.setBoolean(builder, true);
+        } else if (int.class == clazz) {
+            field.setInt(builder, -1);
+        } else {
+            throw new IllegalArgumentException("Unknown field type " + clazz);
+        }
+    }
+
+    private static final class TestQuicCodecBuilder extends QuicCodecBuilder<TestQuicCodecBuilder> {
+
+        TestQuicCodecBuilder() {
+            super(true);
+        }
+
+        TestQuicCodecBuilder(TestQuicCodecBuilder builder) {
+            super(builder);
+        }
+
+        @Override
+        public TestQuicCodecBuilder clone() {
+            // no-op
+            return null;
+        }
+
+        @Override
+        protected ChannelHandler build(
+                QuicheConfig config,
+                Function<QuicChannel, ? extends QuicSslEngine> sslContextProvider,
+                int localConnIdLength,
+                FlushStrategy flushStrategy) {
+            // no-op
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
`QuicCodecBuilder`'s copy constructor does not copy `recvQueueLen` and `sendQueueLen`

Modification:
- Initialise `recvQueueLen` and `sendQueueLen` when `QuicCodecBuilder`'s copy constructor is used

Result:
`QuicCodecBuilder`'s copy constructor copies all fields