### PR TITLE
Upgrade to latest netty-build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <skipTests>false</skipTests>
     <packaging.type>jar</packaging.type>
     <netty.version>4.1.70.Final</netty.version>
-    <netty.build.version>29</netty.build.version>
+    <netty.build.version>30</netty.build.version>
     <junit.version>5.7.0</junit.version>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <jniLibName>netty_quiche_${os.detected.name}_${os.detected.arch}</jniLibName>

--- a/src/main/java/io/netty/incubator/codec/quic/InsecureQuicTokenHandler.java
+++ b/src/main/java/io/netty/incubator/codec/quic/InsecureQuicTokenHandler.java
@@ -32,7 +32,8 @@ public final class InsecureQuicTokenHandler implements QuicTokenHandler {
 
     private static final String SERVER_NAME = "netty";
     private static final byte[] SERVER_NAME_BYTES = SERVER_NAME.getBytes(CharsetUtil.US_ASCII);
-    private static final ByteBuf SERVER_NAME_BUFFER = Unpooled.wrappedBuffer(SERVER_NAME_BYTES);
+    private static final ByteBuf SERVER_NAME_BUFFER = Unpooled.unreleasableBuffer(
+            Unpooled.wrappedBuffer(SERVER_NAME_BYTES)).asReadOnly();
 
     // Just package-private for unit tests
     static final int MAX_TOKEN_LEN = Quiche.QUICHE_MAX_CONN_ID_LEN +


### PR DESCRIPTION
Motivation:

A new netty-build release is out.

Modifications:

- Upgrade version
- Adjust code to match new checkstyle rules

Result:

Use latest netty-build