### PR TITLE
Update to latest quiche sha

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionStats.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionStats.java
@@ -16,7 +16,8 @@
 package io.netty.incubator.codec.quic;
 
 /**
- * Statistics about the {@code QUIC} connection.
+ * Statistics about the {@code QUIC} connection. If unknown by the implementation it might return {@code -1} values
+ * for the various methods. 
  */
 public interface QuicConnectionStats {
     /**
@@ -63,69 +64,4 @@ public interface QuicConnectionStats {
      * @return   The number of known paths for the connection.
      */
     long pathsCount();
-
-    /**
-     * @return   The maximum idle timeout.
-     */
-    long peerMaxIdleTimeout();
-
-    /**
-     * @return   The maximum UDP payload size.
-     */
-    long peerMaxUdpPayloadSize();
-
-    /**
-     * @return   The initial flow control maximum data for the connection.
-     */
-    long peerInitialMaxData();
-
-    /**
-     * @return   The initial flow control maximum data for local bidirectional streams.
-     */
-    long peerInitialMaxStreamDataBidiLocal();
-
-    /**
-     * @return   The initial flow control maximum data for remote bidirectional streams.
-     */
-    long peerInitialMaxStreamDataBidiRemote();
-
-    /**
-     * @return   The initial flow control maximum data for unidirectional streams.
-     */
-    long peerInitialMaxStreamDataUni();
-
-    /**
-     * @return   The initial maximum bidirectional streams.
-     */
-    long peerInitialMaxStreamsBidi();
-
-    /**
-     * @return   The initial maximum unidirectional streams.
-     */
-    long peerInitialMaxStreamsUni();
-
-    /**
-     * @return   The ACK delay exponent.
-     */
-    long peerAckDelayExponent();
-
-    /**
-     * @return   The max ACK delay.
-     */
-    long peerMaxAckDelay();
-
-    /**
-     * @return    Whether active migration is disabled.
-     */
-    boolean peerDisableActiveMigration();
-
-    /**
-     * @return    The active connection ID limit.
-     */
-    long peerActiveConnIdLimit();
-
-    /**
-     * @return    DATAGRAM frame extension parameter, if any.
-     */
-    long peerMaxDatagramFrameSize();
 }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnectionStats.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnectionStats.java
@@ -70,71 +70,6 @@ final class QuicheQuicConnectionStats implements QuicConnectionStats {
         return values[8];
     }
 
-    @Override
-    public long peerMaxIdleTimeout() {
-        return values[9];
-    }
-
-    @Override
-    public long peerMaxUdpPayloadSize() {
-        return values[10];
-    }
-
-    @Override
-    public long peerInitialMaxData() {
-        return values[11];
-    }
-
-    @Override
-    public long peerInitialMaxStreamDataBidiLocal() {
-        return values[12];
-    }
-
-    @Override
-    public long peerInitialMaxStreamDataBidiRemote() {
-        return values[13];
-    }
-
-    @Override
-    public long peerInitialMaxStreamDataUni() {
-        return values[14];
-    }
-
-    @Override
-    public long peerInitialMaxStreamsBidi() {
-        return values[15];
-    }
-
-    @Override
-    public long peerInitialMaxStreamsUni() {
-        return values[16];
-    }
-
-    @Override
-    public long peerAckDelayExponent() {
-        return values[17];
-    }
-
-    @Override
-    public long peerMaxAckDelay() {
-        return values[18];
-    }
-
-    @Override
-    public boolean peerDisableActiveMigration() {
-        return values[19] == 1;
-    }
-
-    @Override
-    public long peerActiveConnIdLimit() {
-        return values[20];
-    }
-
-    @Override
-    public long peerMaxDatagramFrameSize() {
-        return values[21];
-    }
-
     /**
      * Returns the {@link String} representation of stats.
      */
