### PR TITLE
Add javaModuleNameClassifier property to Android profile

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -288,6 +288,7 @@
         <!-- https://developer.android.com/ndk/guides/other_build_systems -->
         <jniLibName>netty_quiche</jniLibName>
         <jni.classifier>${platform}</jni.classifier>
+        <javaModuleNameClassifier>android</javaModuleNameClassifier>
         <cflags>-std=c99 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3 -I${quicheHomeIncludeDir} -I${boringsslHomeIncludeDir}</cflags>
         <ldflags>-L${quicheHomeBuildDir} -lquiche -L${boringsslHomeBuildDir} -lssl -lcrypto</ldflags>
         <bundleNativeCode>META-INF/native/${jniLibName}.dll;osname=android;processor=${androidAbi}</bundleNativeCode>


### PR DESCRIPTION
Motivation:

The javaModuleNameClassifier was missing in the android profile and therefore the `AndroidManifest.xml` contained `package="io.netty.incubator.codec.quic.linux.x86_64"`

Modifications:

Added javaModuleNameClassifier property in pom.xml

Result:

Show the right package name in the `AndroidManifest.xml`