### PR TITLE
Update netty-jni-util from 0.0.5.Final to 0.0.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-jni-util</artifactId>
-        <version>0.0.5.Final</version>
+        <version>0.0.6.Final</version>
         <classifier>sources</classifier>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
Motivation:

We did not correctly escape chars when shading is used.

Modifications:

- Update jni-utils to fix bug

Result:

Fixes escaping

Related:
- netty/netty-jni-util#13
- netty/netty#12358