### PR TITLE
Allow to run expensive tasks on a different Executor

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSL.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSL.java
@@ -82,6 +82,11 @@ final class BoringSSL {
     }
     static native long SSL_new0(long context, boolean server, String hostname);
     static native void SSL_free(long ssl);
+
+    static native Runnable SSL_getTask(long ssl);
+
+    static native void SSL_cleanup(long ssl);
+
     static native long EVP_PKEY_parse(byte[] bytes, String pass);
     static native void EVP_PKEY_free(long key);
 

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallback.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallback.java
@@ -199,7 +199,7 @@ final class BoringSSLCertificateCallback {
         engine.setLocalCertificateChain(certificates);
 
         // Return and signal that the key and chain should be released as well.
-        return new long[] { key,  chain , 1 };
+        return new long[] { key,  chain };
     }
 
     private static byte[] toPemEncoded(PrivateKey key) {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallbackTask.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallbackTask.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+/**
+ * Execute {@link BoringSSLCertificateCallback#handle(long, byte[], byte[][], String[])}.
+ */
+final class BoringSSLCertificateCallbackTask extends BoringSSLTask {
+    private final byte[] keyTypeBytes;
+    private final byte[][] asn1DerEncodedPrincipals;
+    private final String[] authMethods;
+    private final BoringSSLCertificateCallback callback;
+
+    // Accessed via JNI.
+    private long key;
+    private long chain;
+
+    BoringSSLCertificateCallbackTask(long ssl, byte[] keyTypeBytes, byte[][] asn1DerEncodedPrincipals, String[] authMethods,
+                                     BoringSSLCertificateCallback callback) {
+        // It is important that this constructor never throws. Be sure to not change this!
+        super(ssl);
+        // It's ok to not clone the arrays as we create these in JNI and not-reuse.
+        this.keyTypeBytes = keyTypeBytes;
+        this.asn1DerEncodedPrincipals = asn1DerEncodedPrincipals;
+        this.authMethods = authMethods;
+        this.callback = callback;
+    }
+
+    // See https://www.openssl.org/docs/man1.0.2/man3/SSL_set_cert_cb.html.
+    @Override
+    protected void runTask(long ssl, TaskCallback taskCallback) {
+        try {
+            long[] result = callback.handle(ssl, keyTypeBytes, asn1DerEncodedPrincipals, authMethods);
+            if (result == null) {
+                taskCallback.onResult(ssl, 0);
+            } else {
+                this.key = result[0];
+                this.chain = result[1];
+                taskCallback.onResult(ssl, 1);
+            }
+        } catch (Exception e) {
+            // Just catch the exception and return 0 to fail the handshake.
+            // The problem is that rethrowing here is really "useless" as we will process it as part of an openssl
+            // c callback which needs to return 0 for an error to abort the handshake.
+            taskCallback.onResult(ssl, 0);
+        }
+    }
+}

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateVerifyCallbackTask.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateVerifyCallbackTask.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+
+/**
+ * Execute {@link BoringSSLCertificateVerifyCallback#verify(long, byte[][], String)}.
+ */
+final class BoringSSLCertificateVerifyCallbackTask extends BoringSSLTask {
+    private final byte[][] x509;
+    private final String authAlgorithm;
+    private final BoringSSLCertificateVerifyCallback verifier;
+
+    BoringSSLCertificateVerifyCallbackTask(long ssl, byte[][] x509, String authAlgorithm,
+                                           BoringSSLCertificateVerifyCallback verifier) {
+        super(ssl);
+        this.x509 = x509;
+        this.authAlgorithm = authAlgorithm;
+        this.verifier = verifier;
+    }
+
+    @Override
+    protected void runTask(long ssl, TaskCallback callback) {
+        int result = verifier.verify(ssl, x509, authAlgorithm);
+        callback.onResult(ssl, result);
+    }
+}

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLTask.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLTask.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+/**
+ * A SSL related task that will be returned by {@link BoringSSL#SSL_getTask(long)}.
+ */
+abstract class BoringSSLTask implements Runnable {
+    private static final Runnable NOOP = () -> {
+        // NOOP
+    };
+    private final long ssl;
+    protected boolean didRun;
+
+    // These fields are accessed via JNI.
+    private int returnValue;
+    private boolean complete;
+
+    protected BoringSSLTask(long ssl) {
+        // It is important that this constructor never throws. Be sure to not change this!
+        this.ssl = ssl;
+    }
+
+    @Override
+    public final void run() {
+        run(NOOP);
+    }
+
+    protected final void run(final Runnable completeCallback) {
+        if (!didRun) {
+            didRun = true;
+            runTask(ssl, (long ssl, int result) -> {
+                returnValue = result;
+                complete = true;
+                completeCallback.run();
+            });
+        } else {
+            completeCallback.run();
+        }
+    }
+
+    /**
+     * Run the task and return the return value that should be passed back to OpenSSL.
+     */
+    protected abstract void runTask(long ssl, TaskCallback callback);
+
+    interface TaskCallback {
+        void onResult(long ssl, int result);
+    }
+}

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicClientCodecBuilder.java
@@ -17,6 +17,7 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.channel.ChannelHandler;
 
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 /**
@@ -44,7 +45,8 @@ public final class QuicClientCodecBuilder extends QuicCodecBuilder<QuicClientCod
     @Override
     protected ChannelHandler build(QuicheConfig config,
                                    Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider,
+                                   Executor sslTaskExecutor,
                                    int localConnIdLength, FlushStrategy flushStrategy) {
-        return new QuicheQuicClientCodec(config, sslEngineProvider, localConnIdLength, flushStrategy);
+        return new QuicheQuicClientCodec(config, sslEngineProvider, sslTaskExecutor, localConnIdLength, flushStrategy);
     }
 }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -23,6 +23,7 @@ import io.netty.util.internal.ObjectUtil;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 /**
@@ -184,6 +185,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     @Override
     protected ChannelHandler build(QuicheConfig config,
                                    Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider,
+                                   Executor sslTaskExecutor,
                                    int localConnIdLength, FlushStrategy flushStrategy) {
         validate();
         QuicTokenHandler tokenHandler = this.tokenHandler;
@@ -194,7 +196,8 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
         ChannelHandler handler = this.handler;
         ChannelHandler streamHandler = this.streamHandler;
         return new QuicheQuicServerCodec(config, localConnIdLength, tokenHandler, generator, flushStrategy,
-                sslEngineProvider, handler, Quic.toOptionsArray(options), Quic.toAttributesArray(attrs),
+                sslEngineProvider, sslTaskExecutor, handler,
+                Quic.toOptionsArray(options), Quic.toAttributesArray(attrs),
                 streamHandler, Quic.toOptionsArray(streamOptions), Quic.toAttributesArray(streamAttrs));
     }
 }

--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -34,11 +34,17 @@
 
 #define ERR_LEN 256
 
-static jclass verifyCallbackClass = NULL;
-static jmethodID verifyCallbackMethod = NULL;
+static jclass sslTaskClass = NULL;
+static jfieldID  sslTaskReturnValue;
+static jfieldID  sslTaskComplete;
 
-static jclass certificateCallbackClass = NULL;
-static jmethodID certificateCallbackMethod = NULL;
+static jclass verifyTaskClass = NULL;
+static jmethodID verifyTaskClassInitMethod = NULL;
+
+static jclass certificateTaskClass = NULL;
+static jmethodID certificateTaskClassInitMethod = NULL;
+static jfieldID  certificateTaskClassChainField;
+static jfieldID  certificateTaskClassKeyField;
 
 static jclass handshakeCompleteCallbackClass = NULL;
 static jmethodID handshakeCompleteCallbackMethod = NULL;
@@ -61,6 +67,7 @@ static int certificateCallbackIdx = -1;
 static int servernameCallbackIdx = -1;
 static int keylogCallbackIdx = -1;
 static int sessionCallbackIdx = -1;
+static int sslTaskIdx = -1;
 static int alpn_data_idx = -1;
 static int crypto_buffer_pool_idx = -1;
 
@@ -170,6 +177,50 @@ static jbyteArray to_byte_array(JNIEnv* env, uint8_t* bytes, size_t len) {
      return array;
 }
 
+// Store the callback to run and also if it was consumed via SSL.getTask(...).
+typedef struct netty_boringssl_ssl_task_t netty_boringssl_ssl_task_t;
+struct netty_boringssl_ssl_task_t {
+    jboolean consumed;
+    jobject task;
+};
+
+
+static netty_boringssl_ssl_task_t* netty_boringssl_ssl_task_new(JNIEnv* e, jobject task) {
+    if (task == NULL) {
+        // task was NULL which most likely means we did run out of memory when calling NewObject(...). Signal a failure back by returning NULL.
+        return NULL;
+    }
+    netty_boringssl_ssl_task_t* sslTask = (netty_boringssl_ssl_task_t*) OPENSSL_malloc(sizeof(netty_boringssl_ssl_task_t));
+    if (sslTask == NULL) {
+        return NULL;
+    }
+
+    if ((sslTask->task = (*e)->NewGlobalRef(e, task)) == NULL) {
+        // NewGlobalRef failed because we ran out of memory, free what we malloc'ed and fail the handshake.
+        OPENSSL_free(sslTask);
+        return NULL;
+    }
+    sslTask->consumed = JNI_FALSE;
+    return sslTask;
+}
+
+// TODO:
+// Call once the SSL object is freed!
+static void netty_boringssl_ssl_task_free(JNIEnv* e, netty_boringssl_ssl_task_t* sslTask) {
+    if (sslTask == NULL) {
+        return;
+    }
+
+    if (sslTask->task != NULL) {
+        // As we created a Global reference before we need to delete the reference as otherwise we will leak memory.
+        (*e)->DeleteGlobalRef(e, sslTask->task);
+        sslTask->task = NULL;
+    }
+
+    // The task was malloc'ed before, free it and clear it from the SSL storage.
+    OPENSSL_free(sslTask);
+}
+
 enum ssl_verify_result_t quic_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert) {
     enum ssl_verify_result_t ret = ssl_verify_invalid;
     jint result = X509_V_ERR_UNSPECIFIED;
@@ -189,6 +240,23 @@ enum ssl_verify_result_t quic_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_aler
         goto complete;
     }
 
+    netty_boringssl_ssl_task_t* ssl_task = (netty_boringssl_ssl_task_t*) SSL_get_ex_data(ssl, sslTaskIdx);
+    // Let's check if we retried the operation and so have stored a sslTask that runs the certificiate callback.
+    if (ssl_task != NULL) {
+        // Check if the task complete yet. If not the complete field will be still false.
+        if ((*e)->GetBooleanField(e, ssl_task->task, sslTaskComplete) == JNI_FALSE) {
+            // Not done yet, try again later.
+            ret = ssl_verify_retry;
+            goto complete;
+        }
+
+        // The task is complete, retrieve the return value that should be signaled back.
+        result = (*e)->GetIntField(e, ssl_task->task, sslTaskReturnValue);
+
+        SSL_set_ex_data(ssl, sslTaskIdx, NULL);
+        netty_boringssl_ssl_task_free(e, ssl_task);
+        goto complete;
+    }
     const STACK_OF(CRYPTO_BUFFER) *chain = SSL_get0_peer_certificates(ssl);
     if (chain == NULL) {
         goto complete;
@@ -203,13 +271,13 @@ enum ssl_verify_result_t quic_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_aler
     const char* authentication_method = NULL;
     STACK_OF(SSL_CIPHER) *ciphers = SSL_get_ciphers(ssl);
     if (ciphers == NULL || sk_SSL_CIPHER_num(ciphers) <= 0) {
-         // No cipher available so return UNKNOWN.
-         authentication_method = "UNKNOWN";
+        // No cipher available so return UNKNOWN.
+        authentication_method = "UNKNOWN";
     } else {
-         authentication_method = SSL_CIPHER_get_kx_name(sk_SSL_CIPHER_value(ciphers, 0));
-         if (authentication_method == NULL) {
-              authentication_method = "UNKNOWN";
-         }
+        authentication_method = SSL_CIPHER_get_kx_name(sk_SSL_CIPHER_value(ciphers, 0));
+        if (authentication_method == NULL) {
+            authentication_method = "UNKNOWN";
+        }
     }
 
     jstring authMethodString = (*e)->NewStringUTF(e, authentication_method);
@@ -217,27 +285,26 @@ enum ssl_verify_result_t quic_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_aler
         goto complete;
     }
 
-    // Execute the java callback
-    result = (*e)->CallIntMethod(e, verifyCallback, verifyCallbackMethod, (jlong)ssl, array, authMethodString);
+    jobject task = (*e)->NewObject(e, verifyTaskClass, verifyTaskClassInitMethod, (jlong) ssl, array, authMethodString, verifyCallback);
 
-    if ((*e)->ExceptionCheck(e) == JNI_TRUE) {
-        (*e)->ExceptionClear(e);
-        result = X509_V_ERR_UNSPECIFIED;
+    ssl_task = netty_boringssl_ssl_task_new(e, task);
+    if (ssl_task == NULL) {
         goto complete;
     }
 
-    int len = (*e)->GetArrayLength(e, array);
-    // If we failed to verify for an unknown reason (currently this happens if we can't find a common root) then we should
-    // fail with the same status as recommended in the OpenSSL docs https://www.openssl.org/docs/man1.0.2/ssl/SSL_set_verify.html
-    if (result == X509_V_ERR_UNSPECIFIED && len < sk_CRYPTO_BUFFER_num(chain)) {
-        result = X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY;
-    }
+    SSL_set_ex_data(ssl, sslTaskIdx, ssl_task);
+
+    // Signal back that we want to suspend the handshake.
+    ret = ssl_verify_retry;
+    goto complete;
 complete:
-    if (result == X509_V_OK) {
-        ret = ssl_verify_ok;
-    } else {
-        ret = ssl_verify_invalid;
-        *out_alert = SSL_alert_from_verify_result(result);
+    if (ret != ssl_verify_retry) {
+        if (result == X509_V_OK) {
+            ret = ssl_verify_ok;
+        } else {
+            ret = ssl_verify_invalid;
+            *out_alert = SSL_alert_from_verify_result(result);
+        }
     }
     return ret;
 }
@@ -260,71 +327,81 @@ static jbyteArray keyTypes(JNIEnv* e, SSL* ssl) {
 // See https://www.openssl.org/docs/man1.0.2/man3/SSL_set_cert_cb.html for return values.
 static int quic_certificate_cb(SSL* ssl, void* arg) {
     JNIEnv *e = NULL;
-    CRYPTO_BUFFER** certs = NULL;
-    jlong* elements = NULL;
-    int ret = 0;
-    int free = 0;
-
     if (quic_get_java_env(&e) != JNI_OK) {
-        goto done;
+        return 0;
     }
 
-    jobjectArray authMethods = NULL;
-    jobjectArray issuers = NULL;
-    jbyteArray types = NULL;
-    if (SSL_is_server(ssl) == 1) {
-        const STACK_OF(SSL_CIPHER) *ciphers = SSL_get_ciphers(ssl);
-        int len = sk_SSL_CIPHER_num(ciphers);
-        authMethods = (*e)->NewObjectArray(e, len, stringClass, NULL);
-        if (authMethods == NULL) {
-            goto done;
-        }
+    netty_boringssl_ssl_task_t* ssl_task = (netty_boringssl_ssl_task_t*) SSL_get_ex_data(ssl, sslTaskIdx);
 
-        for (int i = 0; i < len; i++) {
-            jstring methodString = (*e)->NewStringUTF(e, SSL_CIPHER_get_kx_name(sk_SSL_CIPHER_value(ciphers, i)));
-            if (methodString == NULL) {
-                // Out of memory
-                goto done;
+    // Let's check if we retried the operation and so have stored a sslTask that runs the certificiate callback.
+    if (ssl_task == NULL) {
+        jobjectArray authMethods = NULL;
+        jobjectArray issuers = NULL;
+        jbyteArray types = NULL;
+        if (SSL_is_server(ssl) == 1) {
+            const STACK_OF(SSL_CIPHER) *ciphers = SSL_get_ciphers(ssl);
+            int len = sk_SSL_CIPHER_num(ciphers);
+            authMethods = (*e)->NewObjectArray(e, len, stringClass, NULL);
+            if (authMethods == NULL) {
+                return 0;
             }
-            (*e)->SetObjectArrayElement(e, authMethods, i, methodString);
+
+            for (int i = 0; i < len; i++) {
+                jstring methodString = (*e)->NewStringUTF(e, SSL_CIPHER_get_kx_name(sk_SSL_CIPHER_value(ciphers, i)));
+                if (methodString == NULL) {
+                    // Out of memory
+                    return 0;
+                }
+                (*e)->SetObjectArrayElement(e, authMethods, i, methodString);
+            }
+
+            // TODO: Consider filling these somehow.
+            types = NULL;
+            issuers = NULL;
+        } else {
+            authMethods = NULL;
+            types = keyTypes(e, ssl);
+            issuers = stackToArray(e, SSL_get0_server_requested_CAs(ssl), 0);
         }
 
-        // TODO: Consider filling these somehow.
-        types = NULL;
-        issuers = NULL;
-    } else {
-        authMethods = NULL;
-        types = keyTypes(e, ssl);
-        issuers = stackToArray(e, SSL_get0_server_requested_CAs(ssl), 0);
+        // Lets create the CertificateCallbackTask and store it on the SSL object. We then later retrieve it via
+        // SSL.getTask(ssl) and run it.
+        jobject task = (*e)->NewObject(e, certificateTaskClass, certificateTaskClassInitMethod, (jlong) ssl, types, issuers, authMethods, arg);
+
+        if ((ssl_task = netty_boringssl_ssl_task_new(e, task)) == NULL) {
+            return 0;
+        }
+
+        SSL_set_ex_data(ssl, sslTaskIdx, ssl_task);
+
+        // Signal back that we want to suspend the handshake.
+        return -1;
     }
 
-    // Execute the java callback
-    jlongArray result = (*e)->CallObjectMethod(e, arg, certificateCallbackMethod, (jlong) ssl, types, issuers, authMethods);
-
-    // Check if java threw an exception and if so signal back that we should not continue with the handshake.
-    if ((*e)->ExceptionCheck(e) == JNI_TRUE) {
-        (*e)->ExceptionClear(e);
-        goto done;
-    }
-    if (result == NULL) {
-        goto done;
+    // Check if the task complete yet. If not the complete field will be still false.
+    if ((*e)->GetBooleanField(e, ssl_task->task, sslTaskComplete) == JNI_FALSE) {
+        // Not done yet, try again later.
+        return -1;
     }
 
-    int arrayLen = (*e)->GetArrayLength(e, result);
-    if (arrayLen != 3) {
-        goto done;
+    // The task is complete, retrieve the return value that should be signaled back.
+    jint retValue = (*e)->GetIntField(e, ssl_task->task, sslTaskReturnValue);
+    if (retValue == 0) {
+        return 0;
     }
 
-    elements = (*e)->GetLongArrayElements(e, result, NULL);
-    EVP_PKEY* pkey = (EVP_PKEY *) elements[0];
-    const STACK_OF(CRYPTO_BUFFER) *cchain = (STACK_OF(CRYPTO_BUFFER) *) elements[1];
-    free = elements[2];
+    int ret = 0;
+    EVP_PKEY* pkey = (EVP_PKEY *) (*e)->GetLongField(e, ssl_task->task, certificateTaskClassKeyField);
+    const STACK_OF(CRYPTO_BUFFER) *cchain = (STACK_OF(CRYPTO_BUFFER) *) (*e)->GetLongField(e, ssl_task->task, certificateTaskClassChainField);
+
+    SSL_set_ex_data(ssl, sslTaskIdx, NULL);
+    netty_boringssl_ssl_task_free(e, ssl_task);
 
     int numCerts = sk_CRYPTO_BUFFER_num(cchain);
     if (numCerts == 0) {
         goto done;
     }
-    certs = OPENSSL_malloc(sizeof(CRYPTO_BUFFER*) * numCerts);
+    CRYPTO_BUFFER** certs = OPENSSL_malloc(sizeof(CRYPTO_BUFFER*) * numCerts);
 
     if (certs == NULL) {
         goto done;
@@ -338,12 +415,9 @@ static int quic_certificate_cb(SSL* ssl, void* arg) {
         ret = 1;
     }
 done:
-    if (elements != NULL) {
-        (*e)->ReleaseLongArrayElements(e, result, elements, 0);
-    }
     OPENSSL_free(certs);
-    if (free == 1) {
-        EVP_PKEY_free(pkey);
+    EVP_PKEY_free(pkey);
+    if (cchain != NULL) {
         sk_CRYPTO_BUFFER_pop_free((STACK_OF(CRYPTO_BUFFER) *) cchain, CRYPTO_BUFFER_free);
     }
     return ret;
@@ -870,6 +944,25 @@ void netty_boringssl_SSL_free(JNIEnv* env, jclass clazz, jlong ssl) {
     SSL_free((SSL *) ssl);
 }
 
+jobject netty_boringssl_SSL_getTask(JNIEnv* env, jclass clazz, jlong ssl) {
+    netty_boringssl_ssl_task_t* ssl_task = SSL_get_ex_data((SSL*) ssl, sslTaskIdx);
+
+    if (ssl_task == NULL || ssl_task->consumed == JNI_TRUE) {
+        // Either no task was produced or it was already consumed by SSL.getTask(...).
+        return NULL;
+    }
+    ssl_task->consumed = JNI_TRUE;
+    return ssl_task->task;
+}
+
+void netty_boringssl_SSL_cleanup(JNIEnv* env, jclass clazz, jlong ssl) {
+    netty_boringssl_ssl_task_t* sslTask = SSL_get_ex_data((SSL *) ssl, sslTaskIdx);
+    if (sslTask != NULL) {
+        SSL_set_ex_data((SSL *) ssl, sslTaskIdx, NULL);
+        netty_boringssl_ssl_task_free(env, sslTask);
+    }
+}
+
 int netty_boringssl_password_callback(char *buf, int bufsiz, int verify, void *cb) {
     char *password = (char *) cb;
     if (password == NULL) {
@@ -936,7 +1029,6 @@ jstring netty_boringssl_ERR_last_error(JNIEnv* env, jclass clazz) {
     return (*env)->NewStringUTF(env, buf);
 }
 
-
 // JNI Registered Methods End
 
 // JNI Method Registration Table Begin
@@ -960,6 +1052,8 @@ static const JNINativeMethod fixed_method_table[] = {
   { "SSLContext_set_early_data_enabled", "(JZ)V", (void *) netty_boringssl_SSLContext_set_early_data_enabled },
   { "SSL_new0", "(JZLjava/lang/String;)J", (void *) netty_boringssl_SSL_new0 },
   { "SSL_free", "(J)V", (void *) netty_boringssl_SSL_free },
+  { "SSL_getTask", "(J)Ljava/lang/Runnable;", (void *) netty_boringssl_SSL_getTask },
+  { "SSL_cleanup", "(J)V", (void *) netty_boringssl_SSL_cleanup },
   { "EVP_PKEY_parse", "([BLjava/lang/String;)J", (void *) netty_boringssl_EVP_PKEY_parse },
   { "EVP_PKEY_free", "(J)V", (void *) netty_boringssl_EVP_PKEY_free },
   { "CRYPTO_BUFFER_stack_new", "(J[[B)J", (void *) netty_boringssl_CRYPTO_BUFFER_stack_new },
@@ -971,6 +1065,18 @@ static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(
 
 // JNI Method Registration Table End
 
+static void unload_all_classes(JNIEnv* env) {
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, byteArrayClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, stringClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, sslTaskClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, certificateTaskClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, verifyTaskClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, handshakeCompleteCallbackClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, servernameCallbackClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, keylogCallbackClass);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, sessionCallbackClass);
+}
+
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
 //            Quiche to reflect that.
 jint netty_boringssl_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
@@ -978,6 +1084,7 @@ jint netty_boringssl_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int staticallyRegistered = 0;
     int nativeRegistered = 0;
     char* name = NULL;
+    char* combinedName = NULL;
 
     // We must register the statically referenced methods first!
     if (netty_jni_util_register_natives(env,
@@ -999,17 +1106,33 @@ jint netty_boringssl_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     nativeRegistered = 1;
     // Initialize this module
 
-
     NETTY_JNI_UTIL_LOAD_CLASS(env, byteArrayClass, "[B", done);
     NETTY_JNI_UTIL_LOAD_CLASS(env, stringClass, "java/lang/String", done);
 
-    NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLCertificateCallback", name, done);
-    NETTY_JNI_UTIL_LOAD_CLASS(env, certificateCallbackClass, name, done);
-    NETTY_JNI_UTIL_GET_METHOD(env, certificateCallbackClass, certificateCallbackMethod, "handle", "(J[B[[B[Ljava/lang/String;)[J", done);
+    NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLTask", name, done);
+    NETTY_JNI_UTIL_LOAD_CLASS(env, sslTaskClass, name, done);
+    NETTY_JNI_UTIL_GET_FIELD(env, sslTaskClass, sslTaskReturnValue, "returnValue", "I", done);
+    NETTY_JNI_UTIL_GET_FIELD(env, sslTaskClass, sslTaskComplete, "complete", "Z", done);
 
-    NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLCertificateVerifyCallback", name, done);
-    NETTY_JNI_UTIL_LOAD_CLASS(env, verifyCallbackClass, name, done);
-    NETTY_JNI_UTIL_GET_METHOD(env, verifyCallbackClass, verifyCallbackMethod, "verify", "(J[[BLjava/lang/String;)I", done);
+    NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLCertificateCallbackTask", name, done);
+    NETTY_JNI_UTIL_LOAD_CLASS(env, certificateTaskClass, name, done);
+    NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLCertificateCallback;)V", name, done);
+    NETTY_JNI_UTIL_PREPEND("(J[B[[B[Ljava/lang/String;L", name, combinedName, done);
+    free(name);
+    name = combinedName;
+    combinedName = NULL;
+    NETTY_JNI_UTIL_GET_METHOD(env, certificateTaskClass, certificateTaskClassInitMethod, "<init>", name, done);
+    NETTY_JNI_UTIL_GET_FIELD(env, certificateTaskClass, certificateTaskClassChainField, "chain", "J", done);
+    NETTY_JNI_UTIL_GET_FIELD(env, certificateTaskClass, certificateTaskClassKeyField, "key", "J", done);
+
+    NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLCertificateVerifyCallbackTask", name, done);
+    NETTY_JNI_UTIL_LOAD_CLASS(env, verifyTaskClass, name, done);
+    NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLCertificateVerifyCallback;)V", name, done);
+    NETTY_JNI_UTIL_PREPEND("(J[[BLjava/lang/String;L", name, combinedName, done);
+    free(name);
+    name = combinedName;
+    combinedName = NULL;
+    NETTY_JNI_UTIL_GET_METHOD(env, verifyTaskClass, verifyTaskClassInitMethod, "<init>", name, done);
 
     NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/incubator/codec/quic/BoringSSLHandshakeCompleteCallback", name, done);
     NETTY_JNI_UTIL_LOAD_CLASS(env, handshakeCompleteCallbackClass, name, done);
@@ -1033,6 +1156,7 @@ jint netty_boringssl_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     servernameCallbackIdx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
     keylogCallbackIdx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
     sessionCallbackIdx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+    sslTaskIdx = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
 
     alpn_data_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
     crypto_buffer_pool_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
@@ -1046,26 +1170,13 @@ done:
             netty_jni_util_unregister_natives(env, packagePrefix, CLASSNAME);
         }
 
-        NETTY_JNI_UTIL_UNLOAD_CLASS(env, byteArrayClass);
-        NETTY_JNI_UTIL_UNLOAD_CLASS(env, stringClass);
-        NETTY_JNI_UTIL_UNLOAD_CLASS(env, certificateCallbackClass);
-        NETTY_JNI_UTIL_UNLOAD_CLASS(env, verifyCallbackClass);
-        NETTY_JNI_UTIL_UNLOAD_CLASS(env, handshakeCompleteCallbackClass);
-        NETTY_JNI_UTIL_UNLOAD_CLASS(env, servernameCallbackClass);
-        NETTY_JNI_UTIL_UNLOAD_CLASS(env, keylogCallbackClass);
-        NETTY_JNI_UTIL_UNLOAD_CLASS(env, sessionCallbackClass);
+        unload_all_classes(env);
     }
     return ret;
 }
 
 void netty_boringssl_JNI_OnUnload(JNIEnv* env, const char* packagePrefix) {
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, byteArrayClass);
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, certificateCallbackClass);
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, verifyCallbackClass);
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, handshakeCompleteCallbackClass);
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, servernameCallbackClass);
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, keylogCallbackClass);
-    NETTY_JNI_UTIL_UNLOAD_CLASS(env, sessionCallbackClass);
+    unload_all_classes(env);
 
     netty_jni_util_unregister_natives(env, packagePrefix, STATICALLY_CLASSNAME);
     netty_jni_util_unregister_natives(env, packagePrefix, CLASSNAME);

--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -35,16 +35,16 @@
 #define ERR_LEN 256
 
 static jclass sslTaskClass = NULL;
-static jfieldID  sslTaskReturnValue;
-static jfieldID  sslTaskComplete;
+static jfieldID sslTaskReturnValue;
+static jfieldID sslTaskComplete;
 
 static jclass verifyTaskClass = NULL;
 static jmethodID verifyTaskClassInitMethod = NULL;
 
 static jclass certificateTaskClass = NULL;
 static jmethodID certificateTaskClassInitMethod = NULL;
-static jfieldID  certificateTaskClassChainField;
-static jfieldID  certificateTaskClassKeyField;
+static jfieldID certificateTaskClassChainField;
+static jfieldID certificateTaskClassKeyField;
 
 static jclass handshakeCompleteCallbackClass = NULL;
 static jmethodID handshakeCompleteCallbackMethod = NULL;
@@ -204,8 +204,6 @@ static netty_boringssl_ssl_task_t* netty_boringssl_ssl_task_new(JNIEnv* e, jobje
     return sslTask;
 }
 
-// TODO:
-// Call once the SSL object is freed!
 static void netty_boringssl_ssl_task_free(JNIEnv* e, netty_boringssl_ssl_task_t* sslTask) {
     if (sslTask == NULL) {
         return;

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
@@ -15,14 +15,40 @@
  */
 package io.netty.incubator.codec.quic;
 
+import io.netty.util.concurrent.ImmediateExecutor;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 @Timeout(10)
 public abstract class AbstractQuicTest {
+    private static final Executor[] executors = new Executor[] {
+            ImmediateExecutor.INSTANCE,
+            Executors.newCachedThreadPool()
+    };
 
     @BeforeAll
     public static void ensureAvailability() {
         Quic.ensureAvailability();
+    }
+
+    @AfterAll
+    public static void shutdownExecutor() {
+        for (Executor executor: executors) {
+            if (executor instanceof ExecutorService) {
+                ((ExecutorService) executor).shutdown();
+            }
+        }
+    }
+
+    static Executor[] sslTaskExecutors() {
+        return new Executor[] {
+                ImmediateExecutor.INSTANCE,
+                Executors.newCachedThreadPool()
+        };
     }
 }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelEchoTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelEchoTest.java
@@ -30,6 +30,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.ImmediateExecutor;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -118,7 +119,7 @@ public class QuicChannelEchoTest extends AbstractQuicTest {
         final EchoHandler sh = new EchoHandler(true, autoRead, allocator);
         final EchoHandler ch = new EchoHandler(false, autoRead, allocator);
         AtomicReference<List<ChannelFuture>> writeFutures = new AtomicReference<>();
-        Channel server = QuicTestUtils.newServer(new ChannelInboundHandlerAdapter() {
+        Channel server = QuicTestUtils.newServer(ImmediateExecutor.INSTANCE, new ChannelInboundHandlerAdapter() {
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
                 setAllocator(ctx.channel(), allocator);
@@ -145,7 +146,7 @@ public class QuicChannelEchoTest extends AbstractQuicTest {
         }, sh);
         setAllocator(server, allocator);
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
-        Channel channel = QuicTestUtils.newClient();
+        Channel channel = QuicTestUtils.newClient(ImmediateExecutor.INSTANCE);
         QuicChannel quicChannel = null;
         try {
             quicChannel = QuicChannel.newBootstrap(channel)
@@ -235,10 +236,10 @@ public class QuicChannelEchoTest extends AbstractQuicTest {
             }
         };
 
-        Channel server = QuicTestUtils.newServer(serverHandler, sh);
+        Channel server = QuicTestUtils.newServer(ImmediateExecutor.INSTANCE, serverHandler, sh);
         setAllocator(server, allocator);
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
-        Channel channel = QuicTestUtils.newClient();
+        Channel channel = QuicTestUtils.newClient(ImmediateExecutor.INSTANCE);
         QuicChannel quicChannel = null;
         try {
             QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler() {

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicCodecBuilderTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicCodecBuilderTest.java
@@ -16,9 +16,11 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.channel.ChannelHandler;
+import io.netty.util.concurrent.ImmediateExecutor;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,6 +63,8 @@ class QuicCodecBuilderTest {
             field.setInt(builder, -1);
         } else if (byte[].class == clazz) {
             field.set(builder, new byte[16]);
+        } else if (Executor.class == clazz) {
+            field.set(builder, ImmediateExecutor.INSTANCE);
         } else {
             throw new IllegalArgumentException("Unknown field type " + clazz);
         }
@@ -86,6 +90,7 @@ class QuicCodecBuilderTest {
         protected ChannelHandler build(
                 QuicheConfig config,
                 Function<QuicChannel, ? extends QuicSslEngine> sslContextProvider,
+                Executor sslTaskExecutor,
                 int localConnIdLength,
                 FlushStrategy flushStrategy) {
             // no-op

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
@@ -23,8 +23,10 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,8 +37,9 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class QuicConnectionStatsTest extends AbstractQuicTest {
 
-    @Test
-    public void testStatsAreCollected() throws Throwable {
+    @ParameterizedTest
+    @MethodSource("sslTaskExecutors")
+    public void testStatsAreCollected(Executor executor) throws Throwable {
         Channel server = null;
         Channel channel = null;
         AtomicInteger counter = new AtomicInteger();
@@ -63,7 +66,7 @@ public class QuicConnectionStatsTest extends AbstractQuicTest {
         };
         QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
         try {
-            server = QuicTestUtils.newServer(serverHandler, new ChannelInboundHandlerAdapter() {
+            server = QuicTestUtils.newServer(executor, serverHandler, new ChannelInboundHandlerAdapter() {
 
                 @Override
                 public void channelActive(ChannelHandlerContext ctx) {
@@ -81,7 +84,7 @@ public class QuicConnectionStatsTest extends AbstractQuicTest {
                     return true;
                 }
             });
-            channel = QuicTestUtils.newClient();
+            channel = QuicTestUtils.newClient(executor);
 
             QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
                     .handler(clientHandler)

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicReadableTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicReadableTest.java
@@ -20,18 +20,21 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class QuicReadableTest extends AbstractQuicTest {
 
-    @Test
-    public void testCorrectlyHandleReadableStreams() throws Throwable  {
+    @ParameterizedTest
+    @MethodSource("sslTaskExecutors")
+    public void testCorrectlyHandleReadableStreams(Executor executor) throws Throwable  {
         int numOfStreams = 1024;
         int readStreams = numOfStreams / 2;
         // We do write longs.
@@ -43,7 +46,7 @@ public class QuicReadableTest extends AbstractQuicTest {
 
         QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler();
         Channel server = QuicTestUtils.newServer(
-                QuicTestUtils.newQuicServerBuilder().initialMaxStreamsBidirectional(5000),
+                QuicTestUtils.newQuicServerBuilder(executor).initialMaxStreamsBidirectional(5000),
                 InsecureQuicTokenHandler.INSTANCE,
                 serverHandler, new ChannelInboundHandlerAdapter() {
                     private int counter;
@@ -80,7 +83,7 @@ public class QuicReadableTest extends AbstractQuicTest {
                         return true;
                     }
                 });
-        Channel channel = QuicTestUtils.newClient();
+        Channel channel = QuicTestUtils.newClient(executor);
         QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
         ByteBuf data = Unpooled.directBuffer().writeLong(8);
         try {

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
@@ -25,42 +25,48 @@ import io.netty.util.ReferenceCountUtil;
 
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 public class QuicStreamChannelCloseTest extends AbstractQuicTest {
 
-    @Test
-    public void testCloseFromServerWhileInActiveUnidirectional() throws Throwable {
-        testCloseFromServerWhileInActive(QuicStreamType.UNIDIRECTIONAL, false);
+    @ParameterizedTest
+    @MethodSource("sslTaskExecutors")
+    public void testCloseFromServerWhileInActiveUnidirectional(Executor executor) throws Throwable {
+        testCloseFromServerWhileInActive(executor, QuicStreamType.UNIDIRECTIONAL, false);
     }
 
-    @Test
-    public void testCloseFromServerWhileInActiveBidirectional() throws Throwable {
-        testCloseFromServerWhileInActive(QuicStreamType.BIDIRECTIONAL, false);
+    @ParameterizedTest
+    @MethodSource("sslTaskExecutors")
+    public void testCloseFromServerWhileInActiveBidirectional(Executor executor) throws Throwable {
+        testCloseFromServerWhileInActive(executor, QuicStreamType.BIDIRECTIONAL, false);
     }
 
-    @Test
-    public void testHalfCloseFromServerWhileInActiveUnidirectional() throws Throwable {
-        testCloseFromServerWhileInActive(QuicStreamType.UNIDIRECTIONAL, true);
+    @ParameterizedTest
+    @MethodSource("sslTaskExecutors")
+    public void testHalfCloseFromServerWhileInActiveUnidirectional(Executor executor) throws Throwable {
+        testCloseFromServerWhileInActive(executor, QuicStreamType.UNIDIRECTIONAL, true);
     }
 
-    @Test
-    public void testHalfCloseFromServerWhileInActiveBidirectional() throws Throwable {
-        testCloseFromServerWhileInActive(QuicStreamType.BIDIRECTIONAL, true);
+    @ParameterizedTest
+    @MethodSource("sslTaskExecutors")
+    public void testHalfCloseFromServerWhileInActiveBidirectional(Executor executor) throws Throwable {
+        testCloseFromServerWhileInActive(executor, QuicStreamType.BIDIRECTIONAL, true);
     }
 
-    private static void testCloseFromServerWhileInActive(QuicStreamType type,
+    private static void testCloseFromServerWhileInActive(Executor executor, QuicStreamType type,
                                                          boolean halfClose) throws Throwable {
         Channel server = null;
         Channel channel = null;
         try {
             final Promise<Channel> streamPromise = ImmediateEventExecutor.INSTANCE.newPromise();
             QuicChannelValidationHandler serverHandler = new StreamCreationHandler(type, halfClose, streamPromise);
-            server = QuicTestUtils.newServer(serverHandler,
+            server = QuicTestUtils.newServer(executor, serverHandler,
                     new ChannelInboundHandlerAdapter());
-            channel = QuicTestUtils.newClient();
+            channel = QuicTestUtils.newClient(executor);
 
             QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
 
@@ -89,35 +95,39 @@ public class QuicStreamChannelCloseTest extends AbstractQuicTest {
         }
     }
 
-    @Test
-    public void testCloseFromClientWhileInActiveUnidirectional() throws Throwable {
-        testCloseFromClientWhileInActive(QuicStreamType.UNIDIRECTIONAL, false);
+    @ParameterizedTest
+    @MethodSource("sslTaskExecutors")
+    public void testCloseFromClientWhileInActiveUnidirectional(Executor executor) throws Throwable {
+        testCloseFromClientWhileInActive(executor, QuicStreamType.UNIDIRECTIONAL, false);
     }
 
-    @Test
-    public void testCloseFromClientWhileInActiveBidirectional() throws Throwable {
-        testCloseFromClientWhileInActive(QuicStreamType.BIDIRECTIONAL, false);
+    @ParameterizedTest
+    @MethodSource("sslTaskExecutors")
+    public void testCloseFromClientWhileInActiveBidirectional(Executor executor) throws Throwable {
+        testCloseFromClientWhileInActive(executor, QuicStreamType.BIDIRECTIONAL, false);
     }
 
-    @Test
-    public void testHalfCloseFromClientWhileInActiveUnidirectional() throws Throwable {
-        testCloseFromClientWhileInActive(QuicStreamType.UNIDIRECTIONAL, true);
+    @ParameterizedTest
+    @MethodSource("sslTaskExecutors")
+    public void testHalfCloseFromClientWhileInActiveUnidirectional(Executor executor) throws Throwable {
+        testCloseFromClientWhileInActive(executor, QuicStreamType.UNIDIRECTIONAL, true);
     }
 
-    @Test
-    public void testHalfCloseFromClientWhileInActiveBidirectional() throws Throwable {
-        testCloseFromClientWhileInActive(QuicStreamType.BIDIRECTIONAL, true);
+    @ParameterizedTest
+    @MethodSource("sslTaskExecutors")
+    public void testHalfCloseFromClientWhileInActiveBidirectional(Executor executor) throws Throwable {
+        testCloseFromClientWhileInActive(executor, QuicStreamType.BIDIRECTIONAL, true);
     }
 
-    private static void testCloseFromClientWhileInActive(QuicStreamType type,
+    private static void testCloseFromClientWhileInActive(Executor executor, QuicStreamType type,
                                                          boolean halfClose) throws Throwable {
         Channel server = null;
         Channel channel = null;
         try {
             final Promise<Channel> streamPromise = ImmediateEventExecutor.INSTANCE.newPromise();
             QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler();
-            server = QuicTestUtils.newServer(serverHandler, new StreamHandler());
-            channel = QuicTestUtils.newClient();
+            server = QuicTestUtils.newServer(executor, serverHandler, new StreamHandler());
+            channel = QuicTestUtils.newClient(executor);
 
             StreamCreationHandler creationHandler = new StreamCreationHandler(type, halfClose, streamPromise);
             QuicChannel quicChannel = QuicChannel.newBootstrap(channel)

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
@@ -20,10 +20,12 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.util.AttributeKey;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -32,13 +34,14 @@ public class QuicStreamChannelCreationTest extends AbstractQuicTest {
     private static final AttributeKey<String> ATTRIBUTE_KEY = AttributeKey.newInstance("testKey");
     private static final String ATTRIBUTE_VALUE = "Test";
 
-    @Test
-    public void testCreateStream() throws Throwable {
+    @ParameterizedTest
+    @MethodSource("sslTaskExecutors")
+    public void testCreateStream(Executor executor) throws Throwable {
         QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler();
-        Channel server = QuicTestUtils.newServer(serverHandler,
+        Channel server = QuicTestUtils.newServer(executor, serverHandler,
                 new ChannelInboundHandlerAdapter());
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
-        Channel channel = QuicTestUtils.newClient();
+        Channel channel = QuicTestUtils.newClient(executor);
         QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
 
         try {
@@ -72,13 +75,14 @@ public class QuicStreamChannelCreationTest extends AbstractQuicTest {
         }
     }
 
-    @Test
-    public void testCreateStreamViaBootstrap() throws Throwable {
+    @ParameterizedTest
+    @MethodSource("sslTaskExecutors")
+    public void testCreateStreamViaBootstrap(Executor executor) throws Throwable {
         QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler();
-        Channel server = QuicTestUtils.newServer(serverHandler,
+        Channel server = QuicTestUtils.newServer(executor, serverHandler,
                 new ChannelInboundHandlerAdapter());
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
-        Channel channel = QuicTestUtils.newClient();
+        Channel channel = QuicTestUtils.newClient(executor);
         QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
 
         try {

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
@@ -20,9 +20,11 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -31,25 +33,27 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QuicStreamFrameTest extends AbstractQuicTest {
 
-    @Test
-    public void testCloseHalfClosureUnidirectional() throws Throwable {
-        testCloseHalfClosure(QuicStreamType.UNIDIRECTIONAL);
+    @ParameterizedTest
+    @MethodSource("sslTaskExecutors")
+    public void testCloseHalfClosureUnidirectional(Executor executor) throws Throwable {
+        testCloseHalfClosure(executor, QuicStreamType.UNIDIRECTIONAL);
     }
 
-    @Test
-    public void testCloseHalfClosureBidirectional() throws Throwable {
-        testCloseHalfClosure(QuicStreamType.BIDIRECTIONAL);
+    @ParameterizedTest
+    @MethodSource("sslTaskExecutors")
+    public void testCloseHalfClosureBidirectional(Executor executor) throws Throwable {
+        testCloseHalfClosure(executor, QuicStreamType.BIDIRECTIONAL);
     }
 
-    private static void testCloseHalfClosure(QuicStreamType type) throws Throwable {
+    private static void testCloseHalfClosure(Executor executor, QuicStreamType type) throws Throwable {
         Channel server = null;
         Channel channel = null;
         QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler();
         QuicChannelValidationHandler clientHandler = new StreamCreationHandler(type);
         try {
             StreamHandler handler = new StreamHandler();
-            server = QuicTestUtils.newServer(serverHandler, handler);
-            channel = QuicTestUtils.newClient();
+            server = QuicTestUtils.newServer(executor, serverHandler, handler);
+            channel = QuicTestUtils.newClient(executor);
             QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicheQuicClientCodecTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicheQuicClientCodecTest.java
@@ -15,9 +15,11 @@
  */
 package io.netty.incubator.codec.quic;
 
+import io.netty.util.concurrent.ImmediateExecutor;
+
 public class QuicheQuicClientCodecTest extends QuicheQuicCodecTest<QuicClientCodecBuilder> {
     @Override
     protected QuicClientCodecBuilder newCodecBuilder() {
-        return QuicTestUtils.newQuicClientBuilder();
+        return QuicTestUtils.newQuicClientBuilder(ImmediateExecutor.INSTANCE);
     }
 }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicheQuicServerCodecTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicheQuicServerCodecTest.java
@@ -16,11 +16,12 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.concurrent.ImmediateExecutor;
 
 public class QuicheQuicServerCodecTest extends QuicheQuicCodecTest<QuicServerCodecBuilder> {
     @Override
     protected QuicServerCodecBuilder newCodecBuilder() {
-        return QuicTestUtils.newQuicServerBuilder()
+        return QuicTestUtils.newQuicServerBuilder(ImmediateExecutor.INSTANCE)
                 .streamHandler(new ChannelInboundHandlerAdapter())
                 .tokenHandler(InsecureQuicTokenHandler.INSTANCE);
     }


### PR DESCRIPTION
Motivation:

It is sometimes benefitial to run specific tasks on a different thread then the EventLoop. For example certificate verification / retrieval might take some time and so block the EventLoop

Modifications:

Be able to run these tasks on a different Executor.

Result:

Allow the same pattern as we do with our native SSL impl in netty itself