### PR TITLE
Ensure we also set the QuicConnectionId when the id has a length of 0.

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionAddress.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionAddress.java
@@ -18,6 +18,7 @@ package io.netty.incubator.codec.quic;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import io.netty.util.internal.EmptyArrays;
 
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -27,6 +28,8 @@ import java.util.Objects;
  * A {@link QuicConnectionAddress} that can be used to connect too.
  */
 public final class QuicConnectionAddress extends SocketAddress {
+
+    static final QuicConnectionAddress NULL_LEN = new QuicConnectionAddress(EmptyArrays.EMPTY_BYTES);
 
     /**
      * Special {@link QuicConnectionAddress} that should be used when the connection address should be generated

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
@@ -153,7 +153,7 @@ final class QuicheQuicConnection {
             }
             id = idSupplier.get();
         }
-        return id == null ? null : new QuicConnectionAddress(id);
+        return id == null ? QuicConnectionAddress.NULL_LEN : new QuicConnectionAddress(id);
     }
 
     QuicheQuicTransportParameters peerParameters() {

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelDatagramTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelDatagramTest.java
@@ -195,6 +195,7 @@ public class QuicChannelDatagramTest extends AbstractQuicTest {
 
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
+                super.channelActive(ctx);
                 ctx.read();
             }
 

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelEchoTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelEchoTest.java
@@ -221,6 +221,7 @@ public class QuicChannelEchoTest extends AbstractQuicTest {
         QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler() {
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
+                super.channelActive(ctx);
                 setAllocator(ctx.channel(), allocator);
                 ctx.channel().config().setAutoRead(autoRead);
                 if (!autoRead) {

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelValidationHandler.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelValidationHandler.java
@@ -18,8 +18,13 @@ package io.netty.incubator.codec.quic;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
-class QuicChannelValidationHandler extends ChannelInboundHandlerAdapter {
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+class QuicChannelValidationHandler extends ChannelInboundHandlerAdapter {
+    private volatile boolean wasActive;
+
+    private volatile QuicConnectionAddress localAddress;
+    private volatile QuicConnectionAddress remoteAddress;
     private volatile Throwable cause;
 
     @Override
@@ -27,10 +32,30 @@ class QuicChannelValidationHandler extends ChannelInboundHandlerAdapter {
         this.cause = cause;
     }
 
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) {
+        wasActive = true;
+        localAddress = (QuicConnectionAddress) ctx.channel().localAddress();
+        remoteAddress = (QuicConnectionAddress) ctx.channel().remoteAddress();
+        ctx.fireChannelActive();
+    }
+
+    QuicConnectionAddress localAddress() {
+        return localAddress;
+    }
+
+    QuicConnectionAddress remoteAddress() {
+        return remoteAddress;
+    }
+
     void assertState() throws Throwable {
         if (cause != null) {
             throw cause;
         }
+        if (wasActive) {
+            // Validate that the addresses could be retrieved
+            assertNotNull(localAddress);
+            assertNotNull(remoteAddress);
+        }
     }
-
 }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelValidationHandler.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelValidationHandler.java
@@ -34,9 +34,9 @@ class QuicChannelValidationHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) {
-        wasActive = true;
         localAddress = (QuicConnectionAddress) ctx.channel().localAddress();
         remoteAddress = (QuicConnectionAddress) ctx.channel().remoteAddress();
+        wasActive = true;
         ctx.fireChannelActive();
     }
 

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
@@ -49,8 +49,8 @@ public class QuicConnectionStatsTest extends AbstractQuicTest {
         QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler() {
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
+                super.channelActive(ctx);
                 collectStats(ctx, serverActiveStats);
-                ctx.fireChannelActive();
             }
 
             @Override

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCloseTest.java
@@ -238,6 +238,7 @@ public class QuicStreamChannelCloseTest extends AbstractQuicTest {
 
         @Override
         public void channelActive(ChannelHandlerContext ctx) {
+            super.channelActive(ctx);
             QuicChannel channel = (QuicChannel) ctx.channel();
             channel.createStream(type, new ChannelInboundHandlerAdapter() {
                 @Override
@@ -271,6 +272,7 @@ public class QuicStreamChannelCloseTest extends AbstractQuicTest {
 
         @Override
         public void channelActive(ChannelHandlerContext ctx) {
+            super.channelActive(ctx);
             QuicChannel channel = (QuicChannel) ctx.channel();
             channel.createStream(type, new ChannelInboundHandlerAdapter() {
                 @Override

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamFrameTest.java
@@ -83,6 +83,7 @@ public class QuicStreamFrameTest extends AbstractQuicTest {
 
         @Override
         public void channelActive(ChannelHandlerContext ctx) {
+            super.channelActive(ctx);
             QuicChannel channel = (QuicChannel) ctx.channel();
             channel.createStream(type, new ChannelInboundHandlerAdapter() {
                 @Override

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamHalfClosureTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamHalfClosureTest.java
@@ -85,6 +85,7 @@ public class QuicStreamHalfClosureTest extends AbstractQuicTest {
 
         @Override
         public void channelActive(ChannelHandlerContext ctx) {
+            super.channelActive(ctx);
             QuicChannel channel = (QuicChannel) ctx.channel();
             channel.createStream(type, new ChannelInboundHandlerAdapter() {
                 @Override

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
@@ -138,6 +138,7 @@ public class QuicStreamLimitTest extends AbstractQuicTest {
         QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler() {
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
+                super.channelActive(ctx);
                 QuicChannel channel = (QuicChannel) ctx.channel();
                 channel.createStream(type, new ChannelInboundHandlerAdapter())
                         .addListener((Future<QuicStreamChannel> future) -> {

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
@@ -100,6 +100,7 @@ public class QuicStreamTypeTest extends AbstractQuicTest {
         QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler() {
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
+                super.channelActive(ctx);
                 QuicChannel channel = (QuicChannel) ctx.channel();
                 channel.createStream(QuicStreamType.UNIDIRECTIONAL, new ChannelInboundHandlerAdapter() {
                     @Override

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTransportParametersTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTransportParametersTest.java
@@ -41,9 +41,9 @@ public class QuicTransportParametersTest extends AbstractQuicTest {
         QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler() {
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
+                super.channelActive(ctx);
                 QuicheQuicChannel channel = (QuicheQuicChannel) ctx.channel();
                 serverParams.setSuccess(channel.peerTransportParameters());
-                ctx.fireChannelActive();
             }
         };
         QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();


### PR DESCRIPTION
Motivation:

We did not correctly handle the case when the remote peer used a connection id with length of 0.

Modifications:

- Correctly handle the case when an id is of length 0
- Modify unit tests to catch the problem

Result:

Correct handling of zero length connection ids