### PR TITLE
Fixed build and CI for Android

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -158,3 +158,54 @@ jobs:
           path: |
             **/target/surefire-reports/
             **/hs_err*.log
+
+  build-android:
+    runs-on: ubuntu-latest
+    name: android
+    env:
+      SDK_VER: "platforms;android-21"
+      NDK_VER: "ndk;21.4.7075529"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup ninja-build
+        run: sudo apt-get install ninja-build
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+
+      - name: Install cargo-ndk
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-ndk
+
+      - name: Install Rust toolchain for Android architectures
+        run: rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Install Android SDK platforms
+        run: sdkmanager "${{ env.SDK_VER }}"
+
+      - name: Install Android NDK
+        run: sdkmanager "${{ env.NDK_VER }}"
+
+      - name: Setup environment
+        run: export ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}
+
+      - name: Build project
+        run: ./mvnw -B -ntp --file pom.xml clean package -Dandroid
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: target
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -163,10 +163,14 @@ jobs:
     runs-on: ubuntu-latest
     name: android
     env:
-      SDK_VER: "platforms;android-21"
-      NDK_VER: "ndk;21.4.7075529"
+      SDK_VER: "android-21"
+      NDK_VER: "21.4.7075529"
     steps:
-      - uses: actions/checkout@v2
+      - name: Set environmental variables
+        run: echo "ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk/$NDK_VER" >> $GITHUB_ENV
+
+      - name: Checkout code
+        uses: actions/checkout@v2
 
       - name: Setup ninja-build
         run: sudo apt-get install ninja-build
@@ -187,17 +191,23 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
-
       - name: Install Android SDK platforms
-        run: sdkmanager "${{ env.SDK_VER }}"
+        run: ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;${{ env.SDK_VER }}"
 
       - name: Install Android NDK
-        run: sdkmanager "${{ env.NDK_VER }}"
+        run: ${ANDROID_HOME}/tools/bin/sdkmanager "ndk;${{ env.NDK_VER }}"
 
       - name: Setup environment
         run: export ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}
+
+      # Cache .m2/repository
+      # Caching of maven dependencies
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: pr-android-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            android-maven-cache-
 
       - name: Build project
         run: ./mvnw -B -ntp --file pom.xml clean package -Dandroid

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -173,3 +173,55 @@ jobs:
           path: |
             **/target/surefire-reports/
             **/hs_err*.log
+
+
+  build-pr-android:
+    runs-on: ubuntu-latest
+    name: android
+    env:
+      SDK_VER: "platforms;android-21"
+      NDK_VER: "ndk;21.4.7075529"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup ninja-build
+        run: sudo apt-get install ninja-build
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+
+      - name: Install cargo-ndk
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-ndk
+
+      - name: Install Rust toolchain for Android architectures
+        run: rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Install Android SDK platforms
+        run: sdkmanager "${{ env.SDK_VER }}"
+
+      - name: Install Android NDK
+        run: sdkmanager "${{ env.NDK_VER }}"
+
+      - name: Setup environment
+        run: export ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}
+
+      - name: Build project
+        run: ./mvnw -B -ntp --file pom.xml clean package -Dandroid
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: build-pr-android-target
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -179,10 +179,14 @@ jobs:
     runs-on: ubuntu-latest
     name: android
     env:
-      SDK_VER: "platforms;android-21"
-      NDK_VER: "ndk;21.4.7075529"
+      SDK_VER: "android-21"
+      NDK_VER: "21.4.7075529"
     steps:
-      - uses: actions/checkout@v2
+      - name: Set environmental variables
+        run: echo "ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk/$NDK_VER" >> $GITHUB_ENV
+
+      - name: Checkout code
+        uses: actions/checkout@v2
 
       - name: Setup ninja-build
         run: sudo apt-get install ninja-build
@@ -203,17 +207,23 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
-
       - name: Install Android SDK platforms
-        run: sdkmanager "${{ env.SDK_VER }}"
+        run: ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;${{ env.SDK_VER }}"
 
       - name: Install Android NDK
-        run: sdkmanager "${{ env.NDK_VER }}"
+        run: ${ANDROID_HOME}/tools/bin/sdkmanager "ndk;${{ env.NDK_VER }}"
 
       - name: Setup environment
         run: export ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}
+
+      # Cache .m2/repository
+      # Caching of maven dependencies
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: pr-android-maven-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            pr-android-maven-cache-
 
       - name: Build project
         run: ./mvnw -B -ntp --file pom.xml clean package -Dandroid

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -263,6 +263,7 @@
         <jniLibName>netty_quiche</jniLibName>
         <jni.classifier>${platform}</jni.classifier>
         <cflags>-std=c99 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3 -I${quicheHomeIncludeDir} -I${boringsslHomeIncludeDir}</cflags>
+        <ldflags>-L${quicheHomeBuildDir} -lquiche -L${boringsslHomeBuildDir} -lssl -lcrypto</ldflags>
         <bundleNativeCode>META-INF/native/${jniLibName}.dll;osname=android;processor=${androidAbi}</bundleNativeCode>
         <ndkToolchain>${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64</ndkToolchain>
         <extraLdflags>-Wl,-soname=${jniLibName}.so -Wl,--strip-debug -Wl,--exclude-libs,ALL -lm</extraLdflags>

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -310,6 +310,7 @@
                       </properties>
                     </itemWithProperty>
                   </itemsWithProperties>
+                  <baseDirectory>${project.basedir}</baseDirectory>
                   <goals>
                     <goal>package</goal>
                   </goals>


### PR DESCRIPTION
Motivation:

Since PR #357 the Android build only contained the native library for the `armeabi-v7a` architecture, because the native library was moved to a separate maven child module and the other architectures failed to build
Since PR #406 the Android build was not working anymore
Since PR #411 the Android CI workflows have been removed

Modifications:

Change the baseDirectory for the iterator-maven-plugin to execute the child module, otherwise it can't find the specified profiles
Re-added the ldflags to the Android profile of the native library
Reverted PR #411 which removed the Android workflows

Result:

The android library now contains native libraries for all four architectures and successfully builds again