### PR TITLE
Update multiple actions to v3

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     name: linux-x86_64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: build-linux-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -60,7 +60,7 @@ jobs:
       - name: Checking for test failures
         run: ./.github/scripts/check_build_result.sh build.output
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: target
@@ -72,10 +72,10 @@ jobs:
     runs-on: ubuntu-latest
     name: linux-aarch64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: build-linux-aarch64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -96,7 +96,7 @@ jobs:
       - name: Build project without leak detection
         run: docker-compose -f docker/docker-compose.centos-7-cross.yaml run cross-compile-aarch64-build
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: target
@@ -112,10 +112,10 @@ jobs:
       # failures sometimes due the fact that not enough memory could be reserved.
       RUSTUP_UNPACK_RAM: 134217728  # Use 128 MiB
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 8
 
@@ -141,7 +141,7 @@ jobs:
           args: install ninja nasm
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: windows-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -151,7 +151,7 @@ jobs:
       - name: Build project
         run: ./mvnw.cmd -B -ntp --file pom.xml clean package
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: build-windows-target
@@ -170,13 +170,13 @@ jobs:
         run: echo "ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk/$NDK_VER" >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup ninja-build
         run: sudo apt-get install ninja-build
 
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
 
       - name: Install cargo-ndk
         uses: actions-rs/install@v0.1
@@ -202,7 +202,7 @@ jobs:
 
       # Cache .m2/repository
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: pr-android-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -212,7 +212,7 @@ jobs:
       - name: Build project
         run: ./mvnw -B -ntp --file pom.xml clean package -Dandroid
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: target

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -43,10 +43,10 @@ jobs:
 
     name: stage-snapshot-${{ matrix.setup }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: stage-snapshot-${{ matrix.setup }}-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -82,7 +82,7 @@ jobs:
         run: docker-compose ${{ matrix.docker-compose-run }}
 
       - name: Upload local staging directory
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.setup }}-local-staging
           path: ~/local-staging
@@ -96,7 +96,7 @@ jobs:
       # failures sometimes due the fact that not enough memory could be reserved.
       RUSTUP_UNPACK_RAM: 134217728  # Use 128 MiB
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 8
         uses: actions/setup-java@v1
@@ -125,7 +125,7 @@ jobs:
           args: install ninja nasm
 
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: stage-snapshot-windows-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -145,7 +145,7 @@ jobs:
         run: ./mvnw.cmd -B -ntp --file pom.xml clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true
 
       - name: Upload local staging directory
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-x86_64-local-staging
           path: local-staging
@@ -156,7 +156,7 @@ jobs:
     # Wait until we have staged everything
     needs: [stage-snapshot-linux, stage-snapshot-windows-x86_64]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 8
         uses: actions/setup-java@v1
@@ -164,7 +164,7 @@ jobs:
           java-version: 8
 
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: deploy-staged-snapshots-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -179,19 +179,19 @@ jobs:
       # Hardcode the staging artifacts that need to be downloaded.
       # These must match the matrix setups and windows build. There is currently no way to pull this out of the config.
       - name: Download windows_x86_64 staging directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows-x86_64-local-staging
           path: ~/windows-x86_64-local-staging
 
       - name: Download linux-aarch64 staging directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux-aarch64-local-staging
           path: ~/linux-aarch64-local-staging
 
       - name: Download linux-x86_64 staging directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux-x86_64-local-staging
           path: ~/linux-x86_64-local-staging

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     name: linux-x86_64 build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: pr-linux-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -62,12 +62,12 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-results-pr-linux-x86_64
           path: '**/target/surefire-reports/TEST-*.xml'
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: target
@@ -79,10 +79,10 @@ jobs:
     runs-on: ubuntu-latest
     name: linux-aarch64 build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: pr-linux-aarch64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -103,7 +103,7 @@ jobs:
       - name: Build project with leak detection
         run: docker-compose -f docker/docker-compose.centos-7-cross.yaml run cross-compile-aarch64-build
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: target
@@ -119,7 +119,7 @@ jobs:
       # failures sometimes due the fact that not enough memory could be reserved.
       RUSTUP_UNPACK_RAM: 134217728  # Use 128 MiB
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 8
         uses: actions/setup-java@v1
@@ -149,7 +149,7 @@ jobs:
 
       # Cache .m2/repository
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: pr-windows-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -161,12 +161,12 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-results-pr-windows-x86_64
           path: '**/target/surefire-reports/TEST-*.xml'
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: build-pr-windows-target
@@ -186,13 +186,13 @@ jobs:
         run: echo "ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk/$NDK_VER" >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup ninja-build
         run: sudo apt-get install ninja-build
 
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
 
       - name: Install cargo-ndk
         uses: actions-rs/install@v0.1
