### PR TITLE
Make QuicConnectionAddress.toString() method more useful

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/QuicConnectionAddress.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicConnectionAddress.java
@@ -34,6 +34,8 @@ public final class QuicConnectionAddress extends SocketAddress {
      */
     public static final QuicConnectionAddress EPHEMERAL = new QuicConnectionAddress((ByteBuffer) null, false);
 
+    private final String toStr;
+
     // Accessed by QuicheQuicheChannel
     final ByteBuffer connId;
 
@@ -66,20 +68,22 @@ public final class QuicConnectionAddress extends SocketAddress {
                     + Quiche.QUICHE_MAX_CONN_ID_LEN);
         }
         this.connId = connId;
+        if (connId == null) {
+            toStr = "QuicConnectionAddress{EPHEMERAL}";
+        } else {
+            ByteBuf buffer = Unpooled.wrappedBuffer(connId);
+            try {
+                toStr = "QuicConnectionAddress{" +
+                        "connId=" + ByteBufUtil.hexDump(buffer) + '}';
+            } finally {
+                buffer.release();
+            }
+        }
     }
 
     @Override
     public String toString() {
-        if (this == EPHEMERAL) {
-            return "QuicConnectionAddress{EPHEMERAL}";
-        }
-        ByteBuf buffer = Unpooled.wrappedBuffer(connId);
-        try {
-            return "QuicConnectionAddress{" +
-                    "connId=" + ByteBufUtil.hexDump(buffer) + '}';
-        } finally {
-            buffer.release();
-        }
+        return toStr;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

The toString() method of QuicConnectionAddress did produce a not so useful string representation.

Modifications:

Use a hexdump presentation of the id

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/338