### PR TITLE
Upgrade to latest netty release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <javaModuleName />
     <skipTests>false</skipTests>
     <packaging.type>jar</packaging.type>
-    <netty.version>4.1.89.Final</netty.version>
+    <netty.version>4.1.90.Final</netty.version>
     <netty.build.version>31</netty.build.version>
     <commons.codec.version>1.15</commons.codec.version>
     <junit.version>5.9.0</junit.version>


### PR DESCRIPTION
Motivation:

Netty 4.1.90.Final was released.

Modifications:

Upgrade to latest version

Result:

Use latest netty version