### PR TITLE
Enable build with JDK21

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -39,6 +39,9 @@ jobs:
           - setup: linux-x86_64-java17
             docker-compose-build: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.117.yaml build"
             docker-compose-run: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.117.yaml run build-leak"
+          - setup: linux-x86_64-java21
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.21.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml -f docker/docker-compose.centos-7.21.yaml run build-leak"
           - setup: linux-aarch64-java8
             docker-compose-build: "-f docker/docker-compose.centos-7-cross.yaml build"
             docker-compose-run: "-f docker/docker-compose.centos-7-cross.yaml run cross-compile-aarch64-build"

--- a/docker/docker-compose.centos-7.21.yaml
+++ b/docker/docker-compose.centos-7.21.yaml
@@ -1,0 +1,36 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-codec-quic-centos7:centos-7-21
+    build:
+      args:
+        java_version : "21-zulu"
+
+  build:
+    image: netty-codec-quic-centos7:centos-7-21
+
+  build-leak:
+    image: netty-codec-quic-centos7:centos-7-21
+
+  build-no-unsafe:
+    image: netty-codec-quic-centos7:centos-7-21
+
+  build-clean:
+    image: netty-codec-quic-centos7:centos-7-21
+
+  deploy:
+    image: netty-codec-quic-centos7:centos-7-21
+
+  deploy-clean:
+    image: netty-codec-quic-centos7:centos-7-21
+
+  stage-snapshot:
+    image: netty-codec-quic-centos7:centos-7-21
+
+  stage-release:
+    image: netty-codec-quic-centos7:centos-7-21
+
+  shell:
+    image: netty-codec-quic-centos7:centos-7-21


### PR DESCRIPTION
Motivation:

Now that JDK21 is released we should also build with it on our CI

Modifications:

Add docker-compose config for JDK21 and use it in the PR workflow

Result:

Test with latest LTS release