### PR TITLE
Fix windows build error on CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -105,7 +105,7 @@ jobs:
             **/hs_err*.log
 
   build-windows:
-    runs-on: windows-2016
+    runs-on: windows-2019
     name: windows-x86_64
     env:
       # Let's limit the amount of ram that is used to unpack rustup as we saw


### PR DESCRIPTION
Motivation:

Github does not support windows-2016 anymore

Modifications:

Switch to windows-2019

Result:

Build does not fail anymore on CI