### PR TITLE
Correctly also run SSL tasks when produced while sending data

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
@@ -110,10 +110,12 @@ final class QuicheQuicConnection {
         if (task == null) {
             return null;
         }
+
         return () -> {
             if (connection == -1) {
                 return;
             }
+
             task.run();
         };
     }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
@@ -46,8 +46,7 @@ public abstract class AbstractQuicTest {
     public static void createExecutors() {
         executors = new Executor[] {
                 ImmediateExecutor.INSTANCE,
-                // TODO: Investigate
-                //Executors.newCachedThreadPool()
+                Executors.newCachedThreadPool()
         };
     }
 


### PR DESCRIPTION
Motivation:

We also need to ensure we run all SSL tasks when sending data as otherwise we might stale.

Modifications:

- Correctly run all tasks in all cases
- Reenable usage of executor during tests

Result:

Correctly handling tasks offloading for all cases