### PR TITLE
Seperate deploy from close / release

### DIFF
--- a/scripts/finish_release.sh
+++ b/scripts/finish_release.sh
@@ -31,7 +31,6 @@ git checkout "$2"
 export JAVA_HOME="$JAVA8_HOME"
 
 ./mvnw -Psonatype-oss-release,"$CROSS_COMPILE_PROFILE" clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
-
-./mvnw -Psonatype-oss-release clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy org.sonatype.plugins:nexus-staging-maven-plugin:rc-close  org.sonatype.plugins:nexus-staging-maven-plugin:rc-release -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true -DstagingProgressTimeoutMinutes=10
-
+./mvnw -Psonatype-oss-release clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true -DstagingProgressTimeoutMinutes=10
+./mvnw -Psonatype-oss-release org.sonatype.plugins:nexus-staging-maven-plugin:rc-close  org.sonatype.plugins:nexus-staging-maven-plugin:rc-release -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true -DstagingProgressTimeoutMinutes=10
 git checkout "$BRANCH"


### PR DESCRIPTION
Motivation:

Let's seperate the build steps when finish the release

Modifications:

Do the close / release in an extra step

Result:

Cleaner release script