### PR TITLE
Fix connection failure when packets are dropped

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -187,6 +187,11 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
             scidLen = localConnIdLength;
             ocidAddr = -1;
             ocidLen = -1;
+
+            QuicheQuicChannel existingChannel = getChannel(key);
+            if (existingChannel != null) {
+                return existingChannel;
+            }
         } else {
             scidAddr = Quiche.memoryAddress(dcid) + dcid.readerIndex();
             scidLen = localConnIdLength;
@@ -197,6 +202,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
             dcid.getBytes(dcid.readerIndex(), bytes);
             key = ByteBuffer.wrap(bytes);
         }
+
         QuicheQuicChannel channel = QuicheQuicChannel.forServer(
                 ctx.channel(), key, sender, config.isDatagramSupported(),
                 streamHandler, streamOptionsArray, streamAttrsArray, this::removeChannel);

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -202,7 +202,6 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
             dcid.getBytes(dcid.readerIndex(), bytes);
             key = ByteBuffer.wrap(bytes);
         }
-
         QuicheQuicChannel channel = QuicheQuicChannel.forServer(
                 ctx.channel(), key, sender, config.isDatagramSupported(),
                 streamHandler, streamOptionsArray, streamAttrsArray, this::removeChannel);

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -63,6 +63,7 @@ import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -335,7 +336,6 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         testConnectWithDroppedPackets(0, QuicConnectionIdGenerator.signGenerator());
     }
 
-    // This test fails but it should not!
     @Test
     @Timeout(5)
     public void testConnectWithDroppedPacketsAndSignConnectionIdGenerator() throws Throwable {

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -269,7 +269,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
                         // Server closes the stream whenever the client sends a FIN.
                         if (evt instanceof ChannelInputShutdownEvent) {
-                            ctx.channel().close();
+                            ctx.close();
                         }
                         ctx.fireUserEventTriggered(evt);
                     }
@@ -278,7 +278,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         // Have the server drop the few first numDroppedPackets incoming packets.
         server.pipeline().addFirst(
                 new ChannelInboundHandlerAdapter() {
-                    int counter = 0;
+                    private int counter = 0;
 
                     public void channelRead(ChannelHandlerContext ctx, Object msg) {
                         if (counter++ < numDroppedPackets) {
@@ -304,8 +304,8 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                     new ChannelInboundHandlerAdapter()).get();
 
             ByteBuf payload = Unpooled.wrappedBuffer("HELLO!".getBytes(StandardCharsets.US_ASCII));
-            quicStream.writeAndFlush(payload);
-            quicStream.shutdownOutput();
+            quicStream.writeAndFlush(payload).sync();
+            quicStream.shutdownOutput().sync();
             assertTrue(quicStream.closeFuture().await().isSuccess());
 
             ChannelFuture closeFuture = channel.close().await();

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -23,12 +23,14 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ConnectTimeoutException;
+import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SniCompletionEvent;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.TrustManagerFactoryWrapper;
 import io.netty.util.DomainWildcardMappingBuilder;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
@@ -47,6 +49,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.channels.AlreadyConnectedException;
 import java.nio.channels.ClosedChannelException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.cert.CertificateException;
@@ -60,7 +63,6 @@ import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -243,6 +245,101 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             // Close the parent Datagram channel as well.
             channel.close().sync();
         }
+    }
+
+    private void testConnectWithDroppedPackets(int numDroppedPackets,
+                                               QuicConnectionIdGenerator connectionIdGenerator) throws Throwable {
+        Channel server = QuicTestUtils.newServer(QuicTestUtils.newQuicServerBuilder()
+                        .connectionIdAddressGenerator(connectionIdGenerator),
+                NoValidationQuicTokenHandler.INSTANCE,
+                new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public boolean isSharable() {
+                        return true;
+                    }
+                },
+                new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public boolean isSharable() {
+                        return true;
+                    }
+
+                    @Override
+                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                        // Server closes the stream whenever the client sends a FIN.
+                        if (evt instanceof ChannelInputShutdownEvent) {
+                            ctx.channel().close();
+                        }
+                        ctx.fireUserEventTriggered(evt);
+                    }
+                });
+
+        // Have the server drop the few first numDroppedPackets incoming packets.
+        server.pipeline().addFirst(
+                new ChannelInboundHandlerAdapter() {
+                    int counter = 0;
+
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        if (counter++ < numDroppedPackets) {
+                            System.out.println("Server dropping incoming packet #" + counter);
+                            ReferenceCountUtil.release(msg);
+                        } else {
+                            ctx.fireChannelRead(msg);
+                        }
+                    }
+                });
+
+        InetSocketAddress address = (InetSocketAddress) server.localAddress();
+        Channel channel = QuicTestUtils.newClient(QuicTestUtils.newQuicClientBuilder());
+        ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
+        try {
+            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+                    .handler(clientQuicChannelHandler)
+                    .remoteAddress(address)
+                    .connect()
+                    .get();
+
+            QuicStreamChannel quicStream = quicChannel.createStream(QuicStreamType.BIDIRECTIONAL,
+                    new ChannelInboundHandlerAdapter()).get();
+
+            ByteBuf payload = Unpooled.wrappedBuffer("HELLO!".getBytes(StandardCharsets.US_ASCII));
+            quicStream.writeAndFlush(payload);
+            quicStream.shutdownOutput();
+            assertTrue(quicStream.closeFuture().await().isSuccess());
+
+            ChannelFuture closeFuture = channel.close().await();
+            assertTrue(closeFuture.isSuccess());
+        }
+        finally {
+            clientQuicChannelHandler.assertState();
+            channel.close().sync();
+            server.close().sync();
+        }
+    }
+
+    @Test
+    @Timeout(3)
+    public void testConnectWithNoDroppedPacketsAndRandomConnectionIdGenerator() throws Throwable {
+        testConnectWithDroppedPackets(0, QuicConnectionIdGenerator.randomGenerator());
+    }
+
+    @Test
+    @Timeout(5)
+    public void testConnectWithDroppedPacketsAndRandomConnectionIdGenerator() throws Throwable {
+        testConnectWithDroppedPackets(2, QuicConnectionIdGenerator.randomGenerator());
+    }
+
+    @Test
+    @Timeout(3)
+    public void testConnectWithNoDroppedPacketsAndSignConnectionIdGenerator() throws Throwable {
+        testConnectWithDroppedPackets(0, QuicConnectionIdGenerator.signGenerator());
+    }
+
+    // This test fails but it should not!
+    @Test
+    @Timeout(5)
+    public void testConnectWithDroppedPacketsAndSignConnectionIdGenerator() throws Throwable {
+        testConnectWithDroppedPackets(2, QuicConnectionIdGenerator.signGenerator());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Client fails to connect under certain conditions:
 - First two packets (CRYPTO) from client are dropped. That causes the client to send a PING packet immediately following the third CRYPTO packet.
 - Server is not using any token validation.
 - Server is using a deterministic connection ID generator such as HmacSignQuicConnectionIdGenerator (which is the default).

When that happens, the server creates two channels under the same key since both the CRYPTO and PING packets have the same DCID.

Modifications:

Before creating a server channel in the noToken case, check that there is no existing channel.

Result:

Client can connect.