### PR TITLE
Use easimon/maximize-build-space to free up build space

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -33,12 +33,11 @@ jobs:
     runs-on: ubuntu-latest
     name: linux-x86_64
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
         with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
 
       - uses: actions/checkout@v3
 
@@ -80,12 +79,11 @@ jobs:
     runs-on: ubuntu-latest
     name: linux-aarch64
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
         with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -43,12 +43,11 @@ jobs:
 
     name: stage-snapshot-${{ matrix.setup }}
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
         with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
 
       - uses: actions/checkout@v3
 
@@ -166,12 +165,11 @@ jobs:
     # Wait until we have staged everything
     needs: [stage-snapshot-linux, stage-snapshot-windows-x86_64]
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
         with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -49,12 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ matrix.setup }} build
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
         with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -26,12 +26,11 @@ jobs:
   prepare-release:
     runs-on: ubuntu-latest
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
         with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
 
       - uses: actions/checkout@v3
         with:
@@ -93,12 +92,11 @@ jobs:
     name: stage-release-${{ matrix.setup }}
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
         with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
 
       - name: Download release-workspace
         uses: actions/download-artifact@v3
@@ -284,12 +282,11 @@ jobs:
     # Wait until we have staged everything
     needs: [stage-release-linux, stage-release-windows-x86_64]
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
         with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
 
       - name: Download release-workspace
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci-verify-load.yml
+++ b/.github/workflows/ci-verify-load.yml
@@ -32,12 +32,11 @@ jobs:
   install-jars-linux-aarch64:
     runs-on: ubuntu-latest
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
         with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
 
       - uses: actions/checkout@v3
 
@@ -77,12 +76,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ install-jars-linux-aarch64 ]
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
         with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
 
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Motivation:

The previous action we used does not work anymore and so failed the build. Let's use a better maintained action for the purpose of maximize build space.

Modifications:

Use easimon/maximize-build-space

Result:

Build works again