### PR TITLE
Use '-Xcheck:jni' during testsuite run to detect JNI bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,8 @@
           </systemPropertyVariables>
           <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
           <trimStackTrace>false</trimStackTrace>
-          <argLine>${test.argLine}</argLine>
+          <!-- Always check JNI during test run so we catch bugs that could cause crashes -->
+          <argLine>-ea -Xcheck:jni ${test.argLine}</argLine>
         </configuration>
       </plugin>
       <!-- always produce osgi bundles -->


### PR DESCRIPTION
Motivation:

We should run our testsuite with '-Xcheck:jni' to ensure we catch bugs in our JNI code which could later cause issues like crashes

Modifications:

- Add -Xcheck:jni
- Add -ea

Result:

Testsuite will be able to catch more JNI bugs