### PR TITLE
Correctly delete global references when free SSL_CTX

### DIFF
--- a/src/main/c/netty_quic_boringssl.c
+++ b/src/main/c/netty_quic_boringssl.c
@@ -662,16 +662,16 @@ static void netty_boringssl_SSLContext_free(JNIEnv* env, jclass clazz, jlong ctx
     }
     jobject verifyCallbackRef = SSL_CTX_get_ex_data(ssl_ctx, verifyCallbackIdx);
     if (verifyCallbackRef != NULL) {
-        (*env)->DeleteLocalRef(env, verifyCallbackRef);
+        (*env)->DeleteGlobalRef(env, verifyCallbackRef);
     }
     jobject certificateCallbackRef = SSL_CTX_get_ex_data(ssl_ctx, certificateCallbackIdx);
     if (certificateCallbackRef != NULL) {
-        (*env)->DeleteLocalRef(env, certificateCallbackRef);
+        (*env)->DeleteGlobalRef(env, certificateCallbackRef);
     }
 
     jobject servernameCallbackRef = SSL_CTX_get_ex_data(ssl_ctx, servernameCallbackIdx);
     if (servernameCallbackRef != NULL) {
-        (*env)->DeleteLocalRef(env, servernameCallbackRef);
+        (*env)->DeleteGlobalRef(env, servernameCallbackRef);
     }
 
     alpn_data* data = SSL_CTX_get_ex_data(ssl_ctx, alpn_data_idx);


### PR DESCRIPTION
Motivation:

We need to delete the previous created global references to ensure we not leak native memory

Modifications:

Use the correct function to delete the global references

Result:

No native memory leak