### PR TITLE
Upgrade to new netty-build release

### DIFF
--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
@@ -15,22 +15,14 @@
  */
 package io.netty.incubator.codec.quic;
 
-import org.junit.Assume;
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Timeout;
 
+@Timeout(10)
 public abstract class AbstractQuicTest {
 
-    private static final int TEST_GLOBAL_TIMEOUT_VALUE = Integer.getInteger(
-            "io.netty.incubator.codec.quic.defaultTestTimeout", 10);
-
-    @Rule
-    public final Timeout globalTimeout = Timeout.seconds(TEST_GLOBAL_TIMEOUT_VALUE);
-
     @BeforeAll
-    public static void assumeTrue() {
+    public static void ensureAvailability() {
         Quic.ensureAvailability();
-       Assume.assumeTrue(Quic.isAvailable());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <skipTests>false</skipTests>
     <packaging.type>jar</packaging.type>
     <netty.version>4.1.77.Final</netty.version>
-    <netty.build.version>30</netty.build.version>
+    <netty.build.version>31</netty.build.version>
     <commons.codec.version>1.15</commons.codec.version>
     <junit.version>5.7.0</junit.version>
     <test.argLine>-D_</test.argLine>


### PR DESCRIPTION
Motivation:

There was a new netty-build release

Modifications:

- Update to latest release
- Remove junit 4 usage

Result:

Use latest release