### PR TITLE
Add correct equals / hashcode implementations for DefaultQuicStreamFrame

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/DefaultQuicStreamFrame.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/DefaultQuicStreamFrame.java
@@ -17,6 +17,7 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DefaultByteBufHolder;
+import io.netty.util.internal.StringUtil;
 
 public final class DefaultQuicStreamFrame extends DefaultByteBufHolder implements QuicStreamFrame {
 
@@ -74,5 +75,37 @@ public final class DefaultQuicStreamFrame extends DefaultByteBufHolder implement
     public QuicStreamFrame touch(Object hint) {
         super.touch(hint);
         return this;
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultQuicStreamFrame{" +
+                "fin=" + fin +
+                ", content=" + contentToString() +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultQuicStreamFrame that = (DefaultQuicStreamFrame) o;
+
+        if (fin != that.fin) {
+            return false;
+        }
+
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (fin ? 1 : 0);
+        return result;
     }
 }


### PR DESCRIPTION
Motivation:

DefaultQuicStreamFrame did miss to override equals(...) and hashcode(...) so it ignored the fin flag.

Modifications:

Add missing overrides

Result:

Correct implementation