### PR TITLE
Move to windows-latest

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -105,7 +105,7 @@ jobs:
             **/hs_err*.log
 
   build-windows:
-    runs-on: windows-2016
+    runs-on: windows-latest
     name: windows-x86_64
     env:
       # Let's limit the amount of ram that is used to unpack rustup as we saw

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -89,7 +89,7 @@ jobs:
           if-no-files-found: error
 
   stage-snapshot-windows-x86_64:
-    runs-on: windows-2016
+    runs-on: windows-latest
     name: stage-snapshot-windows-x86_64
     env:
       # Let's limit the amount of ram that is used to unpack rustup as we saw

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -112,7 +112,7 @@ jobs:
             **/hs_err*.log
 
   build-pr-windows:
-    runs-on: windows-2016
+    runs-on: windows-latest
     name: windows-x86_64 build
     env:
       # Let's limit the amount of ram that is used to unpack rustup as we saw

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -135,7 +135,7 @@ jobs:
           override: true
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.1.1
 
       - name: Configuring Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -165,7 +165,7 @@ jobs:
         run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty-incubator-codec-quic main
 
   stage-release-windows-x86_64:
-    runs-on: windows-2016
+    runs-on: windows-latest
     name: stage-release-windows-x86_64
     needs: prepare-release
     env:

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -925,7 +925,7 @@
               <customPackageDirectory>${templateDir}</customPackageDirectory>
               <windowsBuildTool>msbuild</windowsBuildTool>
               <windowsCustomProps>true</windowsCustomProps>
-              <windowsPlatformToolset>v140</windowsPlatformToolset>
+              <windowsPlatformToolset>v141</windowsPlatformToolset>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <configureArgs>
                 <configureArg>${extraConfigureArg}</configureArg>

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -925,7 +925,7 @@
               <customPackageDirectory>${templateDir}</customPackageDirectory>
               <windowsBuildTool>msbuild</windowsBuildTool>
               <windowsCustomProps>true</windowsCustomProps>
-              <windowsPlatformToolset>v141</windowsPlatformToolset>
+              <windowsPlatformToolset>v142</windowsPlatformToolset>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <configureArgs>
                 <configureArg>${extraConfigureArg}</configureArg>


### PR DESCRIPTION
Motivation:

windows-2016 is deprecated and will be removed

Modifications:

Move to windows-latest for windows job

Result:

Dont use deprecated vm versions