### PR TITLE
Use windows-2019 in workflows

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -89,7 +89,7 @@ jobs:
           if-no-files-found: error
 
   stage-snapshot-windows-x86_64:
-    runs-on: windows-2016
+    runs-on: windows-2019
     name: stage-snapshot-windows-x86_64
     env:
       # Let's limit the amount of ram that is used to unpack rustup as we saw

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -112,7 +112,7 @@ jobs:
             **/hs_err*.log
 
   build-pr-windows:
-    runs-on: windows-2016
+    runs-on: windows-2019
     name: windows-x86_64 build
     env:
       # Let's limit the amount of ram that is used to unpack rustup as we saw

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -165,7 +165,7 @@ jobs:
         run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty-incubator-codec-quic main
 
   stage-release-windows-x86_64:
-    runs-on: windows-2016
+    runs-on: windows-2019
     name: stage-release-windows-x86_64
     needs: prepare-release
     env:

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -926,7 +926,7 @@
               <customPackageDirectory>${templateDir}</customPackageDirectory>
               <windowsBuildTool>msbuild</windowsBuildTool>
               <windowsCustomProps>true</windowsCustomProps>
-              <windowsPlatformToolset>v140</windowsPlatformToolset>
+              <windowsPlatformToolset>v142</windowsPlatformToolset>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <configureArgs>
                 <configureArg>${extraConfigureArg}</configureArg>

--- a/codec-native-quic/src/main/native-package/vs2010.custom.props.template
+++ b/codec-native-quic/src/main/native-package/vs2010.custom.props.template
@@ -23,4 +23,7 @@
       <AdditionalDependencies>ws2_32.lib;crypt32.lib;bcrypt.lib;userenv.lib;@BORINGSSL_LIB_DIR@\@SSL_LIB@;@BORINGSSL_LIB_DIR@\@CRYPTO_LIB@;@QUICHE_LIB_DIR@\@QUICHE_LIB@;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
+  <PropertyGroup Label="Globals">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
 </Project>

--- a/codec-native-quic/src/main/native-package/vs2010.custom.props.template
+++ b/codec-native-quic/src/main/native-package/vs2010.custom.props.template
@@ -23,26 +23,4 @@
       <AdditionalDependencies>ws2_32.lib;crypt32.lib;bcrypt.lib;userenv.lib;@BORINGSSL_LIB_DIR@\@SSL_LIB@;@BORINGSSL_LIB_DIR@\@CRYPTO_LIB@;@QUICHE_LIB_DIR@\@QUICHE_LIB@;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
 </Project>

--- a/codec-native-quic/src/main/native-package/vs2010.custom.props.template
+++ b/codec-native-quic/src/main/native-package/vs2010.custom.props.template
@@ -23,7 +23,26 @@
       <AdditionalDependencies>ws2_32.lib;crypt32.lib;bcrypt.lib;userenv.lib;@BORINGSSL_LIB_DIR@\@SSL_LIB@;@BORINGSSL_LIB_DIR@\@CRYPTO_LIB@;@QUICHE_LIB_DIR@\@QUICHE_LIB@;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <PropertyGroup Label="Globals">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Motivation:

windows-2016 was removed so we need to use the next lowest which is 2019

Modifications:

- Use windows-2019

Result:

Builds on windows work again