### PR TITLE
Remove the comment about Apple M1 support from resource-config.json as it is not needed anymore

### DIFF
--- a/codec-native-quic/src/main/resources/META-INF/native-image/io.netty.incubator/netty-incubator-codec-native-quic/resource-config.json
+++ b/codec-native-quic/src/main/resources/META-INF/native-image/io.netty.incubator/netty-incubator-codec-native-quic/resource-config.json
@@ -7,8 +7,7 @@
     },
     {
       "condition":{"typeReachable":"io.netty.incubator.codec.quic.Quiche"},
-      "pattern":"\\QMETA-INF/native/libnetty_quiche_osx_aarch_64.jnilib\\E",
-      "//note": "Apple M1 is still not supported https://github.com/oracle/graal/issues/2666"
+      "pattern":"\\QMETA-INF/native/libnetty_quiche_osx_aarch_64.jnilib\\E"
     },
     {
       "condition":{"typeReachable":"io.netty.incubator.codec.quic.Quiche"},

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <netty.build.version>31</netty.build.version>
     <netty.jni-util.version>0.0.9.Final</netty.jni-util.version>
     <junit.version>5.9.0</junit.version>
-    <native.maven.plugin.version>0.9.22</native.maven.plugin.version>
+    <native.maven.plugin.version>0.9.27</native.maven.plugin.version>
     <test.argLine>-D_</test.argLine>
     <bundleNativeCode />
     <crossCompile />


### PR DESCRIPTION
Motivation:
Recently GraalVM added support for Apple M1.

Modifications:
- Remove the comment from resource-config.json file
- Update the version for native-maven-plugin

Result:
The comment in resource-config.json is not needed anymore.