### PR TITLE
Use socklen_t when passing sockaddr structs

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -56,7 +56,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>af368e9287ea975d184f9f66df52dbf109adf0e4</quicheCommitSha>
+    <quicheCommitSha>06222e59e0a5fa70686bdf94e7513dcd4c0918d1</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -359,8 +359,8 @@ static jlong netty_quiche_conn_new_with_tls(JNIEnv* env, jclass clazz, jlong sci
     const struct sockaddr *peer_pointer = (const struct sockaddr*) peer;
     quiche_conn *conn = quiche_conn_new_with_tls((const uint8_t *) scid, (size_t) scid_len,
                                  odcid_pointer, (size_t) odcid_len,
-                                 local_pointer, (size_t) local_len,
-                                 peer_pointer, (size_t) peer_len,
+                                 local_pointer, (socklen_t) local_len,
+                                 peer_pointer, (socklen_t) peer_len,
                                  (quiche_config *) config, (void*) ssl, isServer == JNI_TRUE ? true : false);
     if (conn == NULL) {
         return -1;


### PR DESCRIPTION
Motivation:

socklen_t is the right type for anything related to sockaddr.

Modifications:

- Update quiche to have the correct header file
- Change from size_t to socklent_t

Result:

More correct code