### PR TITLE
QuicEvent implementations should have toString() overrides

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionEvent.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionEvent.java
@@ -47,4 +47,12 @@ public final class QuicConnectionEvent implements QuicEvent {
     public SocketAddress newAddress() {
         return newAddress;
     }
+
+    @Override
+    public String toString() {
+        return "QuicConnectionEvent{" +
+                "oldAddress=" + oldAddress +
+                ", newAddress=" + newAddress +
+                '}';
+    }
 }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicDatagramExtensionEvent.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicDatagramExtensionEvent.java
@@ -38,4 +38,11 @@ public final class QuicDatagramExtensionEvent implements QuicExtensionEvent {
     public int maxLength() {
         return maxLength;
     }
+
+    @Override
+    public String toString() {
+        return "QuicDatagramExtensionEvent{" +
+                "maxLength=" + maxLength +
+                '}';
+    }
 }


### PR DESCRIPTION
Motivation:

We should add toString() implementations for our QuicEvent implementations to make debugging easier.

Modifications:

Add toString() methods

Result:

Easier to log / debug events