### PR TITLE
fix jni_GetByteArrayElements release

### DIFF
--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -498,14 +498,14 @@ static enum ssl_private_key_result_t netty_boringssl_private_key_complete_java(S
 
         arrayLen = (*e)->GetArrayLength(e, resultBytes);
         if (max_out < arrayLen) {
-            // We need to fail as otherwise we would end up writing into memory which does not
-            // belong to us.
+             // We need to fail as otherwise we would end up writing into memory which does not
+             // belong to us.
             (*e)->DeleteLocalRef(e, resultBytes);
             return ssl_private_key_failure;
         }
         b = (*e)->GetByteArrayElements(e, resultBytes, NULL);
         memcpy(out, b, arrayLen);
-        (*e)->ReleaseByteArrayElements(e, resultBytes, b, 0);
+        (*e)->ReleaseByteArrayElements(e, resultBytes, b, JNI_ABORT);
         (*e)->DeleteLocalRef(e, resultBytes);
         *out_len = arrayLen;
         return ssl_private_key_success;

--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -185,15 +185,9 @@ static STACK_OF(CRYPTO_BUFFER)* arrayToStack(JNIEnv* env, jobjectArray array, CR
             CRYPTO_BUFFER_free(buffer);
             goto cleanup;
         }
-        (*env)->ReleaseByteArrayElements(env, bytes, (jbyte*)data, 0);
-        (*env)->DeleteLocalRef(env, bytes);
     }
     return stack;
 cleanup:
-    for (int j = 0; j < sk_CRYPTO_BUFFER_num(stack); j++) {
-        CRYPTO_BUFFER *buffer = sk_CRYPTO_BUFFER_value(stack, j);
-        CRYPTO_BUFFER_free(buffer);
-    }
     sk_CRYPTO_BUFFER_pop_free(stack, CRYPTO_BUFFER_free);
     return NULL;
 }
@@ -502,15 +496,13 @@ static enum ssl_private_key_result_t netty_boringssl_private_key_complete_java(S
 
         arrayLen = (*e)->GetArrayLength(e, resultBytes);
         if (max_out < arrayLen) {
-            // We need to fail as otherwise we would end up writing into memory which does not
-            // belong to us.
-            (*e)->DeleteLocalRef(e, resultBytes);
+             // We need to fail as otherwise we would end up writing into memory which does not
+             // belong to us.
             return ssl_private_key_failure;
         }
         b = (*e)->GetByteArrayElements(e, resultBytes, NULL);
         memcpy(out, b, arrayLen);
-        (*e)->ReleaseByteArrayElements(e, resultBytes, b, 0);
-        (*e)->DeleteLocalRef(e, resultBytes);
+        (*e)->ReleaseByteArrayElements(e, resultBytes, b, JNI_ABORT);
         *out_len = arrayLen;
         return ssl_private_key_success;
     }
@@ -1230,10 +1222,8 @@ jlong netty_boringssl_EVP_PKEY_parse(JNIEnv* env, jclass clazz, jbyteArray array
         (*env)->ReleaseStringUTFChars(env, password, charPass);
     }
     if (key == NULL) {
-        (*env)->ReleaseByteArrayElements(env, array, (jbyte*)data, JNI_ABORT);
         return -1;
     }
-    (*env)->ReleaseByteArrayElements(env, array, (jbyte*)data, JNI_ABORT);
     return (jlong) key;
 }
 

--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -190,10 +190,6 @@ static STACK_OF(CRYPTO_BUFFER)* arrayToStack(JNIEnv* env, jobjectArray array, CR
     }
     return stack;
 cleanup:
-    for (int j = 0; j < sk_CRYPTO_BUFFER_num(stack); j++) {
-        CRYPTO_BUFFER *buffer = sk_CRYPTO_BUFFER_value(stack, j);
-        CRYPTO_BUFFER_free(buffer);
-    }
     sk_CRYPTO_BUFFER_pop_free(stack, CRYPTO_BUFFER_free);
     return NULL;
 }

--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -185,7 +185,7 @@ static STACK_OF(CRYPTO_BUFFER)* arrayToStack(JNIEnv* env, jobjectArray array, CR
             CRYPTO_BUFFER_free(buffer);
             goto cleanup;
         }
