### PR TITLE
Upgrade to last LTS release of NDK

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -180,7 +180,7 @@ jobs:
     name: android
     env:
       SDK_VER: "platforms;android-21"
-      NDK_VER: "ndk;23.1.7779620"
+      NDK_VER: "ndk;21.4.7075529"
     steps:
       - uses: actions/checkout@v2
 
@@ -190,13 +190,19 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
 
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: armv7-linux-androideabi
+          override: true
+
       - name: Install cargo-ndk
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-ndk
-
-      - name: Install Rust toolchain for Android architectures
-        run: rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -180,7 +180,7 @@ jobs:
     name: android
     env:
       SDK_VER: "platforms;android-21"
-      NDK_VER: "ndk;21.4.7075529"
+      NDK_VER: "ndk;23.1.7779620"
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -219,7 +219,7 @@ jobs:
         run: sdkmanager "${{ env.NDK_VER }}"
 
       - name: Setup environment
-        run: export ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}
+        run: export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
 
       - name: Build project
         run: ./mvnw -B -ntp --file pom.xml clean package -Dandroid

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -242,7 +242,7 @@
         <packaging.type>aar</packaging.type>
         <skipTests>true</skipTests>
         <platform>android</platform>
-        <androidNdkVersion>23</androidNdkVersion>
+        <androidNdkVersion>21</androidNdkVersion>
         <androidMinSdkVersion>21</androidMinSdkVersion>
         <cargoTarget>--target=${quicheTarget}</cargoTarget>
         <skipIteration>false</skipIteration>

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -242,7 +242,7 @@
         <packaging.type>aar</packaging.type>
         <skipTests>true</skipTests>
         <platform>android</platform>
-        <androidNdkVersion>21</androidNdkVersion>
+        <androidNdkVersion>23</androidNdkVersion>
         <androidMinSdkVersion>21</androidMinSdkVersion>
         <cargoTarget>--target=${quicheTarget}</cargoTarget>
         <skipIteration>false</skipIteration>


### PR DESCRIPTION
Motivation:

Compiling of quiche fails for android. Let's try to update to latest LTS release of NDK to fix it

Modifications:

Update to NDK 23.1.7779620

Result:

Build for android pass again