### PR TITLE
Fix android build

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -180,8 +180,8 @@ jobs:
     runs-on: ubuntu-latest
     name: android
     env:
-      SDK_VER: "android-21"
-      NDK_VER: "21.4.7075529"
+      SDK_VER: "android-23"
+      NDK_VER: "23.2.8568313"
     steps:
       - name: Set environmental variables
         run: echo "ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk/$NDK_VER" >> $GITHUB_ENV

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     name: android
     env:
-      SDK_VER: "android-23"
+      SDK_VER: "android-21"
       NDK_VER: "23.2.8568313"
     steps:
       - name: Set environmental variables

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -273,8 +273,8 @@
         <packaging.type>aar</packaging.type>
         <skipTests>true</skipTests>
         <platform>android</platform>
-        <androidNdkVersion>21</androidNdkVersion>
-        <androidMinSdkVersion>21</androidMinSdkVersion>
+        <androidNdkVersion>23</androidNdkVersion>
+        <androidMinSdkVersion>23</androidMinSdkVersion>
         <cargoTarget>--target=${quicheTarget}</cargoTarget>
         <skipIteration>false</skipIteration>
         <nativeLibOnlyDir>${project.build.directory}/native-lib-only/${androidAbi}</nativeLibOnlyDir>

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -274,7 +274,7 @@
         <skipTests>true</skipTests>
         <platform>android</platform>
         <androidNdkVersion>23</androidNdkVersion>
-        <androidMinSdkVersion>23</androidMinSdkVersion>
+        <androidMinSdkVersion>21</androidMinSdkVersion>
         <cargoTarget>--target=${quicheTarget}</cargoTarget>
         <skipIteration>false</skipIteration>
         <nativeLibOnlyDir>${project.build.directory}/native-lib-only/${androidAbi}</nativeLibOnlyDir>

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -369,7 +369,7 @@
                     <configureArg>TOOLCHAIN=${ndkToolchain}</configureArg>
                     <configureArg>TARGET=${androidTriple}</configureArg>
                     <configureArg>API=${androidMinSdkVersion}</configureArg>
-                    <configureArg>AR=${ndkToolchain}/bin/${androidTriple2}-ar</configureArg>
+                    <configureArg>AR=${ndkToolchain}/bin/llvm-ar</configureArg>
                     <configureArg>CC=${ndkToolchain}/bin/${androidTriple}${androidMinSdkVersion}-clang</configureArg>
                     <configureArg>AS=${ndkToolchain}/bin/${androidTriple2}-as</configureArg>
                     <configureArg>CXX=${ndkToolchain}/bin/${androidTriple}${androidMinSdkVersion}-clang++</configureArg>


### PR DESCRIPTION
Motivation:

We need to use NDK version of 23 or newer as otherwise cargo will fail

Modifications:

Use version 23

Result:

Android build works again