### PR TITLE
Update used BoringSSL version to match netty-tcnative-boringssl-static

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -45,10 +45,9 @@
     <boringsslHomeBuildDir>${boringsslHomeDir}/build</boringsslHomeBuildDir>
     <boringsslHomeIncludeDir>${boringsslHomeDir}/include</boringsslHomeIncludeDir>
     <boringsslRepository>https://boringssl.googlesource.com/boringssl</boringsslRepository>
-    <!-- Follow what is used in quiche for now -->
-    <!-- https://github.com/cloudflare/quiche/tree/master/quiche/deps -->
-    <boringsslBranch>master</boringsslBranch>
-    <boringsslCommitSha>f1c75347daa2ea81a941e953f2263e0a4d970c8d</boringsslCommitSha>
+    <!-- Lets use what we use in netty-tcnative-boringssl-static -->
+    <boringsslBranch>chromium-stable</boringsslBranch>
+    <boringsslCommitSha>ca1690e221677cea3fb946f324eb89d846ec53f2</boringsslCommitSha>
 
     <quicheSourceDir>${project.build.directory}/quiche-source</quicheSourceDir>
     <quicheBuildDir>${quicheSourceDir}/target/release</quicheBuildDir>
@@ -725,10 +724,10 @@
 
                     <!-- Only copy the libs and header files we need -->
                     <mkdir dir="${boringsslHomeBuildDir}" />
-                    <copy file="${boringsslBuildDir}/${libssl}" todir="${boringsslHomeBuildDir}" verbose="true" />
-                    <copy file="${boringsslBuildDir}/${libcrypto}" todir="${boringsslHomeBuildDir}" verbose="true" />
+                    <copy file="${boringsslBuildDir}/ssl/${libssl}" todir="${boringsslHomeBuildDir}" verbose="true" />
+                    <copy file="${boringsslBuildDir}/crypto/${libcrypto}" todir="${boringsslHomeBuildDir}" verbose="true" />
                     <copy todir="${boringsslHomeIncludeDir}" verbose="true">
-                      <fileset dir="${boringsslSourceDir}/src/include" />
+                      <fileset dir="${boringsslSourceDir}/include" />
                     </copy>
                   </else>
                 </if>
@@ -916,8 +915,8 @@
                       <filter token="BORINGSSL_LIB_DIR" value="${boringsslHomeBuildWindowsDir}" />
                       <filter token="QUICHE_LIB_DIR" value="${quicheHomeBuildWindowsDir}" />
                       <filter token="QUICHE_LIB" value="${libquiche}" />
-                      <filter token="CRYPTO_LIB" value="${libcrypto}" />
-                      <filter token="SSL_LIB" value="${libssl}" />
+                      <filter token="CRYPTO_LIB" value="crypto/${libcrypto}" />
+                      <filter token="SSL_LIB" value="ssl/${libssl}" />
                       <copy file="src/main/native-package/vs2010.custom.props.template" tofile="${templateDir}/vs2010.custom.props" filtering="true" overwrite="true" verbose="true" />
                     </then>
                   </elseif>

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -915,8 +915,8 @@
                       <filter token="BORINGSSL_LIB_DIR" value="${boringsslHomeBuildWindowsDir}" />
                       <filter token="QUICHE_LIB_DIR" value="${quicheHomeBuildWindowsDir}" />
                       <filter token="QUICHE_LIB" value="${libquiche}" />
-                      <filter token="CRYPTO_LIB" value="crypto/${libcrypto}" />
-                      <filter token="SSL_LIB" value="ssl/${libssl}" />
+                      <filter token="CRYPTO_LIB" value="${libcrypto}" />
+                      <filter token="SSL_LIB" value="${libssl}" />
                       <copy file="src/main/native-package/vs2010.custom.props.template" tofile="${templateDir}/vs2010.custom.props" filtering="true" overwrite="true" verbose="true" />
                     </then>
                   </elseif>

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -2,8 +2,8 @@ FROM centos:7
 
 ENV SOURCE_DIR /root/source
 ENV LIBS_DIR /root/libs
-ENV CMAKE_VERSION_BASE 3.8
-ENV CMAKE_VERSION $CMAKE_VERSION_BASE.2
+ENV CMAKE_VERSION_BASE 3.26
+ENV CMAKE_VERSION $CMAKE_VERSION_BASE.4
 ENV NINJA_VERSION 1.7.2
 ENV GO_VERSION 1.9.3
 ENV MAVEN_VERSION 3.9.1
@@ -38,8 +38,7 @@ RUN echo 'source /opt/rh/devtoolset-11/enable' >> ~/.bashrc
 
 RUN wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip && unzip ninja-linux.zip && mkdir -p /opt/ninja-$NINJA_VERSION/bin && mv ninja /opt/ninja-$NINJA_VERSION/bin && echo 'PATH=/opt/ninja-$NINJA_VERSION/bin:$PATH' >> ~/.bashrc
 RUN wget -q https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && tar zxf go$GO_VERSION.linux-amd64.tar.gz && mv go /opt/ && echo 'PATH=/opt/go/bin:$PATH' >> ~/.bashrc && echo 'export GOROOT=/opt/go/' >> ~/.bashrc
-RUN curl -s https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz --output cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && tar zvxf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-Linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-Linux-x86_64/bin:$PATH' >> ~/.bashrc
-
+RUN curl -s https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz --output cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && tar zvxf cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-linux-x86_64/bin:$PATH' >> ~/.bashrc
 
 # Downloading and installing SDKMAN!
 RUN curl -s "https://get.sdkman.io" | bash


### PR DESCRIPTION
Motivation:

Using the same BoringSSL version for different native libs related to netty will make things more consistent and easier to debug

Modifications:

Use the same version as netty-tcnative-boringssl-static

Result:

Consistent usage of BoringSSL version