### PR TITLE
bytesBeforeUnwritable() should never return a negative value

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -335,7 +335,8 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
 
     @Override
     public long bytesBeforeUnwritable() {
-        return capacity;
+        // Capacity might be negative if the stream was closed.
+        return Math.max(capacity, 0);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

We need to ensure that bytesBeforeUnwritable() will always return a value >= 0

Modifications:

- Add Math.max(...) call

Result:

Always return valid value