### PR TITLE
Add GraalVM step for PR testing

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -39,6 +39,9 @@ jobs:
           - setup: linux-aarch64-java8
             docker-compose-build: "-f docker/docker-compose.centos-7-cross.yaml build"
             docker-compose-run: "-f docker/docker-compose.centos-7-cross.yaml run cross-compile-aarch64-build"
+          - setup: linux-x86_64-java17-graalvm
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.graalvm117.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.graalvm117.yaml run build-leak"
 
     runs-on: ubuntu-latest
     name: ${{ matrix.setup }} build

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -25,7 +25,8 @@ RUN yum install -y \
  tar \
  unzip \
  wget \
- zip
+ zip \
+ zlib-devel
 
 RUN mkdir $SOURCE_DIR
 WORKDIR $SOURCE_DIR
@@ -63,3 +64,6 @@ RUN echo 'PATH=$PATH:$HOME/.cargo/bin' >> ~/.bashrc
 # Prepare our own build
 ENV PATH /root/.sdkman/candidates/maven/current:$PATH
 ENV JAVA_HOME /root/.sdkman/candidates/java/current
+
+# when the JDK is GraalVM install native-image
+RUN if [ -O /root/.sdkman/candidates/java/current/bin/gu ]; then /root/.sdkman/candidates/java/current/bin/gu install native-image; else echo "Not GraalVM, skip installation of native-image" ; fi

--- a/docker/docker-compose.centos-7.graalvm117.yaml
+++ b/docker/docker-compose.centos-7.graalvm117.yaml
@@ -1,0 +1,21 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-codec-quic-centos6:centos-6-1.17
+    build:
+      args:
+        java_version : "22.3.r17-grl"
+
+  build:
+    image: netty-codec-quic-centos6:centos-6-1.17
+
+  build-leak:
+    image: netty-codec-quic-centos6:centos-6-1.17
+
+  build-clean:
+    image: netty-codec-quic-centos6:centos-6-1.17
+
+  shell:
+    image: netty-codec-quic-centos6:centos-6-1.17

--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -30,6 +30,12 @@
   <profiles>
     <profile>
       <id>native-image-quic-server</id>
+      <activation>
+        <file>
+          <!-- GraalVM Component Updater should exist when using GraalVM-->
+          <exists>${java.home}/bin/gu</exists>
+        </file>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>${project.groupId}</groupId>
@@ -116,6 +122,12 @@
     </profile>
     <profile>
       <id>native-image-quic-client</id>
+      <activation>
+        <file>
+          <!-- GraalVM Component Updater should exists when using GraalVM-->
+          <exists>${java.home}/bin/gu</exists>
+        </file>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Motivation:

Adding GraalVM step for PR testing, checks that the GraalVM metadata is correct.

Modifications:
- Add GraalVM step for PR testing

Result:
GraalVM metadata is tested while building the PR