### PR TITLE
Upgrade to quiche sha of 0.19.0

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -56,7 +56,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>c8d10d26db8994b96b475d85dfd557dddb3d7c6b</quicheCommitSha>
+    <quicheCommitSha>af368e9287ea975d184f9f66df52dbf109adf0e4</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />


### PR DESCRIPTION
Motivation:

Quiche tagged a new release

Modifications:

Bump up sha to match latest quiche release

Result:

Use quiche 0.19.0