### PR TITLE
Update to latest java8 release

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-quic-centos6:centos-6-1.8
     build:
       args:
-        java_version : "8.0.302-zulu"
+        java_version : "8.0.312-zulu"
 
   build:
     image: netty-codec-quic-centos6:centos-6-1.8


### PR DESCRIPTION
Motivation:

A new update for java 8 was released

Modifications:

Update to latest release

Result:

Use latest java 8 version on the CI