### PR TITLE
Update workflows to make things more robust when it comes to caching

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -37,6 +37,7 @@ jobs:
 
       # Caching of maven dependencies
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: build-linux-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -44,7 +45,7 @@ jobs:
             build-linux-x86_64-maven-cache-
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
         with:
           key: build-linux-x86_64-docker-cache-{hash}
@@ -76,6 +77,7 @@ jobs:
 
       # Caching of maven dependencies
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: build-linux-aarch64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -83,7 +85,7 @@ jobs:
             build-linux-aarch64-maven-cache-
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
         with:
           key: build-linux-aarch64-docker-cache-{hash}
@@ -143,6 +145,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: windows-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -202,6 +205,7 @@ jobs:
       # Cache .m2/repository
       # Caching of maven dependencies
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: android-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -47,6 +47,7 @@ jobs:
 
       # Caching of maven dependencies
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: stage-snapshot-${{ matrix.setup }}-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -63,7 +64,7 @@ jobs:
             }]
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         env:
           docker-cache-name: staging-${{ matrix.setup }}-cache-docker
         continue-on-error: true
@@ -127,6 +128,7 @@ jobs:
 
       # Caching of maven dependencies
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: stage-snapshot-windows-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -167,6 +169,7 @@ jobs:
 
       # Caching of maven dependencies
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: deploy-staged-snapshots-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -51,6 +51,7 @@ jobs:
       # Cache .m2/repository
       - name: Cache local Maven repository
         uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ matrix.setup }}-${{ hashFiles('**/pom.xml') }}
@@ -59,7 +60,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
         with:
           key: build-docker-cache-${{ matrix.setup }}-{hash}
@@ -135,6 +136,7 @@ jobs:
       # Cache .m2/repository
       # Caching of maven dependencies
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: pr-windows-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -201,6 +203,7 @@ jobs:
       # Cache .m2/repository
       # Caching of maven dependencies
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: pr-android-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -49,6 +49,7 @@ jobs:
 
       # Caching of maven dependencies
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: prepare-release-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -113,6 +114,7 @@ jobs:
 
       # Caching of maven dependencies
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: staging-${{ matrix.setup }}-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -120,7 +122,7 @@ jobs:
             staging-${{ matrix.setup }}-maven-cache-
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         env:
           docker-cache-name: staging-${{ matrix.setup }}-cache-docker
         continue-on-error: true
@@ -228,6 +230,7 @@ jobs:
 
       # Caching of maven dependencies
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: stage-release-windows-x86_64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -321,6 +324,7 @@ jobs:
 
       # Caching of maven dependencies
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: deploy-staged-release-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-verify-load.yml
+++ b/.github/workflows/ci-verify-load.yml
@@ -36,6 +36,7 @@ jobs:
 
       # Caching of maven dependencies
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: sinstall-jars-linux-aarch64-maven-cache-${{ hashFiles('**/pom.xml') }}
@@ -43,7 +44,7 @@ jobs:
             install-jars-linux-aarch64-maven-cache-
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
         with:
           key: pr-linux-x86_64-docker-cache-{hash}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,6 +46,7 @@ jobs:
 
     # Caching of maven dependencies
     - uses: actions/cache@v3
+      continue-on-error: true
       with:
         path: ~/.m2/repository
         key: analyze-${{ matrix.language }}-maven-cache-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Motivation:

When caching fails during workflow execution we should still continue the build as its just an optimization. Also we should use the new fork for docker layer caching

Modifications:

- Update action that does the docker layer caching to the new fork
- Ignore errors during caching

Result:

More stable builds