### PR TITLE
Add 'serverName' for 'QuicSslEngine'

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSLTlsextServernameCallback.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSLTlsextServernameCallback.java
@@ -40,6 +40,6 @@ final class BoringSSLTlsextServernameCallback {
         if (context == null) {
             return -1;
         }
-        return engine.moveTo((QuicheQuicSslContext) context);
+        return engine.moveTo((QuicheQuicSslContext) context, serverName);
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicSslEngine.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicSslEngine.java
@@ -20,4 +20,11 @@ import javax.net.ssl.SSLEngine;
 /**
  * An {@link SSLEngine} that can be used for QUIC.
  */
-public abstract class QuicSslEngine extends SSLEngine { }
+public abstract class QuicSslEngine extends SSLEngine {
+
+    /**
+     * Return
+     * @return
+     */
+    public abstract String getRemoteServer();
+}

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
@@ -43,6 +43,7 @@ import java.util.function.LongFunction;
 
 final class QuicheQuicSslEngine extends QuicSslEngine {
     QuicheQuicSslContext ctx;
+    String serverName;
     private final String peerHost;
     private final int peerPort;
     private final QuicheQuicSslSession session = new QuicheQuicSslSession();
@@ -67,10 +68,11 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
         }
     }
 
-    long moveTo(QuicheQuicSslContext ctx) {
+    long moveTo(QuicheQuicSslContext ctx, String serverName) {
         // First of remove the engine from its previous QuicheQuicSslContext.
         this.ctx.remove(this);
         this.ctx = ctx;
+        this.serverName = serverName;
         return ctx.add(this);
     }
 
@@ -244,6 +246,11 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
     @Override
     public boolean getEnableSessionCreation() {
         return false;
+    }
+
+    @Override
+    public String getRemoteServer() {
+        return serverName;
     }
 
     synchronized void handshakeFinished(byte[] id, String cipher, String protocol, byte[] peerCertificate,


### PR DESCRIPTION
**Motivation**

There is a commit for SNI support
netty/netty-incubator-codec-quic#313
but i need to pass `sniHostname` to custom handler.

**Modification**

Add `serverName` field and getter to `QuicSslEngine`
After that, `sni` can be obtained as:
>String sniHostname = ((QuicSslEngine) ch.parent().sslEngine()).getRemoteServer();


**Result**

Fixes [#45](https://github.com/netty/netty-incubator-codec-http3/issues/45)