### PR TITLE
Update quiche to latest version

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -57,7 +57,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>92e2db1ec430a8e3fb62ea4b22dd0fba9dc20fda</quicheCommitSha>
+    <quicheCommitSha>24a959abf115923910ce18985aa199d85fb602d7</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />


### PR DESCRIPTION
Motivation:

A new version of quiche is out.

Modifications:

Upgrade to latest quiche version

Result:

Bugfixes related to SSL errors