### PR TITLE
Upgrade to latest netty release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <javaModuleName />
     <skipTests>false</skipTests>
     <packaging.type>jar</packaging.type>
-    <netty.version>4.1.92.Final</netty.version>
+    <netty.version>4.1.93.Final</netty.version>
     <netty.build.version>31</netty.build.version>
     <commons.codec.version>1.15</commons.codec.version>
     <junit.version>5.9.0</junit.version>


### PR DESCRIPTION
Motivation:

There was a new netty release which fixes a bug related to recvmmsg usage, let's upgrade

Modifications:

Upgrade to netty 4.1.93.Final

Result:

Use latest netty release