### PR TITLE
Fix 0RTT test when offloading tasks

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicClientSessionCache.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicClientSessionCache.java
@@ -71,6 +71,17 @@ final class QuicClientSessionCache {
         }
     }
 
+    // Only used for testing.
+    boolean hasSession(String host, int port) {
+        HostPort hostPort = keyFor(host, port);
+        if (hostPort != null) {
+            synchronized (sessions) {
+                return sessions.containsKey(hostPort);
+            }
+        }
+        return false;
+    }
+
     byte[] getSession(String host, int port) {
         HostPort hostPort = keyFor(host, port);
         if (hostPort != null) {


### PR DESCRIPTION
Motivation:

We need to ensure the session was added to the cache before creating the second connection as otherwise the test will timeout due not re-using sessions.

Modifications:

- Add extra method to QuicClientSessionCache that we can use to check if a session was added
- Spin until the session was added to the cache and only after that try to connect the second time

Result:

No more timeouts due a race when testing for 0RTT. Fixes https://github.com/netty/netty-incubator-codec-quic/issues/544