### PR TITLE
Update to latest java8 release

### DIFF
--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-quic-centos6:centos-6-1.8
     build:
       args:
-        java_version : "8.0.322-zulu"
+        java_version : "8.0.352-zulu"
 
   build:
     image: netty-codec-quic-centos6:centos-6-1.8


### PR DESCRIPTION
Motivation:

We should use the latest patch release on our CI

Modifications:

Update to latest java8 release

Result:

Use latest release on  CI