### PR TITLE
Upgrade to quiche a4ac85642eca40e45cc6e0cfd916d55b81537e2c aka 0.17.2

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -57,7 +57,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>0b37da1cc564e40749ba650febd40586a4355be4</quicheCommitSha>
+    <quicheCommitSha>a4ac85642eca40e45cc6e0cfd916d55b81537e2c</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />


### PR DESCRIPTION
Motivation:

Let's upgrade to latest quiche release

Modifications:

Upgrade to quiche sha that is the latest quiche release (0.17.2)

Result:

Use latest quiche release