### PR TITLE
Correctly handle optional client auth on the client

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallback.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallback.java
@@ -102,8 +102,7 @@ final class BoringSSLCertificateCallback {
 
         try {
             if (keyManager == null) {
-                engineMap.remove(ssl);
-                return null;
+                return new long[] { 0, 0 };
             }
             if (engine.getUseClientMode()) {
                 final Set<String> keyTypesSet = supportedClientKeyTypes(keyTypeBytes);

--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -598,6 +598,11 @@ static int quic_certificate_cb(SSL* ssl, void* arg) {
     SSL_set_ex_data(ssl, sslTaskIdx, NULL);
     netty_boringssl_ssl_task_free(e, ssl_task);
 
+    if (pkey == NULL && cchain == NULL) {
+        // No key material found.
+        return 1;
+    }
+
     int numCerts = sk_CRYPTO_BUFFER_num(cchain);
     if (numCerts == 0) {
         goto done;


### PR DESCRIPTION
Motivation:

When client auth is optional we must not fail the handshake on the client side when no keymanager was configured on the client side.

Modifications:

- Fix handling on the client-side
- Add testcase
- Fix test

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/566