### PR TITLE
Fix support for TLS1.3 early data

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SslEarlyDataReadyEvent.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SslEarlyDataReadyEvent.java
@@ -17,7 +17,8 @@ package io.netty.incubator.codec.quic;
 
 
 /**
- * Event which is fired once it's possible to send early data.
+ * Event which is fired once it's possible to send early data on the client-side.
+ * See <a href="https://www.rfc-editor.org/rfc/rfc8446#section-4.2.10">RFC8446 4.2.10 Early Data Indication</a>.
  * <p>
  * Users might call {@link io.netty.channel.Channel#write(Object)} to send early data. The data is automatically
  * flushed as part of the connection establishment.

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SslEarlyDataReadyEvent.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SslEarlyDataReadyEvent.java
@@ -20,8 +20,8 @@ package io.netty.incubator.codec.quic;
  * Event which is fired once it's possible to send early data on the client-side.
  * See <a href="https://www.rfc-editor.org/rfc/rfc8446#section-4.2.10">RFC8446 4.2.10 Early Data Indication</a>.
  * <p>
- * Users might call {@link io.netty.channel.Channel#write(Object)} to send early data. The data is automatically
- * flushed as part of the connection establishment.
+ * Users might call {@link io.netty.channel.Channel#writeAndFlush(Object)} or
+ * {@link io.netty.channel.ChannelHandlerContext#writeAndFlush(Object)} to send early data.
  * Please be aware that early data may be replay-able and so may have other security concerns then other data.
  */
 public final class SslEarlyDataReadyEvent {

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
@@ -597,11 +596,15 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                     @Override
                     public void channelRead(ChannelHandlerContext ctx, Object msg) {
                         ByteBuf buffer = (ByteBuf) msg;
-                        assertEquals(4, buffer.readableBytes());
-                        assertEquals(1, buffer.readInt());
-                        readLatch.countDown();
-                        ctx.close();
-                        ctx.channel().parent().close();
+                        try {
+                            assertEquals(4, buffer.readableBytes());
+                            assertEquals(1, buffer.readInt());
+                            readLatch.countDown();
+                            ctx.close();
+                            ctx.channel().parent().close();
+                        } finally {
+                            buffer.release();
+                        }
                     }
                 });
         InetSocketAddress address = (InetSocketAddress) server.localAddress();


### PR DESCRIPTION
Motivation:

How early data support was implemented was incorrect. We should only indicate early data is ready when it really is.

Modifications:

- Fix implementation to only notify about early data readiness when it is actually the case
- Fix unit test

Result:

Correctly handle and support early data