### PR TITLE
Upgrade to latest maven version and use sdkman to install it

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.9.0/apache-maven-3.9.0-bin.zip
+distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.9.1/apache-maven-3.9.1-bin.zip

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -6,6 +6,8 @@ ENV CMAKE_VERSION_BASE 3.8
 ENV CMAKE_VERSION $CMAKE_VERSION_BASE.2
 ENV NINJA_VERSION 1.7.2
 ENV GO_VERSION 1.9.3
+ENV MAVEN_VERSION 3.9.1
+
 
 # install dependencies
 RUN yum install -y \
@@ -44,9 +46,10 @@ RUN curl -s "https://get.sdkman.io" | bash
 ARG java_version="8.0.302-zulu"
 ENV JAVA_VERSION $java_version
 
-# Installing Java removing some unnecessary SDKMAN files
+# Installing Java and Maven, removing some unnecessary SDKMAN files
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
     yes | sdk install java $JAVA_VERSION && \
+    yes | sdk install maven $MAVEN_VERSION && \
     rm -rf $HOME/.sdkman/archives/* && \
     rm -rf $HOME/.sdkman/tmp/*"
 
@@ -57,10 +60,6 @@ RUN echo 'PATH=$JAVA_HOME/bin:$PATH' >> ~/.bashrc
 run curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN echo 'PATH=$PATH:$HOME/.cargo/bin' >> ~/.bashrc
 
-WORKDIR /opt
-RUN curl https://dlcdn.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz | tar -xz
-RUN echo 'PATH=/opt/apache-maven-3.9.0/bin/:$PATH' >> ~/.bashrc
-
 # Prepare our own build
-ENV PATH /opt/apache-maven-3.9.0/bin/:$PATH
+ENV PATH /root/.sdkman/candidates/maven/current:$PATH
 ENV JAVA_HOME /root/.sdkman/candidates/java/current

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -1,6 +1,7 @@
 FROM centos:7.6.1810
 
 ARG GCC_VERSION=10.2-2020.11
+ENV MAVEN_VERSION 3.9.1
 ENV SOURCE_DIR /root/source
 ENV WORKSPACE_DIR /root/workspace
 ENV PROJECT_DIR /root/workspace/project
@@ -54,9 +55,12 @@ RUN /root/.cargo/bin/rustup target add aarch64-unknown-linux-gnu
 RUN echo '[target.aarch64-unknown-linux-gnu]' >> /root/.cargo/config
 RUN echo 'linker = "aarch64-none-linux-gnu-gcc"' >> /root/.cargo/config
 
-WORKDIR /opt
-RUN curl https://dlcdn.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz | tar -xz
-RUN echo 'PATH=/opt/apache-maven-3.9.0/bin/:$PATH' >> ~/.bashrc
+
+# Installing Java and Maven, removing some unnecessary SDKMAN files
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
+    yes | sdk install maven $MAVEN_VERSION && \
+    rm -rf $HOME/.sdkman/archives/* && \
+    rm -rf $HOME/.sdkman/tmp/*"
 
 # Prepare our own build
-ENV PATH /opt/apache-maven-3.9.0/bin/:$PATH
+ENV PATH /root/.sdkman/candidates/maven/current:$PATH

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -55,6 +55,8 @@ RUN /root/.cargo/bin/rustup target add aarch64-unknown-linux-gnu
 RUN echo '[target.aarch64-unknown-linux-gnu]' >> /root/.cargo/config
 RUN echo 'linker = "aarch64-none-linux-gnu-gcc"' >> /root/.cargo/config
 
+# Downloading and installing SDKMAN!
+RUN curl -s "https://get.sdkman.io" | bash
 
 # Installing Java and Maven, removing some unnecessary SDKMAN files
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \


### PR DESCRIPTION
Motivation:

There was a new maven release we should use. Also just use sdkman to do so.

Modifications:

- Upgrade to maven 3.9.1
- Use sdkman

Result:

Use latest maven version and use sdkman