### PR TITLE
Add a comment to clarify the code

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -1236,6 +1236,10 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private static int calculateSendBufferLength(long connAddr, int maxDatagramSize) {
         int len = Math.min(maxDatagramSize, Quiche.quiche_conn_send_quantum(connAddr));
         if (len <= 0) {
+            // If there is no room left we just return some small number to reduce the risk of packet drop
+            // while still be able to attach the listener to the write future.
+            // We use the value of 8 because such an allocation will be cheap to serve from the
+            // PooledByteBufAllocator while still serve our need.
             return 8;
         }
         return len;


### PR DESCRIPTION
Motivation:

It was not clear why we did return 8 in some cases.

Modifications:

Add comment

Result:

Easier to understand code