### PR TITLE
Allow to completely disable token usage for QUIC connection establish…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/NoQuicTokenHandler.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/NoQuicTokenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2023 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,19 +15,21 @@
  */
 package io.netty.incubator.codec.quic;
 
-import java.net.InetSocketAddress;
-
 import io.netty.buffer.ByteBuf;
 
+import java.net.InetSocketAddress;
+
 /**
- * A {@link QuicTokenHandler} which disables token validation.
+ * {@link QuicTokenHandler} which will disable token generation / validation completely.
+ * This will reduce the round-trip for QUIC connection migration, but will also weaking the
+ * security during connection establishment.
  */
-public final class NoValidationQuicTokenHandler implements QuicTokenHandler {
+final class NoQuicTokenHandler implements QuicTokenHandler {
 
-    private NoValidationQuicTokenHandler() {
+    public final static QuicTokenHandler INSTANCE = new NoQuicTokenHandler();
+
+    private NoQuicTokenHandler() {
     }
-
-    public static final NoValidationQuicTokenHandler INSTANCE = new NoValidationQuicTokenHandler();
 
     @Override
     public boolean writeToken(ByteBuf out, ByteBuf dcid, InetSocketAddress address) {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -161,13 +161,14 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     }
 
     /**
-     * Set the {@link QuicTokenHandler} that is used to generate and validate tokens.
+     * Set the {@link QuicTokenHandler} that is used to generate and validate tokens or
+     * {@code null} if no tokens should be used at all.
      *
      * @param tokenHandler  the {@link QuicTokenHandler} to use.
      * @return              this instance.
      */
     public QuicServerCodecBuilder tokenHandler(QuicTokenHandler tokenHandler) {
-        this.tokenHandler = ObjectUtil.checkNotNull(tokenHandler, "tokenHandler");
+        this.tokenHandler = tokenHandler;
         return self();
     }
 
@@ -176,9 +177,6 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
         super.validate();
         if (handler == null && streamHandler == null) {
             throw new IllegalStateException("handler and streamHandler not set");
-        }
-        if (tokenHandler == null) {
-            throw new IllegalStateException("tokenHandler not set");
         }
     }
 
@@ -189,6 +187,9 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
                                    int localConnIdLength, FlushStrategy flushStrategy) {
         validate();
         QuicTokenHandler tokenHandler = this.tokenHandler;
+        if (tokenHandler == null) {
+            tokenHandler = NoQuicTokenHandler.INSTANCE;
+        }
         QuicConnectionIdGenerator generator = connectionIdAddressGenerator;
         if (generator == null) {
             generator = QuicConnectionIdGenerator.signGenerator();

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -294,7 +294,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                                                QuicConnectionIdGenerator connectionIdGenerator) throws Throwable {
         Channel server = QuicTestUtils.newServer(QuicTestUtils.newQuicServerBuilder(executor)
                         .connectionIdAddressGenerator(connectionIdGenerator),
-                NoValidationQuicTokenHandler.INSTANCE,
+                NoQuicTokenHandler.INSTANCE,
                 new ChannelInboundHandlerAdapter() {
                     @Override
                     public boolean isSharable() {
@@ -460,7 +460,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         CountDownLatch clientLatch = new CountDownLatch(1);
 
         // Disable token validation
-        Channel server = QuicTestUtils.newServer(executor, NoValidationQuicTokenHandler.INSTANCE,
+        Channel server = QuicTestUtils.newServer(executor, NoQuicTokenHandler.INSTANCE,
                 serverQuicChannelHandler, new BytesCountingHandler(serverLatch, numBytes));
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
         Channel channel = QuicTestUtils.newClient(executor);

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/example/QuicServerZeroRTTExample.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/example/QuicServerZeroRTTExample.java
@@ -29,7 +29,6 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
-import io.netty.incubator.codec.quic.NoValidationQuicTokenHandler;
 import io.netty.incubator.codec.quic.QuicChannel;
 import io.netty.incubator.codec.quic.QuicServerCodecBuilder;
 import io.netty.incubator.codec.quic.QuicSslContext;
@@ -60,9 +59,9 @@ public final class QuicServerZeroRTTExample {
                 .initialMaxStreamsBidirectional(100)
                 .initialMaxStreamsUnidirectional(100)
 
-                // Setup a token handler. In a production system you would want to implement and provide your custom
+                // Disable token usage. In a production system you would want to implement and provide your custom
                 // one.
-                .tokenHandler(NoValidationQuicTokenHandler.INSTANCE)
+                .tokenHandler(null)
                 // ChannelHandler that is added into QuicChannel pipeline.
                 .handler(new ChannelInboundHandlerAdapter() {
                     @Override


### PR DESCRIPTION
…ment

Motivation:

Using tokens during connection establishment does require and extra round-trip. While using tokens is generally a good idea there are some scenarios when using a token is not really required. Let's allow the user to disable tokens.

Modifications:

Allow to not configure any QuicTokenHandler and so disable token usage

Result:

More flexible configuration and less round-trips in some setups.