### PR TITLE
Enable UDP_SEGMENT when supported during testing

### DIFF
--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -127,7 +127,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
         Channel channel = QuicTestUtils.newClient(executor);
         try {
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientValidationHandler)
                     .option(QuicChannelOption.QLOG,
                             new QLogConfiguration(path.toString(), "testTitle", "test"))
@@ -199,7 +199,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         Channel channel = QuicTestUtils.newClient(QuicTestUtils.newQuicClientBuilder(sslTaskExecutor, context));
 
         try {
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientValidationHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -228,7 +228,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                 .localConnectionIdLength(10));
         try {
             ChannelStateVerifyHandler verifyHandler = new ChannelStateVerifyHandler();
-            Future<QuicChannel> future = QuicChannel.newBootstrap(channel)
+            Future<QuicChannel> future = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(verifyHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(socket.getLocalSocketAddress())
@@ -269,7 +269,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                 .localConnectionIdLength(idLength));
         try {
             ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientQuicChannelHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -336,7 +336,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         Channel channel = QuicTestUtils.newClient(QuicTestUtils.newQuicClientBuilder(executor));
         ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
         try {
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientQuicChannelHandler)
                     .remoteAddress(address)
                     .connect()
@@ -396,7 +396,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         Channel channel = QuicTestUtils.newClient(executor);
         try {
             ChannelStateVerifyHandler verifyHandler = new ChannelStateVerifyHandler();
-            Future<QuicChannel> future = QuicChannel.newBootstrap(channel)
+            Future<QuicChannel> future = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(verifyHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10)
@@ -425,7 +425,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         Channel channel = QuicTestUtils.newClient(executor);
         try {
             ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientQuicChannelHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -466,7 +466,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         Channel channel = QuicTestUtils.newClient(executor);
         try {
             ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientQuicChannelHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -537,7 +537,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
         Channel channel = QuicTestUtils.newClient(executor);
         try {
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(new ChannelInboundHandlerAdapter())
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -584,7 +584,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         Channel channel = QuicTestUtils.newClient(executor);
         try {
             ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientQuicChannelHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -658,7 +658,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                         .trustManager(new TrustManagerFactoryWrapper(trustManager))
                         .applicationProtocols(QuicTestUtils.PROTOS).build()));
         try {
-            Throwable cause = QuicChannel.newBootstrap(channel)
+            Throwable cause = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(new ChannelInboundHandlerAdapter())
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -714,7 +714,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                         .trustManager(InsecureTrustManagerFactory.INSTANCE).applicationProtocols("protocol").build()));
         AtomicReference<QuicConnectionCloseEvent> closeEventRef = new AtomicReference<>();
         try {
-            Throwable cause = QuicChannel.newBootstrap(channel)
+            Throwable cause = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(new ChannelInboundHandlerAdapter() {
                         @Override
                         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
@@ -765,7 +765,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                         .applicationProtocols(QuicTestUtils.PROTOS).build()));
         try {
             ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientQuicChannelHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -805,7 +805,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                         .applicationProtocols(QuicTestUtils.PROTOS).build()));
         try {
             ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientQuicChannelHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -841,7 +841,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                         .trustManager(InsecureTrustManagerFactory.INSTANCE)
                         .applicationProtocols(QuicTestUtils.PROTOS).build()));
         try {
-            Throwable cause = QuicChannel.newBootstrap(channel)
+            Throwable cause = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(new ChannelInboundHandlerAdapter())
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -904,7 +904,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                 .sslEngineProvider(c -> clientSslContext.newEngine(c.alloc(), hostname, 8080)));
         try {
             ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientQuicChannelHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -972,7 +972,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                 }));
         try {
             ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientQuicChannelHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -1066,7 +1066,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                         .applicationProtocols(QuicTestUtils.PROTOS).build()));
         try {
             ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
-            Future<QuicChannel> connectFuture = QuicChannel.newBootstrap(channel)
+            Future<QuicChannel> connectFuture = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientQuicChannelHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -1135,7 +1135,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         try {
             CountDownLatch clientSslCompletionEventLatch = new CountDownLatch(2);
 
-            QuicChannelBootstrap bootstrap = QuicChannel.newBootstrap(channel)
+            QuicChannelBootstrap bootstrap = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(new ChannelInboundHandlerAdapter() {
                         @Override
                         public boolean isSharable() {

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelDatagramTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelDatagramTest.java
@@ -130,7 +130,7 @@ public class QuicChannelDatagramTest extends AbstractQuicTest {
         };
 
         try {
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .remoteAddress(address)
                     .connect()
@@ -268,7 +268,7 @@ public class QuicChannelDatagramTest extends AbstractQuicTest {
             }
         };
         try {
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .remoteAddress(address)
                     .connect()

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelEchoTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelEchoTest.java
@@ -149,7 +149,7 @@ public class QuicChannelEchoTest extends AbstractQuicTest {
         Channel channel = QuicTestUtils.newClient(ImmediateExecutor.INSTANCE);
         QuicChannel quicChannel = null;
         try {
-            quicChannel = QuicChannel.newBootstrap(channel)
+            quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(new ChannelInboundHandlerAdapter() {
                         @Override
                         public void channelActive(ChannelHandlerContext ctx) {
@@ -257,7 +257,7 @@ public class QuicChannelEchoTest extends AbstractQuicTest {
                     }
                 }
             };
-            quicChannel = QuicChannel.newBootstrap(channel)
+            quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(ch)
                     // Use the same allocator for the streams.

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
@@ -86,7 +86,7 @@ public class QuicConnectionStatsTest extends AbstractQuicTest {
             });
             channel = QuicTestUtils.newClient(executor);
 
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(server.localAddress())

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicReadableTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicReadableTest.java
@@ -87,7 +87,7 @@ public class QuicReadableTest extends AbstractQuicTest {
         QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
         ByteBuf data = Unpooled.directBuffer().writeLong(8);
         try {
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(server.localAddress())

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
@@ -70,7 +70,7 @@ public class QuicStreamChannelCloseTest extends AbstractQuicTest {
 
             QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
 
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(new StreamHandler())
                     .remoteAddress(server.localAddress())
@@ -132,7 +132,7 @@ public class QuicStreamChannelCloseTest extends AbstractQuicTest {
             channel = QuicTestUtils.newClient(executor);
 
             StreamCreationHandler creationHandler = new StreamCreationHandler(type, halfClose, streamPromise);
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(creationHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(server.localAddress())

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
@@ -45,7 +45,7 @@ public class QuicStreamChannelCreationTest extends AbstractQuicTest {
         QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
 
         try {
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -88,7 +88,7 @@ public class QuicStreamChannelCreationTest extends AbstractQuicTest {
         QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
 
         try {
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
@@ -54,7 +54,7 @@ public class QuicStreamFrameTest extends AbstractQuicTest {
             StreamHandler handler = new StreamHandler();
             server = QuicTestUtils.newServer(executor, serverHandler, handler);
             channel = QuicTestUtils.newClient(executor);
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(server.localAddress())

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamHalfClosureTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamHalfClosureTest.java
@@ -56,7 +56,7 @@ public class QuicStreamHalfClosureTest extends AbstractQuicTest {
             StreamHandler handler = new StreamHandler();
             server = QuicTestUtils.newServer(executor, serverHandler, handler);
             channel = QuicTestUtils.newClient(executor);
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(server.localAddress())

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
@@ -86,7 +86,7 @@ public class QuicStreamLimitTest extends AbstractQuicTest {
             }
         };
         try {
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -170,7 +170,7 @@ public class QuicStreamLimitTest extends AbstractQuicTest {
 
         QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
         try {
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
@@ -64,7 +64,7 @@ public class QuicStreamTypeTest extends AbstractQuicTest {
             });
 
             channel = QuicTestUtils.newClient(executor);
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(server.localAddress())
@@ -116,7 +116,7 @@ public class QuicStreamTypeTest extends AbstractQuicTest {
             server = QuicTestUtils.newServer(executor, serverHandler, new ChannelInboundHandlerAdapter());
 
             channel = QuicTestUtils.newClient(executor);
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter() {
                         @Override

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
@@ -73,6 +73,15 @@ final class QuicTestUtils {
                 .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0)).sync().channel();
     }
 
+    static QuicChannelBootstrap newQuicChannelBootstrap(Channel channel) {
+        QuicChannelBootstrap bs = QuicChannel.newBootstrap(channel);
+        if (GROUP instanceof EpollEventLoopGroup) {
+            bs.option(QuicChannelOption.SEGMENTED_DATAGRAM_PACKET_ALLOCATOR,
+                    EpollQuicUtils.newSegmentedAllocator(10));
+        }
+        return bs;
+    }
+
     static QuicClientCodecBuilder newQuicClientBuilder(Executor sslTaskExecutor) {
         return newQuicClientBuilder(sslTaskExecutor, QuicSslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE).applicationProtocols(PROTOS).build());

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicWritableTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicWritableTest.java
@@ -87,7 +87,7 @@ public class QuicWritableTest extends AbstractQuicTest {
 
         QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
         try {
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)
@@ -227,7 +227,7 @@ public class QuicWritableTest extends AbstractQuicTest {
 
         QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
         try {
-            QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientHandler)
                     .streamHandler(new ChannelInboundHandlerAdapter())
                     .remoteAddress(address)


### PR DESCRIPTION
Motivation:

We should enable UDP_SEGMENT on the client side as well when its supported during testing.

Modifications:

Add utility method that enables UDP_SEGMENT for the client side when testing

Result:

Better test coverage