### PR TITLE
Remove dependency on commons-codec

### DIFF
--- a/codec-classes-quic/pom.xml
+++ b/codec-classes-quic/pom.xml
@@ -79,10 +79,6 @@
       <artifactId>netty-transport</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-classes-epoll</artifactId>
       <!-- Let's mark as optional as it is not strictly needed -->

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/HmacSignQuicConnectionIdGenerator.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/HmacSignQuicConnectionIdGenerator.java
@@ -16,12 +16,15 @@
 package io.netty.incubator.codec.quic;
 
 import java.nio.ByteBuffer;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Arrays;
 
 import io.netty.util.internal.ObjectUtil;
-import org.apache.commons.codec.digest.HmacAlgorithms;
-import org.apache.commons.codec.digest.HmacUtils;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 /**
  * A {@link QuicConnectionIdGenerator} which creates new connection id by signing the given input
@@ -29,6 +32,8 @@ import org.apache.commons.codec.digest.HmacUtils;
  */
 final class HmacSignQuicConnectionIdGenerator implements QuicConnectionIdGenerator {
     static final QuicConnectionIdGenerator INSTANCE = new HmacSignQuicConnectionIdGenerator();
+
+    private static final String ALGORITM = "HmacSHA256";
     private static final byte[] randomKey = new byte[16];
 
     static {
@@ -44,13 +49,29 @@ final class HmacSignQuicConnectionIdGenerator implements QuicConnectionIdGenerat
                 "HmacSignQuicConnectionIdGenerator should always have an input to sign with");
     }
 
+    private static Mac newMac() {
+        try {
+            SecretKeySpec keySpec = new SecretKeySpec(randomKey, ALGORITM);
+            Mac mac = Mac.getInstance(ALGORITM);
+            mac.init(keySpec);
+            return mac;
+        } catch (NoSuchAlgorithmException | InvalidKeyException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
     @Override
     public ByteBuffer newId(ByteBuffer buffer, int length) {
         ObjectUtil.checkNotNull(buffer, "buffer");
         ObjectUtil.checkPositive(buffer.remaining(), "buffer");
         ObjectUtil.checkInRange(length, 0, maxConnectionIdLength(), "length");
 
-        byte[] signBytes = new HmacUtils(HmacAlgorithms.HMAC_SHA_256, randomKey).hmac(buffer);
+
+        // TODO: Consider using a ThreadLocal.
+        Mac mac = newMac();
+        mac.update(buffer);
+
+        byte[] signBytes = mac.doFinal();
         if (signBytes.length != length) {
             signBytes = Arrays.copyOf(signBytes, length);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
     <packaging.type>jar</packaging.type>
     <netty.version>4.1.94.Final</netty.version>
     <netty.build.version>31</netty.build.version>
-    <commons.codec.version>1.15</commons.codec.version>
     <junit.version>5.9.0</junit.version>
     <native.maven.plugin.version>0.9.22</native.maven.plugin.version>
     <test.argLine>-D_</test.argLine>
@@ -384,11 +383,6 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-transport</artifactId>
         <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>${commons.codec.version}</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
Motivation:

We dont need this extra dependency as we can just directly use what is provided by the JDK

Modifications:

Remove dependency and call directly what we have in the JDK

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/538