### PR TITLE
Use android-actions/setup-android to fix android build

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -145,7 +145,6 @@ jobs:
             **/hs_err*.log
 
   build-android:
-    if: ${{ false }}
     runs-on: ubuntu-latest
     name: android
     env:
@@ -175,11 +174,16 @@ jobs:
           distribution: zulu
           java-version: 8
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          cmdline-tools-version: 8512546
+
       - name: Install Android SDK platforms
-        run: ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;${{ env.SDK_VER }}"
+        run: sdkmanager "platforms;${{ env.SDK_VER }}"
 
       - name: Install Android NDK
-        run: ${ANDROID_HOME}/tools/bin/sdkmanager "ndk;${{ env.NDK_VER }}"
+        run: sdkmanager "ndk;${{ env.NDK_VER }}"
 
       - name: Setup environment
         run: export ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -156,7 +156,6 @@ jobs:
             **/hs_err*.log
 
   build-pr-android:
-    if: ${{ false }}
     runs-on: ubuntu-latest
     name: android
     env:
@@ -186,11 +185,16 @@ jobs:
           distribution: zulu
           java-version: 8
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          cmdline-tools-version: 8512546
+
       - name: Install Android SDK platforms
-        run: ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;${{ env.SDK_VER }}"
+        run: sdkmanager "platforms;${{ env.SDK_VER }}"
 
       - name: Install Android NDK
-        run: ${ANDROID_HOME}/tools/bin/sdkmanager "ndk;${{ env.NDK_VER }}"
+        run: sdkmanager "ndk;${{ env.NDK_VER }}"
 
       - name: Setup environment
         run: export ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}


### PR DESCRIPTION
Motivation:

We should use android-actions/setup-android when building for android

Modifications:

Use android-actions/setup-android for android build jobs

Result:

Android build works again