### PR TITLE
Upgrade to netty 4.1.94.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <javaModuleName />
     <skipTests>false</skipTests>
     <packaging.type>jar</packaging.type>
-    <netty.version>4.1.93.Final</netty.version>
+    <netty.version>4.1.94.Final</netty.version>
     <netty.build.version>31</netty.build.version>
     <commons.codec.version>1.15</commons.codec.version>
     <junit.version>5.9.0</junit.version>


### PR DESCRIPTION
Motivation:

A new version of netty is out

Modifications:

Upgrade to 4.1.94.Final

Result:

Use latest netty version