### PR TITLE
Consolidate flushes if possible

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -180,10 +180,10 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
                 }
             }
         } finally {
-            if (pendingBytes > 0) {
+            inChannelReadComplete = false;
+            if (pendingPackets > 0) {
                 flushNow(ctx);
             }
-            inChannelReadComplete = false;
         }
     }
 

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -50,6 +50,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
     private QuicHeaderParser.QuicHeaderProcessor parserCallback;
     private int pendingBytes;
     private int pendingPackets;
+    private boolean inChannelReadComplete;
 
     protected final QuicheConfig config;
     protected final int localConnIdLength;
@@ -163,15 +164,23 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
     @Override
     public final void channelReadComplete(ChannelHandlerContext ctx) {
-        for (;;) {
-            QuicheQuicChannel channel = needsFireChannelReadComplete.poll();
-            if (channel == null) {
-                break;
+        inChannelReadComplete = true;
+        try {
+            for (;;) {
+                QuicheQuicChannel channel = needsFireChannelReadComplete.poll();
+                if (channel == null) {
+                    break;
+                }
+                channel.recvComplete();
+                if (channel.freeIfClosed()) {
+                    connections.remove(channel.key());
+                }
             }
-            channel.recvComplete();
-            if (channel.freeIfClosed()) {
-                connections.remove(channel.key());
+        } finally {
+            if (pendingBytes > 0) {
+                flushNow(ctx);
             }
+            inChannelReadComplete = false;
         }
     }
 
@@ -204,17 +213,25 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
         try {
             ctx.write(msg, promise);
         } finally {
-            // Check if we should force a flush() and so ensure the packets are delivered in a timely
-            // manner and also make room in the outboundbuffer again that belongs to the underlying channel.
-            if (flushStrategy.shouldFlushNow(pendingPackets, pendingBytes)) {
-                flushNow(ctx);
-            }
+            flushIfNeeded(ctx);
         }
     }
 
     @Override
     public final void flush(ChannelHandlerContext ctx) {
-        if (pendingBytes > 0) {
+        // If we are in the channelReadComplete(...) method we might be able to delay the flush(...) until we finish
+        // processing all channels.
+        if (inChannelReadComplete) {
+            flushIfNeeded(ctx);
+        } else if (pendingBytes > 0) {
+            flushNow(ctx);
+        }
+    }
+
+    private void flushIfNeeded(ChannelHandlerContext ctx) {
+        // Check if we should force a flush() and so ensure the packets are delivered in a timely
+        // manner and also make room in the outboundbuffer again that belongs to the underlying channel.
+        if (flushStrategy.shouldFlushNow(pendingPackets, pendingBytes)) {
             flushNow(ctx);
         }
     }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
@@ -61,7 +61,11 @@ final class QuicTestUtils {
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
-                GROUP.shutdownGracefully();
+                try {
+                    GROUP.shutdownGracefully().sync();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
             }
         });
     }


### PR DESCRIPTION
Motivation:

While we are in the channelReadComplete(...) method we might trigger flush() multiple times. This is wasteful as we will most likely do multiple sendto syscalls. We can do a better job by consolidate these flushes to just one and so be able to replace X sendto syscalls with 1 sendmmsg syscall.

Modifications:

- Keep track of if we are currently in the channelReadComplete(...) method and if so try to consolidate flushes.

Result:

Less syscalls