### PR TITLE
Upgrade to netty 4.1.69.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
     <skipTests>false</skipTests>
     <packaging.type>jar</packaging.type>
-    <netty.version>4.1.68.Final</netty.version>
+    <netty.version>4.1.69.Final</netty.version>
     <netty.build.version>29</netty.build.version>
     <junit.version>5.7.0</junit.version>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>


### PR DESCRIPTION
Motivation:

A new netty release is out

Modifications:

Upgrade to latest netty release

Result:

Use latest release as dependency