### PR TITLE
Set the number of streams to a value low enough to not deadlock becau…

### DIFF
--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicReadableTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicReadableTest.java
@@ -35,7 +35,7 @@ public class QuicReadableTest extends AbstractQuicTest {
     @ParameterizedTest
     @MethodSource("sslTaskExecutors")
     public void testCorrectlyHandleReadableStreams(Executor executor) throws Throwable  {
-        int numOfStreams = 1024;
+        int numOfStreams = 256;
         int readStreams = numOfStreams / 2;
         // We do write longs.
         int expectedDataRead = readStreams * Long.BYTES;


### PR DESCRIPTION
…se of the window

Motivation:

We used a value of 1024 which was too big if we couldnt schedule the reads / writes in the right timely manner. This could lead to a deadlock.

Modifications:

Use a lower value which still provide the required testing but not put us in risk of deadlocks during tests

Result:

More stable builds on CI