### PR TITLE
Allow to consolidate flushes by adding to the read complete queue bef…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -86,10 +86,12 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
                     type, version, scid,
                     dcid, token);
             if (channel != null) {
-                channel.recv(recipient, sender, buffer);
+                // Add to queue first, we might be able to safe some flushes and consolidate them
+                // in channelReadComplete(...) this way.
                 if (channel.markInFireChannelReadCompleteQueue()) {
                     needsFireChannelReadComplete.add(channel);
                 }
+                channel.recv(recipient, sender, buffer);
             }
         };
         estimatorHandle = ctx.channel().config().getMessageSizeEstimator().newHandle();


### PR DESCRIPTION
…ore dispatching

Motivation:

We should add the Channel to the read complete queue before dispatching the first message. This might allow us to consolidate flushes and so syscalls.

Modifications:

Add to queue before dispatching the first message

Result:

Allow to consolidate flushes