### PR TITLE
Fire SniCompletionEvent when SNI is used

### DIFF
--- a/src/main/java/io/netty/incubator/codec/quic/BoringSSLTlsextServernameCallback.java
+++ b/src/main/java/io/netty/incubator/codec/quic/BoringSSLTlsextServernameCallback.java
@@ -40,6 +40,6 @@ final class BoringSSLTlsextServernameCallback {
         if (context == null) {
             return -1;
         }
-        return engine.moveTo((QuicheQuicSslContext) context);
+        return engine.moveTo(serverName, (QuicheQuicSslContext) context);
     }
 }

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -33,6 +33,7 @@ import io.netty.channel.DefaultChannelPipeline;
 import io.netty.channel.EventLoop;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.socket.DatagramPacket;
+import io.netty.handler.ssl.SniCompletionEvent;
 import io.netty.util.AttributeKey;
 import io.netty.util.collection.LongObjectHashMap;
 import io.netty.util.collection.LongObjectMap;
@@ -1380,6 +1381,11 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                     initAddresses(connection);
 
                     pipeline().fireChannelActive();
+                    String sniHostname = connection.engine().sniHostname;
+                    if (sniHostname != null) {
+                        connection.engine().sniHostname = null;
+                        pipeline().fireUserEventTriggered(new SniCompletionEvent(sniHostname));
+                    }
                     fireDatagramExtensionEvent();
                 }
             } else if (connectPromise != null && Quiche.quiche_conn_is_established(connAddr)) {

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.socket.DatagramPacket;
+import io.netty.handler.ssl.SniCompletionEvent;
 import io.netty.util.AttributeKey;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.logging.InternalLogger;

--- a/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
+++ b/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
@@ -53,6 +53,8 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
     final String tlsHostName;
     volatile QuicheQuicConnection connection;
 
+    String sniHostname;
+
     QuicheQuicSslEngine(QuicheQuicSslContext ctx, String peerHost, int peerPort) {
         this.ctx = ctx;
         this.peerHost = peerHost;
@@ -67,11 +69,13 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
         }
     }
 
-    long moveTo(QuicheQuicSslContext ctx) {
+    long moveTo(String hostname, QuicheQuicSslContext ctx) {
         // First of remove the engine from its previous QuicheQuicSslContext.
         this.ctx.remove(this);
         this.ctx = ctx;
-        return ctx.add(this);
+        long added = ctx.add(this);
+        sniHostname = hostname;
+        return added;
     }
 
     QuicheQuicConnection createConnection(LongFunction<Long> connectionCreator) {


### PR DESCRIPTION
Motivation:

Sometimes it is useful for people to know if SNI was used and for which hostname.

Modifications:

Fire a SniCompletionEvent when SNI is used

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/pull/330