### PR TITLE
Fix CI job to verify aarch64 loading

### DIFF
--- a/.github/workflows/ci-verify-load.yml
+++ b/.github/workflows/ci-verify-load.yml
@@ -77,12 +77,12 @@ jobs:
           name:  maven-repository
           path: /home/runner/jars
 
-      - uses: uraimo/run-on-arch-action@v2.0.9
+      - uses: uraimo/run-on-arch-action@v2.2.0
         name: Check native loading
         id: runcmd
         with:
           arch: aarch64
-          distro: ubuntu18.04
+          distro: ubuntu20.04
 
           # Not required, but speeds up builds by storing container images in
           # a GitHub package registry.


### PR DESCRIPTION
Motivation:

At the moment the CI fails when try to verify aarch64 loading

Modifications:

- Update run-on-arch-action version
- Update ubuntu version

Result:

CI build pass again