### PR TITLE
Fix race when offloading tasks

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -1323,19 +1323,21 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                                     try {
                                         finalTask.run();
                                     } finally {
-                                        Runnable nextTask = connection.sslTask();
-                                        // Consume all tasks before moving back to the EventLoop.
-                                        if (nextTask == null) {
-                                            // Move back to the EventLoop.
-                                            eventLoop().execute(() -> {
-                                                // Call connection send to continue handshake if needed.
-                                                if (connectionSend()) {
-                                                    forceFlushParent();
+                                        // Move back to the EventLoop.
+                                        eventLoop().execute(() -> {
+                                            if (connection != null) {
+                                                Runnable nextTask = connection.sslTask();
+                                                // Consume all tasks before moving back to the EventLoop.
+                                                if (nextTask == null) {
+                                                    // Call connection send to continue handshake if needed.
+                                                    if (connectionSend()) {
+                                                        forceFlushParent();
+                                                    }
+                                                } else {
+                                                    sslTaskExecutor.execute(nextTask);
                                                 }
-                                            });
-                                        } else {
-                                            sslTaskExecutor.execute(nextTask);
-                                        }
+                                            }
+                                        });
                                     }
                                 });
                             }


### PR DESCRIPTION
Motivation:

We need to ensure we bounce back to the EventLoop before trying to access the connection as otherwise we might get into concurrency issues

Modifications:

Correctly schedule to the EventLoop before trying to access connection

Result:

No more race which could lead to for example NPEs.