@@ -150,19 +85,6 @@ final class QuicheQuicConnectionStats implements QuicConnectionStats {
                 ", lostBytes=" + lostBytes() +
                 ", streamRetransBytes=" + streamRetransBytes() +
                 ", pathsCount=" + pathsCount() +
-                ", peerMaxIdleTimeout=" + peerMaxIdleTimeout() +
-                ", peerMaxUdpPayloadSize=" + peerMaxUdpPayloadSize() +
-                ", peerInitialMaxData=" + peerInitialMaxData() +
-                ", peerInitialMaxStreamDataBidiLocal=" + peerInitialMaxStreamDataBidiLocal() +
-                ", peerInitialMaxStreamDataBidiRemote=" + peerInitialMaxStreamDataBidiRemote() +
-                ", peerInitialMaxStreamDataUni=" + peerInitialMaxStreamDataUni() +
-                ", peerInitialMaxStreamsBidi=" + peerInitialMaxStreamsBidi() +
-                ", peerInitialMaxStreamsUni=" + peerInitialMaxStreamsUni() +
-                ", peerAckDelayExponent=" + peerAckDelayExponent() +
-                ", peerMaxAckDelay=" + peerMaxAckDelay() +
-                ", peerDisableActiveMigration=" + peerDisableActiveMigration() +
-                ", peerActiveConnIdLimit=" + peerActiveConnIdLimit() +
-                ", peerMaxDatagramFrameSize=" + peerMaxDatagramFrameSize() +
                 "]";
     }
 

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -56,7 +56,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>28ef289f027713cb024e3171ccfa2972fc12a9e2</quicheCommitSha>
+    <quicheCommitSha>83d9168ab6f76302ae846cb068cc8991f2b06479</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -495,10 +495,10 @@ static jboolean netty_quiche_conn_is_timed_out(JNIEnv* env, jclass clazz, jlong 
 
 static jlongArray netty_quiche_conn_stats(JNIEnv* env, jclass clazz, jlong conn) {
     // See https://github.com/cloudflare/quiche/blob/master/quiche/include/quiche.h#L467
-    quiche_stats stats = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,true,0,0};
+    quiche_stats stats = {0,0,0,0,0,0,0,0,0};
     quiche_conn_stats((quiche_conn *) conn, &stats);
 
-    jlongArray statsArray = (*env)->NewLongArray(env, 22);
+    jlongArray statsArray = (*env)->NewLongArray(env, 9);
     if (statsArray == NULL) {
         // This will put an OOME on the stack
         return NULL;
@@ -512,22 +512,9 @@ static jlongArray netty_quiche_conn_stats(JNIEnv* env, jclass clazz, jlong conn)
         (jlong)stats.recv_bytes,
         (jlong)stats.lost_bytes,
         (jlong)stats.stream_retrans_bytes,
-        (jlong)stats.paths_count,
-        (jlong)stats.peer_max_idle_timeout,
-        (jlong)stats.peer_max_udp_payload_size,
-        (jlong)stats.peer_initial_max_data,
-        (jlong)stats.peer_initial_max_stream_data_bidi_local,
-        (jlong)stats.peer_initial_max_stream_data_bidi_remote,
-        (jlong)stats.peer_initial_max_stream_data_uni,
-        (jlong)stats.peer_initial_max_streams_bidi,
-        (jlong)stats.peer_initial_max_streams_uni,
-        (jlong)stats.peer_ack_delay_exponent,
-        (jlong)stats.peer_max_ack_delay,
-        stats.peer_disable_active_migration ? 1 : 0,
-        (jlong)stats.peer_active_conn_id_limit,
-        (jlong)stats.peer_max_datagram_frame_size,
+        (jlong)stats.paths_count
     };
-    (*env)->SetLongArrayRegion(env, statsArray, 0, 22, statsArrayElements);
+    (*env)->SetLongArrayRegion(env, statsArray, 0, 9, statsArrayElements);
     return statsArray;
 }
 


### PR DESCRIPTION
Motivation:

Let's update to latest quiche sha.

Modifications:

- Update to latest quiche sha
- Fix QuicConnectionStats to be able to compile against latest sha

Result:

Use latest quiche code