### PR TITLE
Disable Android builds until fixed

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -161,6 +161,8 @@ jobs:
             **/hs_err*.log
 
   build-android:
+    # Disable until fixed
+    if: ${{ false }}
     runs-on: ubuntu-latest
     name: android
     env:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -177,6 +177,8 @@ jobs:
 
 
   build-pr-android:
+    # Disable until fixed
+    if: ${{ false }}
     runs-on: ubuntu-latest
     name: android
     env:


### PR DESCRIPTION
Motivation:

At the moment the android builds fail, lets disable these until we figured out how to fix these.

Modifications:

Disable android jobs

Result:

No more failing builds