### PR TITLE
Ensure Executors are not shutdown between tests and so let the build …

### DIFF
--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
@@ -16,44 +16,31 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.util.concurrent.ImmediateExecutor;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 @Timeout(10)
 public abstract class AbstractQuicTest {
-    private static Executor[] executors;
 
     @BeforeAll
     public static void ensureAvailability() {
         Quic.ensureAvailability();
     }
 
-    @AfterAll
-    public static void shutdownExecutor() {
-        // Executors might be null if ensureAvailability() throws
-        if (executors != null) {
-            for (Executor executor : executors) {
-                if (executor instanceof ExecutorService) {
-                    ((ExecutorService) executor).shutdown();
-                }
-            }
-        }
-    }
-
-    @BeforeAll
-    public static void createExecutors() {
-        executors = new Executor[] {
+    static Executor[] newSslTaskExecutors() {
+        return  new Executor[] {
                 ImmediateExecutor.INSTANCE,
-                Executors.newCachedThreadPool()
+                Executors.newSingleThreadExecutor()
         };
     }
 
-    static Executor[] sslTaskExecutors() {
-        return executors;
+    static void shutdown(Executor executor) {
+        if (executor instanceof ScheduledExecutorService) {
+            ((ScheduledExecutorService) executor).shutdown();
+        }
     }
 }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/AbstractQuicTest.java
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 
 @Timeout(10)
 public abstract class AbstractQuicTest {
@@ -39,8 +39,8 @@ public abstract class AbstractQuicTest {
     }
 
     static void shutdown(Executor executor) {
-        if (executor instanceof ScheduledExecutorService) {
-            ((ScheduledExecutorService) executor).shutdown();
+        if (executor instanceof ExecutorService) {
+            ((ExecutorService) executor).shutdown();
         }
     }
 }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -80,7 +80,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class QuicChannelConnectTest extends AbstractQuicTest {
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testConnectAndQLog(Executor executor) throws Throwable {
         Path path = Files.createTempFile("qlog", ".quic");
@@ -98,7 +98,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testConnectAndQLogDir(Executor executor) throws Throwable {
         Path path = Files.createTempDirectory("qlogdir-");
@@ -150,25 +150,27 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testKeylogEnabled(Executor executor) throws Throwable {
         testKeylog(executor, true);
         assertNotEquals(0, TestLogBackAppender.getLogs().size());
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testKeylogDisabled(Executor executor) throws Throwable {
         testKeylog(executor, false);
         assertEquals(0, TestLogBackAppender.getLogs().size());
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testCustomKeylog(Executor executor) throws Throwable {
         AtomicBoolean called = new AtomicBoolean();
         testKeylog(executor, (BoringSSLKeylog) (engine, log) -> {
@@ -212,11 +214,13 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(sslTaskExecutor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testAddressValidation(Executor executor) throws Throwable {
         // Bind to something so we can use the port to connect too and so can ensure we really timeout.
         DatagramSocket socket = new DatagramSocket();
@@ -237,17 +241,19 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             socket.close();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testConnectWithCustomIdLength(Executor executor) throws Throwable {
         testConnectWithCustomIdLength(executor, 10);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testConnectWithCustomIdLengthOfZero(Executor executor) throws Throwable {
         testConnectWithCustomIdLength(executor, 0);
     }
@@ -280,6 +286,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+            shutdown(executor);
         }
     }
 
@@ -345,44 +352,44 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
 
             ChannelFuture closeFuture = channel.close().await();
             assertTrue(closeFuture.isSuccess());
-        }
-        finally {
+        } finally {
             clientQuicChannelHandler.assertState();
             channel.close().sync();
             server.close().sync();
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     @Timeout(3)
     public void testConnectWithNoDroppedPacketsAndRandomConnectionIdGenerator(Executor executor) throws Throwable {
         testConnectWithDroppedPackets(executor, 0, QuicConnectionIdGenerator.randomGenerator());
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     @Timeout(5)
     public void testConnectWithDroppedPacketsAndRandomConnectionIdGenerator(Executor executor) throws Throwable {
         testConnectWithDroppedPackets(executor, 2, QuicConnectionIdGenerator.randomGenerator());
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     @Timeout(3)
     public void testConnectWithNoDroppedPacketsAndSignConnectionIdGenerator(Executor executor) throws Throwable {
         testConnectWithDroppedPackets(executor, 0, QuicConnectionIdGenerator.signGenerator());
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     @Timeout(5)
     public void testConnectWithDroppedPacketsAndSignConnectionIdGenerator(Executor executor) throws Throwable {
         testConnectWithDroppedPackets(executor, 2, QuicConnectionIdGenerator.signGenerator());
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testConnectTimeout(Executor executor) throws Throwable {
         // Bind to something so we can use the port to connect too and so can ensure we really timeout.
         DatagramSocket socket = new DatagramSocket();
@@ -402,11 +409,13 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             socket.close();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testConnectAlreadyConnected(Executor executor) throws Throwable {
         ChannelActiveVerifyHandler serverQuicChannelHandler = new ChannelActiveVerifyHandler();
         ChannelStateVerifyHandler serverQuicStreamHandler = new ChannelStateVerifyHandler();
@@ -437,11 +446,13 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testConnectWithoutTokenValidation(Executor executor) throws Throwable {
         int numBytes = 8;
         ChannelActiveVerifyHandler serverQuicChannelHandler = new ChannelActiveVerifyHandler();
@@ -495,11 +506,13 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testConnectAndGetAddressesAfterClose(Executor executor) throws Throwable {
         AtomicReference<QuicChannel> acceptedRef = new AtomicReference<>();
@@ -552,11 +565,13 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testConnectAndStreamPriority(Executor executor) throws Throwable {
         int numBytes = 8;
         ChannelActiveVerifyHandler serverQuicChannelHandler = new ChannelActiveVerifyHandler();
@@ -597,17 +612,19 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testExtendedTrustManagerFailureOnTheClient(Executor executor) throws Throwable {
         testTrustManagerFailureOnTheClient(executor, true);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testTrustManagerFailureOnTheClient(Executor executor) throws Throwable {
         testTrustManagerFailureOnTheClient(executor, false);
     }
@@ -652,11 +669,13 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testALPNProtocolMissmatch(Executor executor) throws Throwable {
         CountDownLatch latch = new CountDownLatch(1);
         CountDownLatch eventLatch = new CountDownLatch(1);
@@ -707,11 +726,13 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testConnectSuccessWhenTrustManagerBuildFromSameCert(Executor executor) throws Throwable {
         Channel server = QuicTestUtils.newServer(QuicTestUtils.newQuicServerBuilder(executor,
                         QuicSslContextBuilder.forServer(
@@ -742,11 +763,13 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testConnectMutualAuthSuccess(Executor executor) throws Throwable {
         Channel server = QuicTestUtils.newServer(QuicTestUtils.newQuicServerBuilder(executor,
                         QuicSslContextBuilder.forServer(
@@ -780,11 +803,13 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testConnectMutualAuthFailsIfClientNotSendCertificate(Executor executor) throws Throwable {
         Channel server = QuicTestUtils.newServer(QuicTestUtils.newQuicServerBuilder(executor,
                         QuicSslContextBuilder.forServer(
@@ -811,11 +836,13 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testSniMatch(Executor executor) throws Throwable {
         QuicSslContext defaultServerSslContext = QuicSslContextBuilder.forServer(
                 QuicTestUtils.SELF_SIGNED_CERTIFICATE.privateKey(), null,
@@ -878,17 +905,19 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testSniFallbackToDefault(Executor executor) throws Throwable {
         testSniFallbackToDefault(executor, true);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testNoSniFallbackToDefault(Executor executor) throws Throwable {
         testSniFallbackToDefault(executor, false);
     }
@@ -942,18 +971,20 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testConnectKeyless(Executor executor) throws Throwable {
         testConnectKeyless0(executor, false);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testConnectKeylessSignFailure(Executor executor) throws Throwable {
         testConnectKeyless0(executor, true);
     }
@@ -1040,12 +1071,14 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     @Timeout(5)
     public void testSessionReusedOnClientSide(Executor executor) throws Exception {
         CountDownLatch serverSslCompletionEventLatch = new CountDownLatch(2);
@@ -1131,6 +1164,8 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelDatagramTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelDatagramTest.java
@@ -50,13 +50,13 @@ public class QuicChannelDatagramTest extends AbstractQuicTest {
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testDatagramFlushInChannelRead(Executor executor) throws Throwable {
         testDatagram(executor, false);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testDatagramFlushInChannelReadComplete(Executor executor) throws Throwable {
         testDatagram(executor, true);
     }
@@ -154,29 +154,31 @@ public class QuicChannelDatagramTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testDatagramNoAutoReadMaxMessagesPerRead1(Executor executor) throws Throwable {
         testDatagramNoAutoRead(executor, 1, false);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testDatagramNoAutoReadMaxMessagesPerRead3(Executor executor) throws Throwable {
         testDatagramNoAutoRead(executor, 3, false);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testDatagramNoAutoReadMaxMessagesPerRead1OutSideEventLoop(Executor executor) throws Throwable {
         testDatagramNoAutoRead(executor, 1, true);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testDatagramNoAutoReadMaxMessagesPerRead3OutSideEventLoop(Executor executor) throws Throwable {
         testDatagramNoAutoRead(executor, 3, true);
     }
@@ -296,6 +298,8 @@ public class QuicChannelDatagramTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 public class QuicConnectionStatsTest extends AbstractQuicTest {
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testStatsAreCollected(Executor executor) throws Throwable {
         Channel server = null;
         Channel channel = null;
@@ -127,6 +127,8 @@ public class QuicConnectionStatsTest extends AbstractQuicTest {
         } finally {
             QuicTestUtils.closeIfNotNull(channel);
             QuicTestUtils.closeIfNotNull(server);
+
+            shutdown(executor);
         }
     }
 

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicReadableTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicReadableTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class QuicReadableTest extends AbstractQuicTest {
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testCorrectlyHandleReadableStreams(Executor executor) throws Throwable  {
         int numOfStreams = 256;
         int readStreams = numOfStreams / 2;
@@ -124,6 +124,8 @@ public class QuicReadableTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
@@ -34,25 +34,25 @@ import java.util.concurrent.TimeUnit;
 public class QuicStreamChannelCloseTest extends AbstractQuicTest {
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testCloseFromServerWhileInActiveUnidirectional(Executor executor) throws Throwable {
         testCloseFromServerWhileInActive(executor, QuicStreamType.UNIDIRECTIONAL, false);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testCloseFromServerWhileInActiveBidirectional(Executor executor) throws Throwable {
         testCloseFromServerWhileInActive(executor, QuicStreamType.BIDIRECTIONAL, false);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testHalfCloseFromServerWhileInActiveUnidirectional(Executor executor) throws Throwable {
         testCloseFromServerWhileInActive(executor, QuicStreamType.UNIDIRECTIONAL, true);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testHalfCloseFromServerWhileInActiveBidirectional(Executor executor) throws Throwable {
         testCloseFromServerWhileInActive(executor, QuicStreamType.BIDIRECTIONAL, true);
     }
@@ -92,29 +92,31 @@ public class QuicStreamChannelCloseTest extends AbstractQuicTest {
         } finally {
             QuicTestUtils.closeIfNotNull(channel);
             QuicTestUtils.closeIfNotNull(server);
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testCloseFromClientWhileInActiveUnidirectional(Executor executor) throws Throwable {
         testCloseFromClientWhileInActive(executor, QuicStreamType.UNIDIRECTIONAL, false);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testCloseFromClientWhileInActiveBidirectional(Executor executor) throws Throwable {
         testCloseFromClientWhileInActive(executor, QuicStreamType.BIDIRECTIONAL, false);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testHalfCloseFromClientWhileInActiveUnidirectional(Executor executor) throws Throwable {
         testCloseFromClientWhileInActive(executor, QuicStreamType.UNIDIRECTIONAL, true);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testHalfCloseFromClientWhileInActiveBidirectional(Executor executor) throws Throwable {
         testCloseFromClientWhileInActive(executor, QuicStreamType.BIDIRECTIONAL, true);
     }
@@ -152,6 +154,8 @@ public class QuicStreamChannelCloseTest extends AbstractQuicTest {
         } finally {
             QuicTestUtils.closeIfNotNull(channel);
             QuicTestUtils.closeIfNotNull(server);
+
+            shutdown(executor);
         }
     }
 

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
@@ -35,7 +35,7 @@ public class QuicStreamChannelCreationTest extends AbstractQuicTest {
     private static final String ATTRIBUTE_VALUE = "Test";
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testCreateStream(Executor executor) throws Throwable {
         QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler();
         Channel server = QuicTestUtils.newServer(executor, serverHandler,
@@ -72,11 +72,13 @@ public class QuicStreamChannelCreationTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testCreateStreamViaBootstrap(Executor executor) throws Throwable {
         QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler();
         Channel server = QuicTestUtils.newServer(executor, serverHandler,
@@ -116,6 +118,8 @@ public class QuicStreamChannelCreationTest extends AbstractQuicTest {
             server.close().syncUninterruptibly();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
@@ -34,13 +34,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class QuicStreamFrameTest extends AbstractQuicTest {
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testCloseHalfClosureUnidirectional(Executor executor) throws Throwable {
         testCloseHalfClosure(executor, QuicStreamType.UNIDIRECTIONAL);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testCloseHalfClosureBidirectional(Executor executor) throws Throwable {
         testCloseHalfClosure(executor, QuicStreamType.BIDIRECTIONAL);
     }
@@ -69,6 +69,8 @@ public class QuicStreamFrameTest extends AbstractQuicTest {
         } finally {
             QuicTestUtils.closeIfNotNull(channel);
             QuicTestUtils.closeIfNotNull(server);
+
+            shutdown(executor);
         }
     }
 

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamHalfClosureTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamHalfClosureTest.java
@@ -36,13 +36,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class QuicStreamHalfClosureTest extends AbstractQuicTest {
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testCloseHalfClosureUnidirectional(Executor executor) throws Throwable {
         testCloseHalfClosure(executor, QuicStreamType.UNIDIRECTIONAL);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testCloseHalfClosureBidirectional(Executor executor) throws Throwable {
         testCloseHalfClosure(executor, QuicStreamType.BIDIRECTIONAL);
     }
@@ -71,6 +71,8 @@ public class QuicStreamHalfClosureTest extends AbstractQuicTest {
         } finally {
             QuicTestUtils.closeIfNotNull(channel);
             QuicTestUtils.closeIfNotNull(server);
+
+            shutdown(executor);
         }
     }
 

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
@@ -37,13 +37,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class QuicStreamLimitTest extends AbstractQuicTest {
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testStreamLimitEnforcedWhenCreatingViaClientBidirectional(Executor executor) throws Throwable {
         testStreamLimitEnforcedWhenCreatingViaClient(executor, QuicStreamType.BIDIRECTIONAL);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testStreamLimitEnforcedWhenCreatingViaClientUnidirectional(Executor executor) throws Throwable {
         testStreamLimitEnforcedWhenCreatingViaClient(executor, QuicStreamType.UNIDIRECTIONAL);
     }
@@ -115,17 +115,19 @@ public class QuicStreamLimitTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testStreamLimitEnforcedWhenCreatingViaServerBidirectional(Executor executor) throws Throwable {
         testStreamLimitEnforcedWhenCreatingViaServer(executor, QuicStreamType.BIDIRECTIONAL);
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testStreamLimitEnforcedWhenCreatingViaServerUnidirectional(Executor executor) throws Throwable {
         testStreamLimitEnforcedWhenCreatingViaServer(executor, QuicStreamType.UNIDIRECTIONAL);
     }
@@ -184,6 +186,8 @@ public class QuicStreamLimitTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class QuicStreamTypeTest extends AbstractQuicTest {
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testUnidirectionalCreatedByClient(Executor executor) throws Throwable {
         Channel server = null;
         Channel channel = null;
@@ -90,7 +90,7 @@ public class QuicStreamTypeTest extends AbstractQuicTest {
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testUnidirectionalCreatedByServer(Executor executor) throws Throwable {
         Channel server = null;
         Channel channel = null;

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicWritableTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicWritableTest.java
@@ -43,14 +43,14 @@ public class QuicWritableTest extends AbstractQuicTest {
 
     @Disabled("Flaky, needs investigation")
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testCorrectlyHandleWritabilityReadRequestedInReadComplete(Executor executor) throws Throwable {
         testCorrectlyHandleWritability(executor, true);
     }
 
     @Disabled("Flaky, needs investigation")
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     public void testCorrectlyHandleWritabilityReadRequestedInRead(Executor executor) throws Throwable {
         testCorrectlyHandleWritability(executor, false);
     }
@@ -160,11 +160,13 @@ public class QuicWritableTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 
     @ParameterizedTest
-    @MethodSource("sslTaskExecutors")
+    @MethodSource("newSslTaskExecutors")
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testBytesUntilUnwritable(Executor executor) throws Throwable  {
         Promise<Void> writePromise = ImmediateEventExecutor.INSTANCE.newPromise();
@@ -288,6 +290,8 @@ public class QuicWritableTest extends AbstractQuicTest {
             server.close().sync();
             // Close the parent Datagram channel as well.
             channel.close().sync();
+
+            shutdown(executor);
         }
     }
 


### PR DESCRIPTION
…fail

Motivation:

How we shared the Executors between tests could lead to the situation that the Executor were shutdown before all tests did run. In this case the test would hang and timeout

Modifications:

Create a new Executor per test and shutdown explicit

Result:

Better isolation of tests