@@ -218,7 +218,7 @@ jobs:
 
       # Cache .m2/repository
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: pr-android-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -228,7 +228,7 @@ jobs:
       - name: Build project
         run: ./mvnw -B -ntp --file pom.xml clean package -Dandroid
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: build-pr-android-target

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -26,7 +26,7 @@ jobs:
   prepare-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: main
 
@@ -47,7 +47,7 @@ jobs:
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
 
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: prepare-release-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -63,7 +63,7 @@ jobs:
         run: ./.github/scripts/release_checkout_tag.sh release.properties
 
       - name: Upload workspace
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: prepare-release-workspace
           path: ${{ github.workspace }}/**
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Download release-workspace
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: prepare-release-workspace
           path: ./prepare-release-workspace/
@@ -94,7 +94,7 @@ jobs:
         run: chmod 755 ./prepare-release-workspace/mvnw
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 8
 
@@ -104,13 +104,13 @@ jobs:
           git config --global user.name "Netty Project Bot"
 
       - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
+        uses: shimataro/ssh-key-action@v3
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
 
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: staging-${{ matrix.setup }}-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -152,7 +152,7 @@ jobs:
         run: docker-compose ${{ matrix.docker-compose-run }}
 
       - name: Upload local staging directory
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.setup }}-local-staging
           path: ~/local-staging
@@ -174,7 +174,7 @@ jobs:
       RUSTUP_UNPACK_RAM: 134217728  # Use 128 MiB
     steps:
       - name: Download release-workspace
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: prepare-release-workspace
           path: ${{ github.workspace }}/prepare-release-workspace
@@ -224,7 +224,7 @@ jobs:
           args: install ninja nasm
 
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: stage-release-windows-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -247,7 +247,7 @@ jobs:
         run: ./mvnw.cmd -B -ntp --file pom.xml clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=D:\a\netty-incubator-codec-quic\netty-incubator-codec-quic\prepare-release-workspace\local-staging -DskipRemoteStaging=true -DskipTests=true -D'checkstyle.skip=true'
 
       - name: Upload local staging directory
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-x86_64-local-staging
           path: ${{ github.workspace }}/prepare-release-workspace/local-staging
@@ -265,7 +265,7 @@ jobs:
     needs: [stage-release-linux, stage-release-windows-x86_64]
     steps:
       - name: Download release-workspace
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: prepare-release-workspace
           path: ./prepare-release-workspace/
@@ -292,19 +292,19 @@ jobs:
       # Hardcode the staging artifacts that need to be downloaded.
       # These must match the matrix setups. There is currently no way to pull this out of the config.
       - name: Download windows-x86_64 staging directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows-x86_64-local-staging
           path: ~/windows-x86_64-local-staging
 
       - name: Download linux-aarch64 staging directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux-aarch64-local-staging
           path: ~/linux-aarch64-local-staging
 
       - name: Download linux-x86_64 staging directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux-x86_64-local-staging
           path: ~/linux-x86_64-local-staging
@@ -316,7 +316,7 @@ jobs:
         run: bash ./.github/scripts/merge_local_staging.sh /home/runner/local-staging/staging ~/windows-x86_64-local-staging/staging ~/linux-aarch64-local-staging/staging ~/linux-x86_64-local-staging/staging
 
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: deploy-staged-release-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-verify-load.yml
+++ b/.github/workflows/ci-verify-load.yml
@@ -32,10 +32,10 @@ jobs:
   install-jars-linux-aarch64:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Caching of maven dependencies
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: sinstall-jars-linux-aarch64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -57,7 +57,7 @@ jobs:
         run: docker-compose -f docker/docker-compose.centos-7-cross.yaml run cross-compile-aarch64-install
 
       - name: Upload the maven repository
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: maven-repository
           # We only need the netty jars.
@@ -69,10 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ install-jars-linux-aarch64 ]
     steps:
-      - uses: actions/checkout@v2.1.0
+      - uses: actions/checkout@v3
 
       - name: Download the maven repository
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name:  maven-repository
           path: /home/runner/jars

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,10 +42,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Caching of maven dependencies
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.m2/repository
         key: analyze-${{ matrix.language }}-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -54,7 +54,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -84,4 +84,4 @@ jobs:
       run: ./mvnw clean package -DskipTests=true
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,7 +54,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -84,4 +84,4 @@ jobs:
       run: ./mvnw clean package -DskipTests=true
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Motivation:
Actions such as `checkout`, `cache`, `download-artifact`, and `upload-artifact` have a major upgrade available which is v3. We should consider upgrading to them for extended functionalities and support.

Modification:
Upgraded all of those above-mentioned actions to v3.

Result:
Latest actions version