### PR TITLE
Update / replace actions to fix deprecation warnings for node

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -106,13 +106,10 @@ jobs:
           distribution: zulu
           java-version: 8
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install stable rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          target: x86_64-pc-windows-msvc
-          override: true
+          targets: x86_64-pc-windows-msvc
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3.1

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -95,13 +95,10 @@ jobs:
           distribution: zulu
           java-version: 8
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install stable rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          target: x86_64-pc-windows-msvc
-          override: true
+          targets: x86_64-pc-windows-msvc
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3.1

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -109,13 +109,10 @@ jobs:
           distribution: zulu
           java-version: 8
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install stable rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          target: x86_64-pc-windows-msvc
-          override: true
+          targets: x86_64-pc-windows-msvc
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3.1

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -190,13 +190,10 @@ jobs:
           distribution: zulu
           java-version: 8
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install stable rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          target: x86_64-pc-windows-msvc
-          override: true
+          targets: x86_64-pc-windows-msvc
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3.1
@@ -208,7 +205,7 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -227,7 +224,7 @@ jobs:
           restore-keys: |
             stage-release-windows-x86_64-maven-cache-
 
-      - uses: s4u/maven-settings-action@v2.2.0
+      - uses: s4u/maven-settings-action@v2.8.0
         with:
           servers: |
             [{


### PR DESCRIPTION
Motivation:

We used some actions which used old version of node which is deprecated

Modifications:

Update and replace actions

Result:

No more warnings