### PR TITLE
Disable android jobs for now

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -145,6 +145,7 @@ jobs:
             **/hs_err*.log
 
   build-android:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     name: android
     env:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -156,6 +156,7 @@ jobs:
             **/hs_err*.log
 
   build-pr-android:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     name: android
     env:


### PR DESCRIPTION
Motivation:

At the moment the android jobs fail as it seems like ANDROID_HOME is not provided anymore. Until we have time to look into it let's just not run the jobs.

Modifications:

Add expression to disable android jobs for now

Result:

CI checks pass again