### PR TITLE
Do not try to delete a global handle with the local handles APIs

### DIFF
--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -1394,7 +1394,6 @@ jint netty_boringssl_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     NETTY_JNI_UTIL_LOAD_CLASS_WEAK(env, sslTaskClassWeak, name, done);
     NETTY_JNI_UTIL_NEW_LOCAL_FROM_WEAK(env, sslTaskClass, sslTaskClassWeak, done);
 
-    NETTY_JNI_UTIL_LOAD_CLASS(env, sslTaskClass, name, done);
     NETTY_JNI_UTIL_GET_FIELD(env, sslTaskClass, sslTaskReturnValue, "returnValue", "I", done);
     NETTY_JNI_UTIL_GET_FIELD(env, sslTaskClass, sslTaskComplete, "complete", "Z", done);
     NETTY_JNI_UTIL_GET_METHOD(env, sslTaskClass, sslTaskDestroyMethod, "destroy", "()V", done);


### PR DESCRIPTION
Motivation:

The code introduced as part of https://github.com/netty/netty-incubator-codec-quic/pull/574 contained a bug which could crash the JVM. This only manifested in JDK21+ as earlier versions did not contain the related assert.

Modifications:

Remove left-over call that could crash the JVM

Result:

Correct code that also works on JDK21