### PR TITLE
Don't allocate via the pool if we not really interested in the sequence

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -916,11 +916,9 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 boolean sendAndFlush = false;
                 ByteBuffer key = localIdAdrr.connId.duplicate();
                 ByteBuf connIdBuffer = alloc().directBuffer(key.remaining());
-                ByteBuf seqBuffer = alloc().directBuffer(Long.BYTES);
 
                 byte[] resetTokenArray = new byte[Quic.RESET_TOKEN_LEN];
                 try {
-                    long seqAddress = Quiche.memoryAddress(seqBuffer, 0, seqBuffer.capacity());
                     do {
                         ByteBuffer srcId = connectionIdGenerator.newId(key, key.remaining());
                         connIdBuffer.clear();
@@ -929,7 +927,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                         resetToken.get(resetTokenArray);
                         long result = Quiche.quiche_conn_new_scid(
                                 connAddr, Quiche.memoryAddress(connIdBuffer, 0, connIdBuffer.readableBytes()),
-                                connIdBuffer.readableBytes(), resetTokenArray, false, seqAddress);
+                                connIdBuffer.readableBytes(), resetTokenArray, false, -1);
                         if (result < 0) {
                             break;
                         }
@@ -939,7 +937,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                     } while (--left > 0);
                 } finally {
                     connIdBuffer.release();
-                    seqBuffer.release();
                 }
 
                 if (sendAndFlush) {

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -664,9 +664,17 @@ static jint netty_quiche_conn_scids_left(JNIEnv* env, jclass clazz, jlong conn) 
     return (jint) quiche_conn_scids_left((quiche_conn *) conn);
 }
 
-static jlong netty_quiche_conn_new_scid(JNIEnv* env, jclass clazz, jlong conn, jlong scid, jint scid_len, jbyteArray reset_token, jboolean retire_if_needed, jlong seq) {
+static jlong netty_quiche_conn_new_scid(JNIEnv* env, jclass clazz, jlong conn, jlong scid, jint scid_len, jbyteArray reset_token, jboolean retire_if_needed, jlong sequenceAddr) {
     uint8_t* buf = (uint8_t*) (*env)->GetByteArrayElements(env, reset_token, 0);
-    jlong ret = quiche_conn_new_scid((quiche_conn *) conn, (const uint8_t *) scid, scid_len, buf, retire_if_needed == JNI_TRUE ? true : false, (uint64_t*) seq);
+
+    uint64_t* seq;
+    if (sequenceAddr < 0) {
+        uint64_t tmp;
+        seq = &tmp;
+    } else {
+        seq = (uint64_t *) sequenceAddr;
+    }
+    jlong ret = quiche_conn_new_scid((quiche_conn *) conn, (const uint8_t *) scid, scid_len, buf, retire_if_needed == JNI_TRUE ? true : false, seq);
     (*env)->ReleaseByteArrayElements(env, reset_token, (jbyte*)buf, JNI_ABORT);
     return ret;
 }


### PR DESCRIPTION
Motivation:

Let's just allocate the memory on the stack and not use the pool if we never use the actual value

Modifications:

Just allocate on the stack

Result:

Reduce pool usage if not needed.