### PR TITLE
Close the channel when there is a TLS / CRYPTO failure

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -710,6 +710,10 @@ final class Quiche {
         return reason;
     }
 
+    static boolean shouldClose(int res)  {
+        return res == Quiche.QUICHE_ERR_CRYPTO_FAIL || res == Quiche.QUICHE_ERR_TLS_FAIL;
+    }
+
     static boolean throwIfError(int res) throws Exception {
         if (res < 0) {
              if (res == Quiche.QUICHE_ERR_DONE) {


### PR DESCRIPTION
Motivation:

Let's ensure we close the connection when there is a TLS / CRYPTO failure as we cant recover anyway.

Modifications:

Close the QuicChannel if we see a TLS / CRYPTO failure

Result:

Not depend on the timeout to close the channel