### PR TITLE
Add unit test for SSL session caching

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLHandshakeCompleteCallback.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLHandshakeCompleteCallback.java
@@ -25,11 +25,12 @@ final class BoringSSLHandshakeCompleteCallback {
 
     @SuppressWarnings("unused")
     void handshakeComplete(long ssl, byte[] id, String cipher, String protocol, byte[] peerCertificate,
-                           byte[][] peerCertificateChain, long creationTime, long timeout, byte[] applicationProtocol) {
+                           byte[][] peerCertificateChain, long creationTime, long timeout, byte[] applicationProtocol,
+                           boolean sessionReused) {
         QuicheQuicSslEngine engine = map.get(ssl);
         if (engine != null) {
             engine.handshakeFinished(id, cipher, protocol, peerCertificate, peerCertificateChain, creationTime,
-                    timeout, applicationProtocol);
+                    timeout, applicationProtocol, sessionReused);
         }
     }
 }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
@@ -50,6 +50,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
     private List<SNIServerName> sniHostNames;
     private boolean handshakeFinished;
     private String applicationProtocol;
+    private boolean sessionReused;
     final String tlsHostName;
     volatile QuicheQuicConnection connection;
 
@@ -253,18 +254,23 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
     synchronized void handshakeFinished(byte[] id, String cipher, String protocol, byte[] peerCertificate,
                                         byte[][] peerCertificateChain,
                                         long creationTime, long timeout,
-                                        byte[] applicationProtocol) {
+                                        byte[] applicationProtocol, boolean sessionReused) {
         if (applicationProtocol == null) {
             this.applicationProtocol = null;
         } else {
             this.applicationProtocol = new String(applicationProtocol);
         }
         session.handshakeFinished(id, cipher, protocol, peerCertificate, peerCertificateChain, creationTime, timeout);
+        this.sessionReused = sessionReused;
         handshakeFinished = true;
     }
 
     void removeSessionFromCacheIfInvalid() {
         session.removeFromCacheIfInvalid();
+    }
+
+    synchronized boolean isSessionReused() {
+        return sessionReused;
     }
 
     private final class QuicheQuicSslSession implements SSLSession {

--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -524,10 +524,11 @@ void quic_SSL_info_callback(const SSL *ssl, int type, int value) {
         jlong creationTime = netty_boringssl_SSL_getTime(e, ssl);
         jlong timeout = netty_boringssl_SSL_getTimeout(e, ssl);
         jbyteArray alpnSelected = netty_boringssl_SSL_getAlpnSelected(e, ssl);
+        jboolean sessionReused = SSL_session_reused((SSL *) ssl) == 1 ? JNI_TRUE : JNI_FALSE;
 
         // Execute the java callback
         (*e)->CallVoidMethod(e, handshakeCompleteCallback, handshakeCompleteCallbackMethod,
-                 (jlong) ssl, session_id, cipher, version, peerCert, certChain, creationTime, timeout, alpnSelected);
+                 (jlong) ssl, session_id, cipher, version, peerCert, certChain, creationTime, timeout, alpnSelected, sessionReused);
     }
 }
 
@@ -1012,7 +1013,7 @@ jint netty_boringssl_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
 
     NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLHandshakeCompleteCallback", name, done);
     NETTY_JNI_UTIL_LOAD_CLASS(env, handshakeCompleteCallbackClass, name, done);
-    NETTY_JNI_UTIL_GET_METHOD(env, handshakeCompleteCallbackClass, handshakeCompleteCallbackMethod, "handshakeComplete", "(J[BLjava/lang/String;Ljava/lang/String;[B[[BJJ[B)V", done);
+    NETTY_JNI_UTIL_GET_METHOD(env, handshakeCompleteCallbackClass, handshakeCompleteCallbackMethod, "handshakeComplete", "(J[BLjava/lang/String;Ljava/lang/String;[B[[BJJ[BZ)V", done);
 
     NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLTlsextServernameCallback", name, done);
     NETTY_JNI_UTIL_LOAD_CLASS(env, servernameCallbackClass, name, done);


### PR DESCRIPTION
Motivation:

07d872f190401f016c4cecc145792bc6940ce5aa added support for 0-RTT when on the client-side by adding client side session caching. While the implementation worked we missed to add a unit test

Modifications:

- Add a unit test

Result:

Test for SSL session re-use on the client-side