### PR TITLE
Replace EarlyDataSendCallback with SslEarlyDataReadyEvent

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
@@ -52,7 +52,6 @@ public final class QuicChannelBootstrap {
     private QuicConnectionAddress connectionAddress = QuicConnectionAddress.EPHEMERAL;
     private ChannelHandler handler;
     private ChannelHandler streamHandler;
-    private EarlyDataSendCallback earlyDataSendCallback;
 
     /**
      * Creates a new instance which uses the given {@link Channel} to bootstrap the {@link QuicChannel}.
@@ -183,17 +182,6 @@ public final class QuicChannelBootstrap {
     }
 
     /**
-     * Set the {@link EarlyDataSendCallback} to use.
-     *
-     * @param earlyDataSendCallback the callback.
-     * @return                      this instance.
-     */
-    public QuicChannelBootstrap earlyDataSendCallBack(EarlyDataSendCallback earlyDataSendCallback) {
-        this.earlyDataSendCallback = ObjectUtil.checkNotNull(earlyDataSendCallback, "earlyDataSendCallback");
-        return this;
-    }
-
-    /**
      * Connects a {@link QuicChannel} to the remote peer and notifies the future once done.
      *
      * @return {@link Future} which is notified once the operation completes.
@@ -232,8 +220,7 @@ public final class QuicChannelBootstrap {
         final QuicConnectionAddress address = connectionAddress;
         QuicChannel channel = QuicheQuicChannel.forClient(parent, (InetSocketAddress)  local,
                 (InetSocketAddress) remote,
-                streamHandler, Quic.toOptionsArray(streamOptions), Quic.toAttributesArray(streamAttrs),
-                earlyDataSendCallback);
+                streamHandler, Quic.toOptionsArray(streamOptions), Quic.toAttributesArray(streamAttrs));
 
         Quic.setupChannel(channel, Quic.toOptionsArray(options), Quic.toAttributesArray(attrs), handler, logger);
         EventLoop eventLoop = parent.eventLoop();

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SslEarlyDataReadyEvent.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SslEarlyDataReadyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2023 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,16 +15,17 @@
  */
 package io.netty.incubator.codec.quic;
 
+
 /**
- * Implementations of this interface can be used to send early data for a {@link QuicChannel}.
+ * Event which is fired once it's possible to send early data.
+ * <p>
+ * Users might call {@link io.netty.channel.Channel#write(Object)} to send early data. The data is automatically
+ * flushed as part of the connection establishment.
+ * Please be aware that early data may be replay-able and so may have other security concerns then other data.
  */
-@FunctionalInterface
-public interface EarlyDataSendCallback {
-    /**
-     * Allow to send early-data if possible. Please be aware that early data may be replayable and so may have other
-     * security concerns then other data.
-     *
-     * @param quicChannel   the {@link QuicChannel} which will be used to send data on (if any).
-     */
-    void send(QuicChannel quicChannel);
+public final class SslEarlyDataReadyEvent {
+
+    static final SslEarlyDataReadyEvent INSTANCE = new SslEarlyDataReadyEvent();
+
+    private SslEarlyDataReadyEvent() { }
 }


### PR DESCRIPTION
Motivation:

Let's use use an user-event to signal that the user might be able to send early data. This is more consistent with what we usually do in netty.

Modifications:

Replace EarlyDataSendCallback with SslEarlyDataReadyEvent

Result:

More consistent API