### PR TITLE
Use quiche_conn_max_send_udp_payload_size(...) to determine the datag…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -512,6 +512,13 @@ final class Quiche {
 
     /**
      * See
+     * <a href="https://github.com/cloudflare/quiche/blob/0.10.0/include/quiche.h#L328">
+     *     quiche_conn_max_send_udp_payload_size</a>.
+     */
+    static native int quiche_conn_max_send_udp_payload_size(long connAddr);
+
+    /**
+     * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L115">quiche_config_new</a>.
      */
     static native long quiche_config_new(int version);

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -555,6 +555,10 @@ static jint netty_quiche_conn_set_session(JNIEnv* env, jclass clazz, jlong conn,
     return (jint) quiche_conn_set_session((quiche_conn *) conn, (uint8_t *) buf, (size_t) buf_len);
 }
 
+static jint netty_quiche_conn_max_send_udp_payload_size(JNIEnv* env, jclass clazz, jlong conn) {
+    return (jint) quiche_conn_max_send_udp_payload_size((quiche_conn *) conn);
+}
+
 static jlong netty_quiche_config_new(JNIEnv* env, jclass clazz, jint version) {
     quiche_config* config = quiche_config_new((uint32_t) version);
     return config == NULL ? -1 : (jlong) config;
@@ -808,6 +812,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_dgram_recv", "(JJI)I", (void* ) netty_quiche_conn_dgram_recv },
   { "quiche_conn_dgram_send", "(JJI)I", (void* ) netty_quiche_conn_dgram_send },
   { "quiche_conn_set_session", "(J[B)I", (void* ) netty_quiche_conn_set_session },
+  { "quiche_conn_max_send_udp_payload_size", "(J)I", (void* ) netty_quiche_conn_max_send_udp_payload_size },
   { "quiche_config_new", "(I)J", (void *) netty_quiche_config_new },
   { "quiche_config_enable_dgram", "(JZII)V", (void *) netty_quiche_config_enable_dgram },
   { "quiche_config_grease", "(JZ)V", (void *) netty_quiche_config_grease },


### PR DESCRIPTION
…ram size

Motivation:

We used a hardcoded value for the maximum datagram packet size before. This is problematic for two reasons, first off if the remote peer uses a smaller MTU it might never receive a packet. Secondly it might also affect performance in a negative way.

Modifications:

- Use quiche_conn_max_send_udp_payload_size(...) to obtain the maximum datagram payload size.

Result:

No risk of packet loss due small MTU and also better performance if remote peer supports large datagrams