### PR TITLE
Reduce native memory usage of QuicheQuicConnection

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -1178,7 +1178,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 int segmentSize = -1;
                 if (connection.isSendInfoChanged()) {
                     // Change the cached address and let the user know there was a connection migration.
-                    InetSocketAddress oldRemote = remote;
                     remote = QuicheSendInfo.getToAddress(sendInfo);
                     local = QuicheSendInfo.getFromAddress(sendInfo);
 
@@ -1508,10 +1507,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 ByteBuffer recvInfo = connection.nextRecvInfo();
                 QuicheRecvInfo.setRecvInfo(recvInfo, sender, recipient);
 
-                if (connection.isRecvInfoChanged()) {
-                    // Update the cached address
-                    remote = sender;
-                }
+                remote = sender;
                 local = recipient;
 
                 long connAddr = connection.address();

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheRecvInfo.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheRecvInfo.java
@@ -70,16 +70,4 @@ final class QuicheRecvInfo {
             memory.position(position);
         }
     }
-
-    /**
-     * Returns {@code true} if both {@link ByteBuffer}s have the same {@code sock_addr} stored.
-     *
-     * @param memory    the first {@link ByteBuffer} which holds a {@code quiche_recv_info}.
-     * @param memory2   the second {@link ByteBuffer} which holds a {@code quiche_recv_info}.
-     * @return          {@code true} if both {@link ByteBuffer}s have the same {@code sock_addr} stored, {@code false}
-     *                  otherwise.
-     */
-    static boolean isSameAddress(ByteBuffer memory, ByteBuffer memory2) {
-        return Quiche.isSameAddress(memory, memory2, Quiche.SIZEOF_QUICHE_RECV_INFO);
-    }
 }


### PR DESCRIPTION
Motivation:

QuicheQuicConnection does only need native memory for one recipient addres, while we allocated memory for two.

Modifications:

Only allocate native memory for one address

Result:

Less native memory usage per quic connection