### PR TITLE
Fix aarch64 processor name for OSGi

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -149,7 +149,7 @@
         <libquiche>libquiche.a</libquiche>
         <extraLdflags>-arch arm64 -Wl,-exported_symbol,_JNI_* -Wl,-platform_version,macos,${macosxDeploymentTarget},${macosxDeploymentTarget}</extraLdflags>
         <extraConfigureArg>--host=aarch64-apple-darwin</extraConfigureArg>
-        <bundleNativeCode>META-INF/native/lib${jniLibName}.jnilib;osname=macos;osname=macosx;processor=aarch_64</bundleNativeCode>
+        <bundleNativeCode>META-INF/native/lib${jniLibName}.jnilib;osname=macos;osname=macosx;processor=aarch64</bundleNativeCode>
         <!-- Don't run tests as we can't load the aarch64 lib on a x86_64 system -->
         <skipTests>true</skipTests>
         <crossCompile>mac</crossCompile>
@@ -441,7 +441,7 @@
         <libcrypto>libcrypto.a</libcrypto>
         <libquiche>libquiche.a</libquiche>
         <extraLdflags>-Wl,--strip-debug -Wl,--exclude-libs,ALL</extraLdflags>
-        <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=aarch_64</bundleNativeCode>
+        <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=aarch64</bundleNativeCode>
         <jniLibName>netty_quiche_linux_aarch_64</jniLibName>
         <jni.classifier>linux-aarch_64</jni.classifier>
         <javaModuleNameWithClassifier>linux.aarch_64</javaModuleNameWithClassifier>


### PR DESCRIPTION
Motivation:
OSGi does not recognize aarch_64 (with the underscore) as a processor name.

Modification:
Fix processor name

Result:
Our quic bundles should work again, on aarch_64 systems.

This is the quic equivalent of netty/netty#12498