### PR TITLE
Add PR builds with unsafe disabled

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -33,6 +33,9 @@ jobs:
           - setup: linux-x86_64-java8
             docker-compose-build: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build"
             docker-compose-run: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run build-leak"
+          - setup: linux-x86_64-java8-no-unsafe
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.18.yaml run build-no-unsafe"
           - setup: linux-x86_64-java17
             docker-compose-build: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.117.yaml build"
             docker-compose-run: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.117.yaml run build-leak"

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -491,6 +491,14 @@
       </properties>
     </profile>
 
+    <!-- Build with unsafe disabled which also means the memory address cant be accessed-->
+    <profile>
+      <id>noUnsafe</id>
+      <properties>
+        <test.argLine>-Dio.netty.noUnsafe=true</test.argLine>
+      </properties>
+    </profile>
+
     <!-- Profile related to native-image -->
     <!-- ./mvnw -Pnative-image-agent -pl codec-native-quic test -->
     <profile>

--- a/docker/docker-compose.centos-7.117.yaml
+++ b/docker/docker-compose.centos-7.117.yaml
@@ -14,6 +14,9 @@ services:
   build-leak:
     image: netty-codec-quic-centos6:centos-6-1.17
 
+  build-no-unsafe:
+    image: netty-codec-quic-centos6:centos-6-1.17
+
   build-clean:
     image: netty-codec-quic-centos6:centos-6-1.17
 

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -14,6 +14,9 @@ services:
   build-leak:
     image: netty-codec-quic-centos6:centos-6-1.8
 
+  build-no-unsafe:
+    image: netty-codec-quic-centos6:centos-6-1.8
+
   build-clean:
     image: netty-codec-quic-centos6:centos-6-1.8
 

--- a/docker/docker-compose.centos-7.graalvm117.yaml
+++ b/docker/docker-compose.centos-7.graalvm117.yaml
@@ -14,6 +14,9 @@ services:
   build-leak:
     image: netty-codec-quic-centos6:centos-6-1.17
 
+  build-no-unsafe:
+    image: netty-codec-quic-centos6:centos-6-1.17
+
   build-clean:
     image: netty-codec-quic-centos6:centos-6-1.17
 

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -31,6 +31,10 @@ services:
     <<: *common
     command: /bin/bash -cl "./mvnw -B -ntp -Pleak clean package"
 
+  build-no-unsafe:
+    <<: *common
+    command: /bin/bash -cl "./mvnw -B -ntp -PnoUnsafe clean package"
+
   build-clean:
     <<: *common
     command: /bin/bash -cl "./mvnw -B -ntp clean package"


### PR DESCRIPTION
Motivation:

We recently had a bug which only showed up when the memoryAddress of a direct buffer could not be accessed directly. We didnt catch this as the memory address always was accessible by unsafe. Let's add a PR build job which explicit disable unsafe.

Modifications:

- Add profile which disables unsafe during build
- Add job which builds with unsafe disabled

Result:

Better test coverage