### PR TITLE
Support connection migration on the server-side

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Hmac.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Hmac.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.util.concurrent.FastThreadLocal;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+final class Hmac {
+
+    private static final FastThreadLocal<Mac> MACS = new FastThreadLocal<Mac>() {
+        @Override
+        protected Mac initialValue() {
+            return newMac();
+        }
+    };
+
+    private static final String ALGORITM = "HmacSHA256";
+    private static final byte[] randomKey = new byte[16];
+
+    static {
+        new SecureRandom().nextBytes(randomKey);
+    }
+
+    private static Mac newMac() {
+        try {
+            SecretKeySpec keySpec = new SecretKeySpec(randomKey, ALGORITM);
+            Mac mac = Mac.getInstance(ALGORITM);
+            mac.init(keySpec);
+            return mac;
+        } catch (NoSuchAlgorithmException | InvalidKeyException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    static ByteBuffer sign(ByteBuffer input, int outLength) {
+        Mac mac = MACS.get();
+        mac.reset();
+        mac.update(input);
+        byte[] signBytes = mac.doFinal();
+        if (signBytes.length != outLength) {
+            signBytes = Arrays.copyOf(signBytes, outLength);
+        }
+        return ByteBuffer.wrap(signBytes);
+    }
+
+    private Hmac() { }
+}

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/HmacSignQuicConnectionIdGenerator.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/HmacSignQuicConnectionIdGenerator.java
@@ -16,16 +16,8 @@
 package io.netty.incubator.codec.quic;
 
 import java.nio.ByteBuffer;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.util.Arrays;
 
-import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.ObjectUtil;
-
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 
 /**
  * A {@link QuicConnectionIdGenerator} which creates new connection id by signing the given input
@@ -33,20 +25,6 @@ import javax.crypto.spec.SecretKeySpec;
  */
 final class HmacSignQuicConnectionIdGenerator implements QuicConnectionIdGenerator {
     static final QuicConnectionIdGenerator INSTANCE = new HmacSignQuicConnectionIdGenerator();
-
-    private static final FastThreadLocal<Mac> MACS = new FastThreadLocal<Mac>() {
-        @Override
-        protected Mac initialValue() {
-            return newMac();
-        }
-    };
-
-    private static final String ALGORITM = "HmacSHA256";
-    private static final byte[] randomKey = new byte[16];
-
-    static {
-        new SecureRandom().nextBytes(randomKey);
-    }
 
     private HmacSignQuicConnectionIdGenerator() {
     }
@@ -57,31 +35,13 @@ final class HmacSignQuicConnectionIdGenerator implements QuicConnectionIdGenerat
                 "HmacSignQuicConnectionIdGenerator should always have an input to sign with");
     }
 
-    private static Mac newMac() {
-        try {
-            SecretKeySpec keySpec = new SecretKeySpec(randomKey, ALGORITM);
-            Mac mac = Mac.getInstance(ALGORITM);
-            mac.init(keySpec);
-            return mac;
-        } catch (NoSuchAlgorithmException | InvalidKeyException exception) {
-            throw new IllegalStateException(exception);
-        }
-    }
-
     @Override
     public ByteBuffer newId(ByteBuffer buffer, int length) {
         ObjectUtil.checkNotNull(buffer, "buffer");
         ObjectUtil.checkPositive(buffer.remaining(), "buffer");
         ObjectUtil.checkInRange(length, 0, maxConnectionIdLength(), "length");
 
-        Mac mac = MACS.get();
-        mac.reset();
-        mac.update(buffer);
-        byte[] signBytes = mac.doFinal();
-        if (signBytes.length != length) {
-            signBytes = Arrays.copyOf(signBytes, length);
-        }
-        return ByteBuffer.wrap(signBytes);
+        return Hmac.sign(buffer, length);
     }
 
     @Override

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/HmacSignQuicResetTokenGenerator.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/HmacSignQuicResetTokenGenerator.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.util.internal.ObjectUtil;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+/**
+ * A {@link QuicResetTokenGenerator} which creates new reset token by using the connection id by signing the given input
+ * using <a href="https://www.ietf.org/archive/id/draft-ietf-quic-transport-29.html#section-10.4.2">HMAC algorithms</a>.
+ */
+final class HmacSignQuicResetTokenGenerator implements QuicResetTokenGenerator {
+    static final QuicResetTokenGenerator INSTANCE = new HmacSignQuicResetTokenGenerator();
+
+    private static final String ALGORITM = "HmacSHA256";
+    private static final byte[] randomKey = new byte[Quic.RESET_TOKEN_LEN];
+
+    static {
+        new SecureRandom().nextBytes(randomKey);
+    }
+
+    private HmacSignQuicResetTokenGenerator() {
+    }
+
+    private static Mac newMac() {
+        try {
+            SecretKeySpec keySpec = new SecretKeySpec(randomKey, ALGORITM);
+            Mac mac = Mac.getInstance(ALGORITM);
+            mac.init(keySpec);
+            return mac;
+        } catch (NoSuchAlgorithmException | InvalidKeyException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    @Override
+    public ByteBuffer newResetToken(ByteBuffer cid) {
+        ObjectUtil.checkNotNull(cid, "buffer");
+        ObjectUtil.checkPositive(cid.remaining(), "buffer");
+
+        // TODO: Consider using a ThreadLocal.
+        Mac mac = newMac();
+        mac.update(cid);
+
+        byte[] signBytes = mac.doFinal();
+        if (signBytes.length != Quic.RESET_TOKEN_LEN) {
+            signBytes = Arrays.copyOf(signBytes, Quic.RESET_TOKEN_LEN);
+        }
+        return ByteBuffer.wrap(signBytes);
+    }
+}

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quic.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quic.java
@@ -34,6 +34,8 @@ public final class Quic {
 
     static final int MAX_DATAGRAM_SIZE = 1350;
 
+    static final int RESET_TOKEN_LEN = 16;
+
     private static final Throwable UNAVAILABILITY_CAUSE;
 
     static {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicResetTokenGenerator.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicResetTokenGenerator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Generate
+ * <a href="https://www.ietf.org/archive/id/draft-ietf-quic-transport-29.html#name-calculating-a-stateless-res">
+ *     stateless reset tokens</a> to use.
+ */
+public interface QuicResetTokenGenerator {
+
+    /**
+     * Generate a reset token to use for the given connection id. The returned token MUST be of length 16.
+     * @param cid
+     * @return
+     */
+    ByteBuffer newResetToken(ByteBuffer cid);
+
+    /**
+     * Return a {@link QuicResetTokenGenerator} which generates new reset tokens by signing the given input.
+     *
+     * @return a {@link QuicResetTokenGenerator} which generates new reset tokens by signing the given input.
+     */
+    static QuicResetTokenGenerator signGenerator() {
+        return HmacSignQuicResetTokenGenerator.INSTANCE;
+    }
+}

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -41,6 +41,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
     private ChannelHandler streamHandler;
     private QuicConnectionIdGenerator connectionIdAddressGenerator;
     private QuicTokenHandler tokenHandler;
+    private QuicResetTokenGenerator resetTokenGenerator;
 
     /**
      * Creates a new instance.
@@ -172,6 +173,18 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
         return self();
     }
 
+    /**
+     * Set the {@link QuicResetTokenGenerator} that is used to generate stateless reset tokens or
+     * {@code null} if the default should be used.
+     *
+     * @param resetTokenGenerator  the {@link QuicResetTokenGenerator} to use.
+     * @return                     this instance.
+     */
+    public QuicServerCodecBuilder resetTokenGenerator(QuicResetTokenGenerator resetTokenGenerator) {
+        this.resetTokenGenerator = resetTokenGenerator;
+        return self();
+    }
+
     @Override
     protected void validate() {
         super.validate();
@@ -194,10 +207,14 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
         if (generator == null) {
             generator = QuicConnectionIdGenerator.signGenerator();
         }
+        QuicResetTokenGenerator resetTokenGenerator = this.resetTokenGenerator;
+        if (resetTokenGenerator == null) {
+            resetTokenGenerator = QuicResetTokenGenerator.signGenerator();
+        }
         ChannelHandler handler = this.handler;
         ChannelHandler streamHandler = this.streamHandler;
-        return new QuicheQuicServerCodec(config, localConnIdLength, tokenHandler, generator, flushStrategy,
-                sslEngineProvider, sslTaskExecutor, handler,
+        return new QuicheQuicServerCodec(config, localConnIdLength, tokenHandler, generator, resetTokenGenerator,
+                flushStrategy, sslEngineProvider, sslTaskExecutor, handler,
                 Quic.toOptionsArray(options), Quic.toAttributesArray(attrs),
                 streamHandler, Quic.toOptionsArray(streamOptions), Quic.toAttributesArray(streamAttrs));
     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -547,6 +547,12 @@ final class Quiche {
      */
     static native int quiche_conn_max_send_udp_payload_size(long connAddr);
 
+    static native int quiche_conn_source_cids_left(long connAddr);
+
+    static native long quiche_conn_new_source_cid(long connAddr, long scidAddr, int scidLen, byte[] resetToken, boolean retire_if_needed);
+
+    static native byte[] quiche_conn_retired_scid_next(long connAddr);
+
     /**
      * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L115">quiche_config_new</a>.

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -547,9 +547,9 @@ final class Quiche {
      */
     static native int quiche_conn_max_send_udp_payload_size(long connAddr);
 
-    static native int quiche_conn_source_cids_left(long connAddr);
+    static native int quiche_conn_scids_left(long connAddr);
 
-    static native long quiche_conn_new_source_cid(long connAddr, long scidAddr, int scidLen, byte[] resetToken, boolean retire_if_needed);
+    static native long quiche_conn_new_scid(long connAddr, long scidAddr, int scidLen, byte[] resetToken, boolean retire_if_needed);
 
     static native byte[] quiche_conn_retired_scid_next(long connAddr);
 

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -910,7 +910,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             long connAddr = connection.address();
             // Generate all extra source ids that we can provide. This will cause frames that need to be send. Which
             // is the reason why we might need to call connectionSendAndFlush().
-            int left = Quiche.quiche_conn_source_cids_left(connAddr);
+            int left = Quiche.quiche_conn_scids_left(connAddr);
             if (left > 0) {
                 List<ByteBuffer> generatedIds = new ArrayList<>(left);
                 boolean sendAndFlush = false;
@@ -925,7 +925,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                         connIdBuffer.writeBytes(srcId.duplicate());
                         ByteBuffer resetToken = resetTokenGenerator.newResetToken(srcId.duplicate());
                         resetToken.get(resetTokenArray);
-                        long result = Quiche.quiche_conn_new_source_cid(
+                        long result = Quiche.quiche_conn_new_scid(
                                 connAddr, Quiche.memoryAddress(connIdBuffer, 0, connIdBuffer.readableBytes()),
                                 connIdBuffer.readableBytes(), resetTokenArray, false);
                         if (result < 0) {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -57,8 +57,11 @@ import java.nio.channels.AlreadyConnectedException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ConnectionPendingException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -134,7 +137,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private ChannelPromise connectPromise;
     private ScheduledFuture<?> connectTimeoutFuture;
     private QuicConnectionAddress connectAddress;
-    private ByteBuffer key;
+    private final Set<ByteBuffer> sourceConnectionIds = new HashSet<>();
     private CloseData closeData;
     private QuicConnectionCloseEvent connectionCloseEvent;
     private QuicConnectionStats statsAtClose;
@@ -184,7 +187,9 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         config = new QuicheQuicChannelConfig(this);
         this.server = server;
         this.idGenerator = new QuicStreamIdGenerator(server);
-        this.key = key;
+        if (key != null) {
+            this.sourceConnectionIds.add(key);
+        }
         state = OPEN;
 
         this.supportsDatagram = supportsDatagram;
@@ -309,7 +314,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             throws Exception {
         assert this.connection == null;
         assert this.traceId == null;
-        assert this.key == null;
+        assert this.sourceConnectionIds.isEmpty();
 
         this.sslTaskExecutor = sslTaskExecutor;
 
@@ -358,7 +363,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 }
             }
             this.supportsDatagram = supportsDatagram;
-            key = connectId;
+            sourceConnectionIds.add(connectId);
         } finally {
             idBuffer.release();
         }
@@ -379,8 +384,8 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         return false;
     }
 
-    ByteBuffer key() {
-        return key;
+    Set<ByteBuffer> sourceConnectionIds() {
+        return sourceConnectionIds;
     }
 
     private boolean closeAllIfConnectionClosed() {
@@ -864,6 +869,85 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         ((QuicChannelUnsafe) unsafe()).connectionRecv(sender, recipient, buffer);
     }
 
+    /**
+     * Return all source connection ids that are retired and so should be removed to map to the channel.
+     *
+     * @return retired ids.
+     */
+    List<ByteBuffer> retiredSourceConnectionId() {
+        QuicheQuicConnection connection = this.connection;
+        if (connection == null || connection.isClosed()) {
+            return Collections.emptyList();
+        }
+        long connAddr = connection.address();
+        assert connAddr != -1;
+        List<ByteBuffer> retiredSourceIds = null;
+        for (;;) {
+            byte[] retired = Quiche.quiche_conn_retired_scid_next(connAddr);
+            if (retired == null) {
+                break;
+            }
+            if (retiredSourceIds == null) {
+                retiredSourceIds = new ArrayList<>();
+            }
+            ByteBuffer retiredId = ByteBuffer.wrap(retired);
+            retiredSourceIds.add(retiredId);
+            sourceConnectionIds.remove(retiredId);
+        }
+        if (retiredSourceIds == null) {
+            return Collections.emptyList();
+        }
+        return retiredSourceIds;
+    }
+
+    List<ByteBuffer> newSourceConnectionIds(
+            QuicConnectionIdGenerator connectionIdGenerator, QuicResetTokenGenerator resetTokenGenerator) {
+        if (server) {
+            QuicheQuicConnection connection = this.connection;
+            if (connection == null || connection.isClosed()) {
+                return Collections.emptyList();
+            }
+            long connAddr = connection.address();
+            // Generate all extra source ids that we can provide. This will cause frames that need to be send. Which
+            // is the reason why we might need to call connectionSendAndFlush().
+            int left = Quiche.quiche_conn_source_cids_left(connAddr);
+            if (left > 0) {
+                List<ByteBuffer> generatedIds = new ArrayList<>(left);
+                boolean sendAndFlush = false;
+                ByteBuffer key = localIdAdrr.connId.duplicate();
+                ByteBuf connIdBuffer = alloc().directBuffer(key.remaining());
+
+                byte[] resetTokenArray = new byte[Quic.RESET_TOKEN_LEN];
+                try {
+                    do {
+                        ByteBuffer srcId = connectionIdGenerator.newId(key, key.remaining());
+                        connIdBuffer.clear();
+                        connIdBuffer.writeBytes(srcId.duplicate());
+                        ByteBuffer resetToken = resetTokenGenerator.newResetToken(srcId.duplicate());
+                        resetToken.get(resetTokenArray);
+                        long result = Quiche.quiche_conn_new_source_cid(
+                                connAddr, Quiche.memoryAddress(connIdBuffer, 0, connIdBuffer.readableBytes()),
+                                connIdBuffer.readableBytes(), resetTokenArray, false);
+                        if (result < 0) {
+                            break;
+                        }
+                        sendAndFlush = true;
+                        generatedIds.add(srcId);
+                        sourceConnectionIds.add(srcId);
+                    } while (--left > 0);
+                } finally {
+                    connIdBuffer.release();
+                }
+
+                if (sendAndFlush) {
+                    connectionSendAndFlush();
+                }
+                return generatedIds;
+            }
+        }
+        return Collections.emptyList();
+    }
+
     void writable() {
         boolean written = connectionSend();
         handleWritableStreams();
@@ -1320,7 +1404,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             }
 
             if (remote instanceof QuicConnectionAddress) {
-                if (key != null) {
+                if (!sourceConnectionIds.isEmpty()) {
                     // If a key is assigned we know this channel was already connected.
                     channelPromise.setFailure(new AlreadyConnectedException());
                     return;
@@ -1492,6 +1576,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
                 datagramReadable = true;
                 streamReadable = true;
+
                 recvDatagram();
                 recvStream();
             }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
@@ -65,7 +65,8 @@ final class QuicheQuicClientCodec extends QuicheQuicCodec {
             return;
         }
         if (channel != null) {
-            putChannel(channel);
+            addChannel(channel);
+
             channel.finishConnect();
             promise.setSuccess();
             return;

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -56,7 +56,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/normanmaurer/quiche</quicheRepository>
     <quicheBranch>c_api</quicheBranch>
-    <quicheCommitSha>b140659a16bba84d2a30d8990ec5c9c9b0b88104</quicheCommitSha>
+    <quicheCommitSha>2893a3b3837ca11350fc7f542901c56a3ae49e2c</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -54,9 +54,9 @@
     <quicheHomeDir>${project.build.directory}/quiche</quicheHomeDir>
     <quicheHomeBuildDir>${quicheHomeDir}/build</quicheHomeBuildDir>
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
-    <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
-    <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>af368e9287ea975d184f9f66df52dbf109adf0e4</quicheCommitSha>
+    <quicheRepository>https://github.com/normanmaurer/quiche</quicheRepository>
+    <quicheBranch>c_api</quicheBranch>
+    <quicheCommitSha>b140659a16bba84d2a30d8990ec5c9c9b0b88104</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -54,9 +54,9 @@
     <quicheHomeDir>${project.build.directory}/quiche</quicheHomeDir>
     <quicheHomeBuildDir>${quicheHomeDir}/build</quicheHomeBuildDir>
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
-    <quicheRepository>https://github.com/normanmaurer/quiche</quicheRepository>
-    <quicheBranch>c_api</quicheBranch>
-    <quicheCommitSha>2893a3b3837ca11350fc7f542901c56a3ae49e2c</quicheCommitSha>
+    <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
+    <quicheBranch>master</quicheBranch>
+    <quicheCommitSha>b91019ebd80f51f3d2fec28a2eef9d9ae0c5cb86</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -624,13 +624,13 @@ static jint netty_quiche_conn_max_send_udp_payload_size(JNIEnv* env, jclass claz
     return (jint) quiche_conn_max_send_udp_payload_size((quiche_conn *) conn);
 }
 
-static jint netty_quiche_conn_source_cids_left(JNIEnv* env, jclass clazz, jlong conn) {
-    return (jint) quiche_conn_source_cids_left((quiche_conn *) conn);
+static jint netty_quiche_conn_scids_left(JNIEnv* env, jclass clazz, jlong conn) {
+    return (jint) quiche_conn_scids_left((quiche_conn *) conn);
 }
 
-static jlong netty_quiche_conn_new_source_cid(JNIEnv* env, jclass clazz, jlong conn, jlong scid, jint scid_len, jbyteArray reset_token, jboolean retire_if_needed) {
+static jlong netty_quiche_conn_new_scid(JNIEnv* env, jclass clazz, jlong conn, jlong scid, jint scid_len, jbyteArray reset_token, jboolean retire_if_needed) {
     uint8_t* buf = (uint8_t*) (*env)->GetByteArrayElements(env, reset_token, 0);
-    jlong ret = quiche_conn_new_source_cid((quiche_conn *) conn, (const uint8_t *) scid, scid_len, buf, retire_if_needed == JNI_TRUE ? true : false);
+    jlong ret = quiche_conn_new_scid((quiche_conn *) conn, (const uint8_t *) scid, scid_len, buf, retire_if_needed == JNI_TRUE ? true : false);
     (*env)->ReleaseByteArrayElements(env, reset_token, (jbyte*)buf, JNI_ABORT);
     return ret;
 }
@@ -905,8 +905,8 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_dgram_send", "(JJI)I", (void* ) netty_quiche_conn_dgram_send },
   { "quiche_conn_set_session", "(J[B)I", (void* ) netty_quiche_conn_set_session },
   { "quiche_conn_max_send_udp_payload_size", "(J)I", (void* ) netty_quiche_conn_max_send_udp_payload_size },
-  { "quiche_conn_source_cids_left", "(J)I", (void* ) netty_quiche_conn_source_cids_left },
-  { "quiche_conn_new_source_cid", "(JJI[BZ)J", (void* ) netty_quiche_conn_new_source_cid },
+  { "quiche_conn_scids_left", "(J)I", (void* ) netty_quiche_conn_scids_left },
+  { "quiche_conn_new_scid", "(JJI[BZ)J", (void* ) netty_quiche_conn_new_scid },
   { "quiche_conn_retired_scid_next", "(J)[B", (void* ) netty_quiche_conn_retired_scid_next },
   { "quiche_config_new", "(I)J", (void *) netty_quiche_config_new },
   { "quiche_config_enable_dgram", "(JZII)V", (void *) netty_quiche_config_enable_dgram },

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -624,6 +624,27 @@ static jint netty_quiche_conn_max_send_udp_payload_size(JNIEnv* env, jclass claz
     return (jint) quiche_conn_max_send_udp_payload_size((quiche_conn *) conn);
 }
 
+static jint netty_quiche_conn_source_cids_left(JNIEnv* env, jclass clazz, jlong conn) {
+    return (jint) quiche_conn_source_cids_left((quiche_conn *) conn);
+}
+
+static jlong netty_quiche_conn_new_source_cid(JNIEnv* env, jclass clazz, jlong conn, jlong scid, jint scid_len, jbyteArray reset_token, jboolean retire_if_needed) {
+    uint8_t* buf = (uint8_t*) (*env)->GetByteArrayElements(env, reset_token, 0);
+    jlong ret = quiche_conn_new_source_cid((quiche_conn *) conn, (const uint8_t *) scid, scid_len, buf, retire_if_needed == JNI_TRUE ? true : false);
+    (*env)->ReleaseByteArrayElements(env, reset_token, (jbyte*)buf, JNI_ABORT);
+    return ret;
+}
+
+static jbyteArray netty_quiche_conn_retired_scid_next(JNIEnv* env, jclass clazz, jlong conn) {
+    const uint8_t *id = NULL;
+    size_t len = 0;
+
+    if (quiche_conn_retired_scid_next((quiche_conn *) conn, &id, &len)) {
+        return to_byte_array(env, id, len);
+    }
+    return NULL;
+}
+
 static jlong netty_quiche_config_new(JNIEnv* env, jclass clazz, jint version) {
     quiche_config* config = quiche_config_new((uint32_t) version);
     return config == NULL ? -1 : (jlong) config;
@@ -884,6 +905,9 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_dgram_send", "(JJI)I", (void* ) netty_quiche_conn_dgram_send },
   { "quiche_conn_set_session", "(J[B)I", (void* ) netty_quiche_conn_set_session },
   { "quiche_conn_max_send_udp_payload_size", "(J)I", (void* ) netty_quiche_conn_max_send_udp_payload_size },
+  { "quiche_conn_source_cids_left", "(J)I", (void* ) netty_quiche_conn_source_cids_left },
+  { "quiche_conn_new_source_cid", "(JJI[BZ)J", (void* ) netty_quiche_conn_new_source_cid },
+  { "quiche_conn_retired_scid_next", "(J)[B", (void* ) netty_quiche_conn_retired_scid_next },
   { "quiche_config_new", "(I)J", (void *) netty_quiche_config_new },
   { "quiche_config_enable_dgram", "(JZII)V", (void *) netty_quiche_config_enable_dgram },
   { "quiche_config_grease", "(JZ)V", (void *) netty_quiche_config_grease },

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/example/QuicServerExample.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/example/QuicServerExample.java
@@ -59,6 +59,7 @@ public final class QuicServerExample {
                 .initialMaxStreamDataBidirectionalRemote(1000000)
                 .initialMaxStreamsBidirectional(100)
                 .initialMaxStreamsUnidirectional(100)
+                .activeMigration(true)
 
                 // Setup a token handler. In a production system you would want to implement and provide your custom
                 // one.


### PR DESCRIPTION
Motivation:

We should be able to support connection migration the server side. This can be tested via quiche:

```
cargo run --bin quiche-client -- --no-verify --perform-migration https://127.0.0.1:9999/`
```

Modifications:

Be able to support migrations by offering the remote peer connection ids to use.

Result:

Be able to do connection migration in all cases.