### PR TITLE
Copy a missing field in QuicServerCodecBuilder's copy constructor

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -60,6 +60,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
         streamHandler = builder.streamHandler;
         connectionIdAddressGenerator = builder.connectionIdAddressGenerator;
         tokenHandler = builder.tokenHandler;
+        resetTokenGenerator = builder.resetTokenGenerator;
     }
 
     @Override


### PR DESCRIPTION
Motivation:
QuicServerCodecBuilder's copy constructor doesn't copy resetTokenGenerator

Modification:
- Copy resetTokenGenerator when QuicServerCodecBuilder's copy constructor is used

Result:
QuicServerCodecBuilder's copy constructor copies all fields