### PR TITLE
Include linux-aarch64 epoll dependency for tests

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -1091,6 +1091,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>${netty.version}</version>
+      <classifier>linux-aarch_64</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>${junit.version}</version>


### PR DESCRIPTION
Motivation:

Let's also use the native epoll transport on aarch64 during testing

Modifications:

Add dependency

Result:

Tests use native lib on aarch64