### PR TITLE
Don't leak buffers when segments are used and the connect promise is …

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SegmentedDatagramPacketAllocator.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SegmentedDatagramPacketAllocator.java
@@ -42,7 +42,7 @@ public interface SegmentedDatagramPacketAllocator {
     };
 
     /**
-     * The maximum number of segments to use per packet. By default this is {@code 10} but this may be overriden by
+     * The maximum number of segments to use per packet. By default this is {@code 10} but this may be overridden by
      * the implementation of the interface.
      *
      * @return  the segments.


### PR DESCRIPTION
…failed

Motivation:

It was possible we leaked buffers when the connect promise was failed while we already started to collect buffers for segments.

Modifications:

- Ensure we write the already collected buffers before return
- Cleanup / simplify code for sending segments
- Add hint to easier debug leaks

Result:

No more buffer leak