### PR TITLE
Fix NPE when ensureAvailability() check in unit test fails

### DIFF
--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
@@ -35,9 +35,12 @@ public abstract class AbstractQuicTest {
 
     @AfterAll
     public static void shutdownExecutor() {
-        for (Executor executor: executors) {
-            if (executor instanceof ExecutorService) {
-                ((ExecutorService) executor).shutdown();
+        // Executors might be null if ensureAvailability() throws
+        if (executors != null) {
+            for (Executor executor : executors) {
+                if (executor instanceof ExecutorService) {
+                    ((ExecutorService) executor).shutdown();
+                }
             }
         }
     }


### PR DESCRIPTION
Motivation:

There was a NPE thrown if ensureAvailability() did throw during tests.

Modifications:

Add missing null check

Result:

No NPE