### PR TITLE
Ensure all global references are deleted when SSL_CTX creation fails

### DIFF
--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -847,8 +847,17 @@ error:
     if (certificateCallbackRef != NULL) {
         (*env)->DeleteGlobalRef(env, certificateCallbackRef);
     }
-    if (certificateCallbackRef != NULL) {
-        (*env)->DeleteGlobalRef(env, certificateCallbackRef);
+    if (verifyCallbackRef != NULL) {
+        (*env)->DeleteGlobalRef(env, verifyCallbackRef);
+    }
+    if (servernameCallbackRef != NULL) {
+        (*env)->DeleteGlobalRef(env, servernameCallbackRef);
+    }
+    if (keylogCallbackRef != NULL) {
+        (*env)->DeleteGlobalRef(env, keylogCallbackRef);
+    }
+    if (sessionCallbackRef != NULL) {
+        (*env)->DeleteGlobalRef(env, sessionCallbackRef);
     }
     return -1;
 }


### PR DESCRIPTION
Motivation:

To prevent memory leaks we need to ensure we delete all global references when we failed to create the SSL_CTX.

Modifications:

Add missing deletion code for a few references

Result:

No more memory leak when SSL_CTX creation fails