### PR TITLE
Fix bug related to memoryAddress access when unsafe is not accessible…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -1602,10 +1602,12 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                         return;
                     }
 
-                    ByteBuf datagramBuffer = alloc().ioBuffer(len);
+                    ByteBuf datagramBuffer = alloc().directBuffer(len);
                     int writerIndex = datagramBuffer.writerIndex();
+                    long memoryAddress = Quiche.writerMemoryAddress(datagramBuffer);
+
                     int written = Quiche.quiche_conn_dgram_recv(connAddr,
-                            datagramBuffer.memoryAddress() + writerIndex, datagramBuffer.writableBytes());
+                            memoryAddress, datagramBuffer.writableBytes());
                     try {
                         if (Quiche.throwIfError(written)) {
                             datagramBuffer.release();


### PR DESCRIPTION
… and Datagram extension is used

Motivation:

We can't assume we can directly access the memoryAddress of the ByteBuf as it might not be possible on all platforms or even explicit disabled by the end user

Modifications:

Use static helper method that will always be able to return the correct memory address

Result:

Code works as expected on all platforms