### PR TITLE
Fix reentrance guards for writable streams and force close

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -154,7 +154,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private static final int IN_RECV = 1 << 1;
     private static final int IN_CONNECTION_SEND = 1 << 2;
     private static final int IN_HANDLE_WRITABLE_STREAMS = 1 << 3;
-    private static final int IN_FORCE_CLOSE = 1 << 3;
+    private static final int IN_FORCE_CLOSE = 1 << 4;
 
     private static final int CLOSED = 0;
     private static final int OPEN = 1;


### PR DESCRIPTION
Motivation:

QuicheQuicChannel uses bitmasking for its reentrace guard. Unfortunally the guard for writable streams and force close used the same mask and so overlapped.

Modifications:

Use different masks for writable streams and force close

Result:

Correct reentrance guards