### PR TITLE
Ensure private key and cert chain are always destroyed even when the …

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallbackTask.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallbackTask.java
@@ -58,4 +58,16 @@ final class BoringSSLCertificateCallbackTask extends BoringSSLTask {
             taskCallback.onResult(ssl, 0);
         }
     }
+
+    @Override
+    protected void destroy() {
+        if (key != 0) {
+            BoringSSL.EVP_PKEY_free(key);
+            key = 0;
+        }
+        if (chain != 0) {
+            BoringSSL.CRYPTO_BUFFER_stack_free(chain);
+            chain = 0;
+        }
+    }
 }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLTask.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLTask.java
@@ -19,9 +19,6 @@ package io.netty.incubator.codec.quic;
  * A SSL related task that will be returned by {@link BoringSSL#SSL_getTask(long)}.
  */
 abstract class BoringSSLTask implements Runnable {
-    private static final Runnable NOOP = () -> {
-        // NOOP
-    };
     private final long ssl;
     protected boolean didRun;
 
@@ -43,6 +40,13 @@ abstract class BoringSSLTask implements Runnable {
                 complete = true;
             });
         }
+    }
+
+    /**
+     * Called once the task should be destroyed.
+     */
+    protected void destroy() {
+        // Noop
     }
 
     /**

--- a/codec-native-quic/src/main/resources/META-INF/native-image/io.netty.incubator/netty-incubator-codec-native-quic/jni-config.json
+++ b/codec-native-quic/src/main/resources/META-INF/native-image/io.netty.incubator/netty-incubator-codec-native-quic/jni-config.json
@@ -73,7 +73,8 @@
   "fields":[
     {"name":"complete"}, 
     {"name":"returnValue"}
-  ]
+  ],
+  "methods":[{"name":"destroy","parameterTypes":[] }]
 },
 {
   "condition":{"typeReachable":"io.netty.incubator.codec.quic.Quiche"},


### PR DESCRIPTION
…result is not used

Motivation:

We need to ensure the cert chain and the key are also destroyed if we not run the certificate_cb again to pick them up.

Modifications:

- Add destroy() method to BoringSSLTask that we call whenever we destroy the BoringSSLTask.
- Implement this method to release key and chain if needded.

Result:

Fix possible memory leak