### PR TITLE
Fix assertation of params

### DIFF
--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTransportParametersTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTransportParametersTest.java
@@ -89,6 +89,6 @@ public class QuicTransportParametersTest extends AbstractQuicTest {
         assertThat(parameters.maxAckDelay(), greaterThanOrEqualTo(1L));
         assertFalse(parameters.disableActiveMigration());
         assertThat(parameters.activeConnIdLimit(), greaterThanOrEqualTo(1L));
-        assertThat(parameters.maxDatagramFrameSize(), greaterThanOrEqualTo(1L));
+        assertThat(parameters.maxDatagramFrameSize(), greaterThanOrEqualTo(0L));
     }
 }


### PR DESCRIPTION
Motivation:

The asseertation of the params was not correct and so could fail sometimes

Modifications:

Fix assert

Result:

Testsuite passes all the time again