### PR TITLE
Add Fragment-Host declaration to bundles shipping native libs

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -29,6 +29,7 @@
 
   <properties>
     <javaModuleName>io.netty.incubator.codec.quic</javaModuleName>
+    <fragmentHost>io.netty.incubator.netty-incubator-codec-classes-quic</fragmentHost>
     <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
     <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
     <skipTests>false</skipTests>
@@ -981,6 +982,7 @@
                 </manifest>
                 <manifestEntries>
                   <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                  <Fragment-Host>${fragmentHost}</Fragment-Host>
                   <Bundle-NativeCode>${bundleNativeCode}</Bundle-NativeCode>
                 </manifestEntries>
                 <index>true</index>


### PR DESCRIPTION
Motivation:

We need to add a Fragment-Host entry to the manifest for the jars that contain the native libs so its possible to use these in OSGI.

Modifications:

Add Fragment-Host entry to manifest.

Result:

Be able to use via OSGI