### PR TITLE
Directly close stream when STREAM_STOPPED is received.

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -906,11 +906,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                             if (streamChannel != null) {
                                 int capacity = Quiche.quiche_conn_stream_capacity(connAddr, streamId);
                                 if (capacity < 0) {
-                                    if (capacity == Quiche.QUICHE_ERR_STREAM_STOPPED) {
-                                        // Streams that received STOP_SENDING and no longer writable
-                                        // but should be not closed.
-                                        continue;
-                                    }
                                     if (!Quiche.quiche_conn_stream_finished(connAddr, streamId)) {
                                         // Only fire an exception if the error was not caused because the stream is
                                         // considered finished.


### PR DESCRIPTION
Motivation:

We should just directly close the stream when STREAM_STOPPED is received as it will always lead to a RESET_STREAM.

Modifications:

Remove special handling of STREAM_STOPPED

Result:

Faster closing of channel when STREAM_STOPPED is received