### PR TITLE
Cleanup connect implementation

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -317,9 +317,9 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         }
     }
 
-    private void connect(Function<QuicChannel, ? extends QuicSslEngine> engineProvider, Executor sslTaskExecutor,
-                         long configAddr, int localConnIdLength,
-                         boolean supportsDatagram, ByteBuffer fromSockaddrMemory, ByteBuffer toSockaddrMemory)
+    void connectNow(Function<QuicChannel, ? extends QuicSslEngine> engineProvider, Executor sslTaskExecutor,
+                 long configAddr, int localConnIdLength,
+                 boolean supportsDatagram, ByteBuffer fromSockaddrMemory, ByteBuffer toSockaddrMemory)
             throws Exception {
         assert this.connection == null;
         assert this.traceId == null;
@@ -1851,34 +1851,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 !isConnDestroyed() && Quiche.quiche_conn_is_in_early_data(connection.address())) {
             earlyDataReadyNotified = true;
             pipeline().fireUserEventTriggered(SslEarlyDataReadyEvent.INSTANCE);
-        }
-    }
-
-    // TODO: Come up with something better.
-    static QuicheQuicChannel handleConnect(Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider,
-                                           Executor sslTaskExecutor,
-                                           SocketAddress address, long config, int localConnIdLength,
-                                           boolean supportsDatagram, ByteBuffer fromSockaddrMemory,
-                                           ByteBuffer toSockaddrMemory) throws Exception {
-        if (address instanceof QuicheQuicChannel.QuicheQuicChannelAddress) {
-            QuicheQuicChannel.QuicheQuicChannelAddress addr = (QuicheQuicChannel.QuicheQuicChannelAddress) address;
-            QuicheQuicChannel channel = addr.channel;
-            channel.connect(sslEngineProvider, sslTaskExecutor, config, localConnIdLength, supportsDatagram,
-                    fromSockaddrMemory, toSockaddrMemory);
-            return channel;
-        }
-        return null;
-    }
-
-    /**
-     * Just a container to pass the {@link QuicheQuicChannel} to {@link QuicheQuicClientCodec}.
-     */
-    private static final class QuicheQuicChannelAddress extends SocketAddress {
-
-        final QuicheQuicChannel channel;
-
-        QuicheQuicChannelAddress(QuicheQuicChannel channel) {
-            this.channel = channel;
         }
     }
 

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannelAddress.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannelAddress.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import java.net.SocketAddress;
+
+/**
+ * Just a container to pass the {@link QuicheQuicChannel} to {@link QuicheQuicClientCodec}.
+ */
+final class QuicheQuicChannelAddress extends SocketAddress {
+
+    final QuicheQuicChannel channel;
+
+    QuicheQuicChannelAddress(QuicheQuicChannel channel) {
+        this.channel = channel;
+    }
+}


### PR DESCRIPTION
Motivation:

We can cleanup our code a bit by moving the instanceof check into the codec

Modifications:

- Move QuicheQuicChannelAddress out of QuicheQuicChannel
- Move instanceof check into QuicheQuicClientCodec
- Remove static helper method

Result:

Code cleanup