### PR TITLE
Set default MAX_MESSAGES_PER_READ to 16

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -114,7 +114,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         }
     };
 
-    private static final ChannelMetadata METADATA = new ChannelMetadata(false);
+    private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
     private final long[] readableStreams = new long[128];
     private final long[] writableStreams = new long[128];
 

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -49,7 +49,7 @@ import java.util.concurrent.RejectedExecutionException;
  * {@link QuicStreamChannel} implementation that uses <a href="https://github.com/cloudflare/quiche">quiche</a>.
  */
 final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicStreamChannel {
-    private static final ChannelMetadata METADATA = new ChannelMetadata(false);
+    private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
     private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(QuicheQuicStreamChannel.class);
     private final QuicheQuicChannel parent;
     private final ChannelId id;


### PR DESCRIPTION
Motivation:

We should use a more sane default value then 1 for MAX_MESSAGES_PER_READ that also match our other Channel implementations

Modifications:

Use 16 as default value

Result:

Less overhead and more consistent