### PR TITLE
Fire SniCompletionEvent as soon as the SNI hostname was selected

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -247,11 +247,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             case NOT_HANDSHAKING:
             case FINISHED:
                 handshakeCompletionNotified = true;
-                String sniHostname = connection.engine().sniHostname;
-                if (sniHostname != null) {
-                    connection.engine().sniHostname = null;
-                    pipeline().fireUserEventTriggered(new SniCompletionEvent(sniHostname));
-                }
                 pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
                 break;
             default:
@@ -279,7 +274,8 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             this.traceId = new String(traceId);
         }
 
-        connection.initInfo(local, remote);
+        connection.init(local, remote,
+                sniHostname -> pipeline().fireUserEventTriggered(new SniCompletionEvent(sniHostname)));
 
         // Setup QLOG if needed.
         QLogConfiguration configuration = config.getQLogConfiguration();

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
@@ -23,6 +23,7 @@ import io.netty.util.ResourceLeakTracker;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 final class QuicheQuicConnection {
@@ -178,7 +179,7 @@ final class QuicheQuicConnection {
         return connection;
     }
 
-    void initInfo(InetSocketAddress local, InetSocketAddress remote) {
+    void init(InetSocketAddress local, InetSocketAddress remote, Consumer<String> sniSelectedCallback) {
         assert connection != -1;
         assert recvInfoBuffer.refCnt() != 0;
         assert sendInfoBuffer.refCnt() != 0;
@@ -190,6 +191,7 @@ final class QuicheQuicConnection {
         // Fill both quiche_send_info structs with the same address.
         QuicheSendInfo.setSendInfo(sendInfoBuffer1, local, remote);
         QuicheSendInfo.setSendInfo(sendInfoBuffer2, local, remote);
+        engine.sniSelectedCallback = sniSelectedCallback;
     }
 
     ByteBuffer nextRecvInfo() {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.LongFunction;
 
 final class QuicheQuicSslEngine extends QuicSslEngine {
@@ -54,7 +55,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
     final String tlsHostName;
     volatile QuicheQuicConnection connection;
 
-    String sniHostname;
+    volatile Consumer<String> sniSelectedCallback;
 
     QuicheQuicSslEngine(QuicheQuicSslContext ctx, String peerHost, int peerPort) {
         this.ctx = ctx;
@@ -75,7 +76,10 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
         this.ctx.remove(this);
         this.ctx = ctx;
         long added = ctx.add(this);
-        sniHostname = hostname;
+        Consumer<String> sniSelectedCallback = this.sniSelectedCallback;
+        if (sniSelectedCallback != null) {
+            sniSelectedCallback.accept(hostname);
+        }
         return added;
     }
 


### PR DESCRIPTION
Motivation:

We did fire the SniCompletionEvent only once we were done with the handshake which is not really the correct time to do this. We should fire the event as soon as we were able to process the client hello and selected the hostname.

Modifications:

- Fire the event as soon as we select the hostname

Result:

Fire the event at the correct time