### PR TITLE
Adjust API usage to match latest quiche code

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -557,7 +557,7 @@ final class Quiche {
 
     static native int quiche_conn_scids_left(long connAddr);
 
-    static native long quiche_conn_new_scid(long connAddr, long scidAddr, int scidLen, byte[] resetToken, boolean retire_if_needed);
+    static native long quiche_conn_new_scid(long connAddr, long scidAddr, int scidLen, byte[] resetToken, boolean retire_if_needed, long seq);
 
     static native byte[] quiche_conn_retired_scid_next(long connAddr);
 

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -56,7 +56,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>5796adc0a06044e9e4f2020ad51f680bd0d071bc</quicheCommitSha>
+    <quicheCommitSha>b0944d88882e412685554446e6209c317b6f912b</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -664,9 +664,9 @@ static jint netty_quiche_conn_scids_left(JNIEnv* env, jclass clazz, jlong conn) 
     return (jint) quiche_conn_scids_left((quiche_conn *) conn);
 }
 
-static jlong netty_quiche_conn_new_scid(JNIEnv* env, jclass clazz, jlong conn, jlong scid, jint scid_len, jbyteArray reset_token, jboolean retire_if_needed) {
+static jlong netty_quiche_conn_new_scid(JNIEnv* env, jclass clazz, jlong conn, jlong scid, jint scid_len, jbyteArray reset_token, jboolean retire_if_needed, jlong seq) {
     uint8_t* buf = (uint8_t*) (*env)->GetByteArrayElements(env, reset_token, 0);
-    jlong ret = quiche_conn_new_scid((quiche_conn *) conn, (const uint8_t *) scid, scid_len, buf, retire_if_needed == JNI_TRUE ? true : false);
+    jlong ret = quiche_conn_new_scid((quiche_conn *) conn, (const uint8_t *) scid, scid_len, buf, retire_if_needed == JNI_TRUE ? true : false, (uint64_t*) seq);
     (*env)->ReleaseByteArrayElements(env, reset_token, (jbyte*)buf, JNI_ABORT);
     return ret;
 }
@@ -1134,7 +1134,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_set_session", "(J[B)I", (void* ) netty_quiche_conn_set_session },
   { "quiche_conn_max_send_udp_payload_size", "(J)I", (void* ) netty_quiche_conn_max_send_udp_payload_size },
   { "quiche_conn_scids_left", "(J)I", (void* ) netty_quiche_conn_scids_left },
-  { "quiche_conn_new_scid", "(JJI[BZ)J", (void* ) netty_quiche_conn_new_scid },
+  { "quiche_conn_new_scid", "(JJI[BZJ)J", (void* ) netty_quiche_conn_new_scid },
   { "quiche_conn_retired_scid_next", "(J)[B", (void* ) netty_quiche_conn_retired_scid_next },
   { "quiche_config_new", "(I)J", (void *) netty_quiche_config_new },
   { "quiche_config_enable_dgram", "(JZII)V", (void *) netty_quiche_config_enable_dgram },


### PR DESCRIPTION
Motivation:

A API was changed in quiche to address a bug. We need to adjust our code as well

Modifications:

Pass in a pointer for the sequence number

Result:

Compiles against latest quiche code