### PR TITLE
Update to quiche 0.18.0

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -782,7 +782,7 @@
                       <equals arg1="${platform}" arg2="android" />
                       <then>
                         <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                          <arg line="ndk ${cargoTarget} -p ${androidNdkVersion} -- build --features &quot;ffi qlog&quot; --release" />
+                          <arg line="ndk ${cargoTarget} -p ${androidNdkVersion} -- build --exclude quiche_apps --workspace --features &quot;ffi qlog&quot; --release" />
                           <env key="CFLAGS" value="${extraCflags}" />
                           <env key="CXXFLAGS" value="${extraCxxflags}" />
                           <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
@@ -793,7 +793,7 @@
                           <equals arg1="${os.detected.name}" arg2="windows" />
                           <then>
                             <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                              <arg line="build --features &quot;ffi qlog&quot; --release" />
+                              <arg line="build --exclude quiche_apps --workspace --features &quot;ffi qlog&quot; --release" />
                               <arg value="${cargoTarget}" />
                               <!-- See https://github.com/cloudflare/quiche/blob/0.7.0/src/build.rs#L73 -->
                               <env key="DEBUG" value="true" />
@@ -805,7 +805,7 @@
                             <equals arg1="${crossCompile}" arg2="linux" />
                             <then>
                               <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                                <arg line="build --features &quot;ffi qlog&quot; --release" />
+                                <arg line="build --exclude quiche_apps --workspace --features &quot;ffi qlog&quot; --release" />
                                 <arg value="${cargoTarget}" />
                                 <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
                                 <!-- Lets enable frame-pointers so we can profile better -->
@@ -818,7 +818,7 @@
                             <equals arg1="${crossCompile}" arg2="mac" />
                             <then>
                               <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                                <arg line="build --features &quot;ffi qlog&quot; --release" />
+                                <arg line="build --exclude quiche_apps --workspace --features &quot;ffi qlog&quot; --release" />
                                 <env key="CFLAGS" value="${extraCflags}" />
                                 <env key="CXXFLAGS" value="${extraCxxflags}" />
                                 <arg value="${cargoTarget}" />
@@ -831,7 +831,7 @@
                           </elseif>
                           <else>
                             <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                              <arg line="build --features &quot;ffi qlog&quot; --release" />
+                              <arg line="build --exclude quiche_apps --workspace --features &quot;ffi qlog&quot; --release" />
                               <env key="CFLAGS" value="${extraCflags}" />
                               <env key="CXXFLAGS" value="${extraCxxflags}" />
                               <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -56,7 +56,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>5ddba81a3ab03c0fd4c262d444bded4208013669</quicheCommitSha>
+    <quicheCommitSha>28ef289f027713cb024e3171ccfa2972fc12a9e2</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />


### PR DESCRIPTION
Motivation:

Let's use the commit sha of quiche for the 0.18.0 release.

Modifications:

Change quiche sha

Result:

Use sha that represent the latest quiche release