### PR TITLE
Upgrade to 8.0.362-zulu on CI

### DIFF
--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-quic-centos6:centos-6-1.8
     build:
       args:
-        java_version : "8.0.352-zulu"
+        java_version : "8.0.362-zulu"
 
   build:
     image: netty-codec-quic-centos6:centos-6-1.8


### PR DESCRIPTION
Motivation:

We should use the latest java release on the CI

Modifications:

Upgrade to 8.0.362-zulu

Result:

Test with latest JDK