### PR TITLE
Update to latest quiche version which added support for key updates

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -57,7 +57,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>90fcd18bf006d2b232a57e9ab8c91dfbf6e48a69</quicheCommitSha>
+    <quicheCommitSha>3b1e5b21977d5b4838362c460444dc758487397c</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />


### PR DESCRIPTION
Motivation:

Quiche added support for key updates, which are required for long living connections. Lets use the version that added support

Modifications:

Update to 3b1e5b21977d5b4838362c460444dc758487397c

Result:

No more issues with long living connections