### PR TITLE
Also add Specification-* entries to MANIFEST.MF

### DIFF
--- a/codec-classes-quic/pom.xml
+++ b/codec-classes-quic/pom.xml
@@ -43,6 +43,7 @@
               <archive>
                 <manifest>
                   <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                  <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                 </manifest>
                 <manifestEntries>
                   <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -1099,6 +1099,7 @@
               <archive>
                 <manifest>
                   <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                  <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                 </manifest>
                 <manifestEntries>
                   <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
@@ -1118,6 +1119,7 @@
               <archive>
                 <manifest>
                   <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                  <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                 </manifest>
                 <manifestEntries>
                   <Automatic-Module-Name>${javaModuleNameWithClassifier}</Automatic-Module-Name>


### PR DESCRIPTION
Motivation:

Some tools depend on the Specification-* entries in the MANIFEST.MF. Unfortunaly
 we don't add these at the moment

Modifications:

Configure plugin to also add the Specification-* entries

Result:

MANIFEST.MF contains Specification-* entries