### PR TITLE
Correctly set cache size and timeout

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
@@ -347,10 +347,10 @@ public final class QuicSslContextBuilder {
      */
     public QuicSslContext build() {
         if (forServer) {
-            return new QuicheQuicSslContext(true, sessionCacheSize, sessionTimeout, clientAuth, trustManagerFactory,
+            return new QuicheQuicSslContext(true, sessionTimeout, sessionCacheSize, clientAuth, trustManagerFactory,
                     keyManagerFactory, keyPassword, mapping, earlyData, keylog, applicationProtocols);
         } else {
-            return new QuicheQuicSslContext(false, sessionCacheSize, sessionTimeout, clientAuth, trustManagerFactory,
+            return new QuicheQuicSslContext(false, sessionTimeout, sessionCacheSize, clientAuth, trustManagerFactory,
                     keyManagerFactory, keyPassword, mapping, earlyData, keylog,
                     applicationProtocols);
         }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
@@ -113,10 +113,13 @@ final class QuicheQuicSslContext extends QuicSslContext {
             this.sessionCache.setSessionTimeout((int) sessionTimeout);
         } else {
             // Cache is handled by BoringSSL internally
-            this.sessionCacheSize = BoringSSL.SSLContext_setSessionCacheSize(
+            BoringSSL.SSLContext_setSessionCacheSize(
                     nativeSslContext.address(), sessionCacheSize);
-            this.sessionTimeout = BoringSSL.SSLContext_setSessionCacheTimeout(
+            this.sessionCacheSize = sessionCacheSize;
+
+            BoringSSL.SSLContext_setSessionCacheTimeout(
                     nativeSslContext.address(), sessionTimeout);
+            this.sessionTimeout = sessionTimeout;
         }
         if (earlyData != null) {
             BoringSSL.SSLContext_set_early_data_enabled(nativeSslContext.address(), earlyData);
@@ -313,7 +316,8 @@ final class QuicheQuicSslContext extends QuicSslContext {
         if (sessionCache != null) {
             sessionCache.setSessionTimeout(seconds);
         } else {
-            sessionTimeout = BoringSSL.SSLContext_setSessionCacheTimeout(nativeSslContext.address(), seconds);
+            BoringSSL.SSLContext_setSessionCacheTimeout(nativeSslContext.address(), seconds);
+            this.sessionTimeout = seconds;
         }
     }
 
@@ -321,7 +325,8 @@ final class QuicheQuicSslContext extends QuicSslContext {
         if (sessionCache != null) {
             sessionCache.setSessionCacheSize(size);
         } else {
-            sessionCacheSize = BoringSSL.SSLContext_setSessionCacheSize(nativeSslContext.address(), size);
+            BoringSSL.SSLContext_setSessionCacheSize(nativeSslContext.address(), size);
+            sessionCacheSize = size;
         }
     }
 

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicSslContextTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicSslContextTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.util.internal.EmptyArrays;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.X509ExtendedKeyManager;
+
+import java.net.Socket;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class QuicSslContextTest {
+
+    @Test
+    public void testSessionContextSettingsForClient() {
+        testSessionContextSettings(QuicSslContextBuilder.forClient(), 20, 50);
+    }
+
+    @Test
+    public void testSessionContextSettingsForServer() {
+        testSessionContextSettings(QuicSslContextBuilder.forServer(new X509ExtendedKeyManager() {
+            @Override
+            public String[] getClientAliases(String keyType, Principal[] issuers) {
+                return EmptyArrays.EMPTY_STRINGS;
+            }
+
+            @Override
+            public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+                return null;
+            }
+
+            @Override
+            public String[] getServerAliases(String keyType, Principal[] issuers) {
+                return EmptyArrays.EMPTY_STRINGS;
+            }
+
+            @Override
+            public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+                return null;
+            }
+
+            @Override
+            public X509Certificate[] getCertificateChain(String alias) {
+                return new X509Certificate[0];
+            }
+
+            @Override
+            public PrivateKey getPrivateKey(String alias) {
+                return null;
+            }
+        }, null), 20, 50);
+    }
+
+    private void testSessionContextSettings(QuicSslContextBuilder builder, int size, int timeout) {
+        SslContext context = builder.sessionCacheSize(size).sessionTimeout(timeout).build();
+        assertEquals(size, context.sessionCacheSize());
+        assertEquals(timeout, context.sessionTimeout());
+        SSLSessionContext sessionContext = context.sessionContext();
+        assertEquals(size, sessionContext.getSessionCacheSize());
+        assertEquals(timeout, sessionContext.getSessionTimeout());
+
+        int newSize = size / 2;
+        sessionContext.setSessionCacheSize(newSize);
+        assertEquals(newSize, context.sessionCacheSize());
+
+        int newTimeout = timeout / 2;
+        sessionContext.setSessionTimeout(newTimeout);
+        assertEquals(newTimeout, sessionContext.getSessionTimeout());
+    }
+}


### PR DESCRIPTION
Motivation:

Due a bug we did not use the correct values when setting the cache size / timeout. Beside this we also returned the wrong value when server-side was used.

Modifications:

- Fix usage of values
- Store correct values when on server side

Result:

Be able to configure session caching correctly