### PR TITLE
Revert "Run action that frees up diskspace during workflows (#573)"

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -33,13 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     name: linux-x86_64
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
       - uses: actions/checkout@v3
 
       # Caching of maven dependencies
@@ -80,13 +73,6 @@ jobs:
     runs-on: ubuntu-latest
     name: linux-aarch64
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
       - uses: actions/checkout@v3
 
       # Caching of maven dependencies

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -43,13 +43,6 @@ jobs:
 
     name: stage-snapshot-${{ matrix.setup }}
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
       - uses: actions/checkout@v3
 
       # Caching of maven dependencies
@@ -166,13 +159,6 @@ jobs:
     # Wait until we have staged everything
     needs: [stage-snapshot-linux, stage-snapshot-windows-x86_64]
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
       - uses: actions/checkout@v3
 
       - name: Set up JDK 8

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -49,13 +49,6 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ matrix.setup }} build
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
       - uses: actions/checkout@v3
 
       # Cache .m2/repository

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -26,13 +26,6 @@ jobs:
   prepare-release:
     runs-on: ubuntu-latest
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
       - uses: actions/checkout@v3
         with:
           ref: main
@@ -93,13 +86,6 @@ jobs:
     name: stage-release-${{ matrix.setup }}
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
       - name: Download release-workspace
         uses: actions/download-artifact@v3
         with:
@@ -284,13 +270,6 @@ jobs:
     # Wait until we have staged everything
     needs: [stage-release-linux, stage-release-windows-x86_64]
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
       - name: Download release-workspace
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci-verify-load.yml
+++ b/.github/workflows/ci-verify-load.yml
@@ -32,13 +32,6 @@ jobs:
   install-jars-linux-aarch64:
     runs-on: ubuntu-latest
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
       - uses: actions/checkout@v3
 
       # Caching of maven dependencies
@@ -77,13 +70,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ install-jars-linux-aarch64 ]
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
       - uses: actions/checkout@v3
 
       - name: Download the maven repository


### PR DESCRIPTION
Motivation:

The used github action does not work anymore

Modifications:

This reverts commit 776c601ba3d3849b798faa9acf313f43584c81cd.

Result:

Build pass again