### PR TITLE
Use multi threads on server side

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -17,6 +17,7 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
 import io.netty.util.AttributeKey;
 import io.netty.util.internal.ObjectUtil;
 
@@ -41,6 +42,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     private ChannelHandler streamHandler;
     private QuicConnectionIdGenerator connectionIdAddressGenerator;
     private QuicTokenHandler tokenHandler;
+    private EventLoopGroup workerGroup;
 
     /**
      * Creates a new instance.
@@ -59,6 +61,17 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
         streamHandler = builder.streamHandler;
         connectionIdAddressGenerator = builder.connectionIdAddressGenerator;
         tokenHandler = builder.tokenHandler;
+    }
+
+    /**
+     * These {@link EventLoopGroup}'s are used to handle all the events and IO for {@link QuicChannel}.
+     */
+    public QuicServerCodecBuilder group(EventLoopGroup workerGroup) {
+        if (this.workerGroup != null) {
+            throw new IllegalStateException("workerGroup set already");
+        }
+        this.workerGroup = ObjectUtil.checkNotNull(workerGroup, "workerGroup");
+        return self();
     }
 
     @Override
@@ -195,8 +208,9 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
         }
         ChannelHandler handler = this.handler;
         ChannelHandler streamHandler = this.streamHandler;
+        EventLoopGroup workerGroup = this.workerGroup;
         return new QuicheQuicServerCodec(config, localConnIdLength, tokenHandler, generator, flushStrategy,
-                sslEngineProvider, sslTaskExecutor, handler,
+                sslEngineProvider, sslTaskExecutor, workerGroup, handler,
                 Quic.toOptionsArray(options), Quic.toAttributesArray(attrs),
                 streamHandler, Quic.toOptionsArray(streamOptions), Quic.toAttributesArray(streamAttrs));
     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -32,6 +32,7 @@ import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.DefaultChannelPipeline;
 import io.netty.channel.EventLoop;
 import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.nio.NioEventLoop;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.ssl.SniCompletionEvent;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
@@ -544,7 +545,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
     @Override
     protected boolean isCompatible(EventLoop eventLoop) {
-        return parent().eventLoop() == eventLoop;
+        return eventLoop instanceof NioEventLoop;
     }
 
     @Override


### PR DESCRIPTION
#504 
Use multi threads on server side, Improve processing speed.
Set EventLoopGroup for QuicServerCodecBuilder: 
`EventLoopGroup workerGroup = new NioEventLoopGroup();

QuicServerCodecBuilder builder = new QuicServerCodecBuilder().group(workerGroup)
                .sslEngineProvider(q -> context.newEngine(q.alloc()))
                .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
                .initialMaxData(10000000)
                .initialMaxStreamDataBidirectionalLocal(1000000)
                .initialMaxStreamDataBidirectionalRemote(1000000)
                .initialMaxStreamDataUnidirectional(1000000)
                .initialMaxStreamsBidirectional(100)
                .initialMaxStreamsUnidirectional(100)
                .activeMigration(false)
                .sslTaskExecutor(sslTaskExecutor);`