### PR TITLE
Remove the listener as its not included anymore in latest netty build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,12 +255,6 @@
             <logback.configurationFile>src/test/resources/logback-test.xml</logback.configurationFile>
             <logLevel>info</logLevel>
           </systemPropertyVariables>
-          <properties>
-            <property>
-              <name>listener</name>
-              <value>io.netty.build.junit.TimedOutTestsListener</value>
-            </property>
-          </properties>
           <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
           <trimStackTrace>false</trimStackTrace>
           <argLine>${test.argLine}</argLine>


### PR DESCRIPTION
Motivation:

We updated to junit5 and so not provide the listener anymore

Modifications:

Remove usage of listener property

Result:

Cleanup