### PR TITLE
Update trustmanager javadoc

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
@@ -193,7 +193,10 @@ public final class QuicSslContextBuilder {
 
     /**
      * Trusted certificates for verifying the remote endpoint's certificate. The file should
-     * contain an X.509 certificate collection in PEM format. {@code null} uses the system default.
+     * contain an X.509 certificate collection in PEM format. {@code null} uses the system default
+     * and note this only works with Java 8u261 and later as these versions support TLS1.3,
+     * see <a href="https://www.oracle.com/java/technologies/javase/8u261-relnotes.html">
+     *     JDK 8u261 Update Release Notes</a>
      */
     public QuicSslContextBuilder trustManager(File trustCertCollectionFile) {
         try {
@@ -205,7 +208,10 @@ public final class QuicSslContextBuilder {
     }
 
     /**
-     * Trusted certificates for verifying the remote endpoint's certificate, {@code null} uses the system default.
+     * Trusted certificates for verifying the remote endpoint's certificate, {@code null} uses the system default
+     * and note this only works with Java 8u261 and later as these versions support TLS1.3,
+     * see <a href="https://www.oracle.com/java/technologies/javase/8u261-relnotes.html">
+     *     JDK 8u261 Update Release Notes</a>
      */
     public QuicSslContextBuilder trustManager(X509Certificate... trustCertCollection) {
         try {
@@ -216,7 +222,10 @@ public final class QuicSslContextBuilder {
     }
 
     /**
-     * Trusted manager for verifying the remote endpoint's certificate. {@code null} uses the system default.
+     * Trusted manager for verifying the remote endpoint's certificate. {@code null} uses the system default
+     * and note this only works with Java 8u261 and later as these versions support TLS1.3,
+     * see <a href="https://www.oracle.com/java/technologies/javase/8u261-relnotes.html">
+     *     JDK 8u261 Update Release Notes</a>
      */
     public QuicSslContextBuilder trustManager(TrustManagerFactory trustManagerFactory) {
         this.trustManagerFactory = trustManagerFactory;

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
@@ -194,7 +194,7 @@ public final class QuicSslContextBuilder {
     /**
      * Trusted certificates for verifying the remote endpoint's certificate. The file should
      * contain an X.509 certificate collection in PEM format. {@code null} uses the system default
-     * and note this only works with Java 8u261 and later as these versions support TLS1.3,
+     * which only works with Java 8u261 and later as these versions support TLS1.3,
      * see <a href="https://www.oracle.com/java/technologies/javase/8u261-relnotes.html">
      *     JDK 8u261 Update Release Notes</a>
      */
@@ -208,8 +208,8 @@ public final class QuicSslContextBuilder {
     }
 
     /**
-     * Trusted certificates for verifying the remote endpoint's certificate, {@code null} uses the system default
-     * and note this only works with Java 8u261 and later as these versions support TLS1.3,
+     * Trusted certificates for verifying the remote endpoint's certificate. {@code null} uses the system default
+     * which only works with Java 8u261 and later as these versions support TLS1.3,
      * see <a href="https://www.oracle.com/java/technologies/javase/8u261-relnotes.html">
      *     JDK 8u261 Update Release Notes</a>
      */
@@ -223,7 +223,7 @@ public final class QuicSslContextBuilder {
 
     /**
      * Trusted manager for verifying the remote endpoint's certificate. {@code null} uses the system default
-     * and note this only works with Java 8u261 and later as these versions support TLS1.3,
+     * which only works with Java 8u261 and later as these versions support TLS1.3,
      * see <a href="https://www.oracle.com/java/technologies/javase/8u261-relnotes.html">
      *     JDK 8u261 Update Release Notes</a>
      */


### PR DESCRIPTION
Motivation:

- When uses the system default TrustManager `sun.security.ssl.X509TrustManagerImpl`, lower JDK versions before 8u261 do not work as expected due to lack of support of TLS1.3, and we will get an `CERTIFICATE_VERIFY_FAILED` error. we should point this out in javadoc.

Modifications:

- Update javadoc for QuicSslContextBuilder#trustManager.

Result:

- Now we have a clear javadoc when use QuicSslContextBuilder#trustManager api.