### PR TITLE
Upgrade to latest jni-util release

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -1151,7 +1151,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-jni-util</artifactId>
-      <version>0.0.3.Final</version>
+      <version>${netty.jni-util.version}</version>
       <classifier>sources</classifier>
       <optional>true</optional>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
     <packaging.type>jar</packaging.type>
     <netty.version>4.1.94.Final</netty.version>
     <netty.build.version>31</netty.build.version>
+    <netty.jni-util.version>0.0.7.Final</netty.jni-util.version>
     <junit.version>5.9.0</junit.version>
     <native.maven.plugin.version>0.9.22</native.maven.plugin.version>
     <test.argLine>-D_</test.argLine>
@@ -355,7 +356,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-jni-util</artifactId>
-        <version>0.0.6.Final</version>
+        <version>${netty.jni-util.version}</version>
         <classifier>sources</classifier>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
Motivation:

We released a new version of jni-util

Modifications:

- Update to latest version

Result:

Use up-to-date version