### PR TITLE
Correctly fail connect future if failure in parent pipeline accours

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -1450,7 +1450,13 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                     }
                 });
 
-                parent().connect(new QuicheQuicChannelAddress(QuicheQuicChannel.this));
+                parent().connect(new QuicheQuicChannelAddress(QuicheQuicChannel.this))
+                        .addListener(f -> {
+                            ChannelPromise connectPromise = QuicheQuicChannel.this.connectPromise;
+                            if (connectPromise != null && !f.isSuccess()) {
+                                connectPromise.tryFailure(f.cause());
+                            }
+                        });
                 return;
             }
 


### PR DESCRIPTION
Motivation:

We need to propagate any exception that happens in the parent ChannelPipeline during connect.

Modifications:

- Correct propagate exception
- Add unit case

Result:

No more connect stalls when a exception happens in the parent pipeline during processing the connect