-        (*env)->ReleaseByteArrayElements(env, bytes, (jbyte*)data, 0);
+        (*env)->ReleaseByteArrayElements(env, bytes, (jbyte*)data, JNI_ABORT);
         (*env)->DeleteLocalRef(env, bytes);
     }
     return stack;

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -667,13 +667,9 @@ static void netty_quiche_config_set_active_connection_id_limit(JNIEnv* env, jcla
 }
 
 static void netty_quiche_config_set_stateless_reset_token(JNIEnv* env, jclass clazz, jlong config, jbyteArray token) {
-    jbyte* buf = (*env)->GetByteArrayElements(env, token, NULL);
-    jsize buf_len = (*env)->GetArrayLength(env, token);
-    uint8_t* token_buf = (uint8_t*) malloc(buf_len * sizeof(uint8_t));
-    memcpy(token_buf, buf, buf_len);
-    (*env)->ReleaseByteArrayElements(env, token, buf, JNI_ABORT);
-    quiche_config_set_stateless_reset_token((quiche_config*) config, token_buf);
-    free(token_buf);
+    uint8_t* buf = (uint8_t*) (*env)->GetByteArrayElements(env, token, 0);
+    quiche_config_set_stateless_reset_token((quiche_config*) config, buf);
+    (*env)->ReleaseByteArrayElements(env, token, (jbyte*)buf, JNI_ABORT);
 }
 
 static void netty_quiche_config_free(JNIEnv* env, jclass clazz, jlong config) {

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -584,9 +584,7 @@ static jint netty_quiche_conn_dgram_send(JNIEnv* env, jclass clazz, jlong conn, 
 static jint netty_quiche_conn_set_session(JNIEnv* env, jclass clazz, jlong conn, jbyteArray sessionBytes) {
     int buf_len = (*env)->GetArrayLength(env, sessionBytes);
     uint8_t* buf = (uint8_t*) (*env)->GetByteArrayElements(env, sessionBytes, 0);
-    int result = (jint) quiche_conn_set_session((quiche_conn *) conn, (uint8_t *) buf, (size_t) buf_len);
-    (*env)->ReleaseByteArrayElements(env, sessionBytes, (jbyte*) buf, JNI_ABORT);
-    return result;
+    return (jint) quiche_conn_set_session((quiche_conn *) conn, (uint8_t *) buf, (size_t) buf_len);
 }
 
 static jint netty_quiche_conn_max_send_udp_payload_size(JNIEnv* env, jclass clazz, jlong conn) {

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -584,7 +584,9 @@ static jint netty_quiche_conn_dgram_send(JNIEnv* env, jclass clazz, jlong conn, 
 static jint netty_quiche_conn_set_session(JNIEnv* env, jclass clazz, jlong conn, jbyteArray sessionBytes) {
     int buf_len = (*env)->GetArrayLength(env, sessionBytes);
     uint8_t* buf = (uint8_t*) (*env)->GetByteArrayElements(env, sessionBytes, 0);
-    return (jint) quiche_conn_set_session((quiche_conn *) conn, (uint8_t *) buf, (size_t) buf_len);
+    int result = (jint) quiche_conn_set_session((quiche_conn *) conn, (uint8_t *) buf, (size_t) buf_len);
+    (*env)->ReleaseByteArrayElements(env, sessionBytes, (jbyte*) buf, JNI_ABORT);
+    return result;
 }
 
 static jint netty_quiche_conn_max_send_udp_payload_size(JNIEnv* env, jclass clazz, jlong conn) {

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -584,7 +584,9 @@ static jint netty_quiche_conn_dgram_send(JNIEnv* env, jclass clazz, jlong conn, 
 static jint netty_quiche_conn_set_session(JNIEnv* env, jclass clazz, jlong conn, jbyteArray sessionBytes) {
     int buf_len = (*env)->GetArrayLength(env, sessionBytes);
     uint8_t* buf = (uint8_t*) (*env)->GetByteArrayElements(env, sessionBytes, 0);
-    return (jint) quiche_conn_set_session((quiche_conn *) conn, (uint8_t *) buf, (size_t) buf_len);
+    int result = (jint) quiche_conn_set_session((quiche_conn *) conn, (uint8_t *) buf, (size_t) buf_len);
+    (*env)->ReleaseByteArrayElements(env, sessionBytes, (jbyte*) buf, JNI_ABORT);
+    return result;
 }
 
 static jint netty_quiche_conn_max_send_udp_payload_size(JNIEnv* env, jclass clazz, jlong conn) {
@@ -665,8 +667,13 @@ static void netty_quiche_config_set_active_connection_id_limit(JNIEnv* env, jcla
 }
 
 static void netty_quiche_config_set_stateless_reset_token(JNIEnv* env, jclass clazz, jlong config, jbyteArray token) {
-    uint8_t* buf = (uint8_t*) (*env)->GetByteArrayElements(env, token, 0);
-    quiche_config_set_stateless_reset_token((quiche_config*) config, buf);
+    jbyte* buf = (*env)->GetByteArrayElements(env, token, NULL);
+    jsize buf_len = (*env)->GetArrayLength(env, token);
+    uint8_t* token_buf = (uint8_t*) malloc(buf_len * sizeof(uint8_t));
+    memcpy(token_buf, buf, buf_len);
+    (*env)->ReleaseByteArrayElements(env, token, buf, JNI_ABORT);
+    quiche_config_set_stateless_reset_token((quiche_config*) config, token_buf);
+    free(token_buf);
 }
 
 static void netty_quiche_config_free(JNIEnv* env, jclass clazz, jlong config) {


### PR DESCRIPTION
Caught the memory overflow stack

_malloc_zone_malloc_instrumented_or_legacy libsystem_malloc.dylib
os::malloc(unsigned long, MemoryType, NativeCallStack const&) libjvm.dylib
AllocateHeap(unsigned long, MemoryType, NativeCallStack const&, AllocFailStrategy::AllocFailEnum) libjvm.dylib
jni_GetByteArrayElements libjvm.dylib