### PR TITLE
Upgrade to latest quiche version and update supported quic versions

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -57,7 +57,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>a4ac85642eca40e45cc6e0cfd916d55b81537e2c</quicheCommitSha>
+    <quicheCommitSha>de4c26c1fd3d42c364daedae3fb6a557c3f6fd38</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTest.java
@@ -38,13 +38,11 @@ public class QuicTest extends AbstractQuicTest {
 
     @Test
     public void testVersionSupported() {
-        // draft-27, draft-28, draft-29 and 1 should be supported.
-        assertTrue(Quic.isVersionSupported(0xff00_001b));
-        assertTrue(Quic.isVersionSupported(0xff00_001c));
-        assertTrue(Quic.isVersionSupported(0xff00_001d));
+        // Only v1 should be supported.
+        assertFalse(Quic.isVersionSupported(0xff00_001c));
+        assertFalse(Quic.isVersionSupported(0xff00_001d));
+        assertFalse(Quic.isVersionSupported(0xff00_001c));
         assertTrue(Quic.isVersionSupported(0x0000_0001));
-
-        assertFalse(Quic.isVersionSupported(0xff00_001a));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Let us update to latest quiche code

Modifications:

- Update dependency
- Adjust unit test to match what quiche supports now

Result:

Use latest quiche code as dependency