### PR TITLE
Don't cache local and remote address as these might change during the…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
@@ -23,6 +23,8 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import java.util.function.Function;
 

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -86,10 +86,11 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
     private void removeChannel(QuicheQuicChannel channel) {
         boolean removed = channels.remove(channel);
-        assert removed;
-        for (ByteBuffer id : channel.sourceConnectionIds()) {
-            QuicheQuicChannel ch = connectionIdToChannel.remove(id);
-            assert ch == channel;
+        if (removed) {
+            for (ByteBuffer id : channel.sourceConnectionIds()) {
+                QuicheQuicChannel ch = connectionIdToChannel.remove(id);
+                assert ch == channel;
+            }
         }
     }
 

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -288,12 +288,12 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             ChannelFuture closeFuture = quicChannel.closeFuture().await();
             assertTrue(closeFuture.isSuccess());
             clientQuicChannelHandler.assertState();
-            assertEquals(clientIdLength, clientQuicChannelHandler.localAddress().connId.remaining());
-            assertEquals(serverIdLength, clientQuicChannelHandler.remoteAddress().connId.remaining());
+            assertEquals(clientIdLength, clientQuicChannelHandler.localAddress().id().remaining());
+            assertEquals(serverIdLength, clientQuicChannelHandler.remoteAddress().id().remaining());
         } finally {
             serverQuicChannelHandler.assertState();
-            assertEquals(serverIdLength, serverQuicChannelHandler.localAddress().connId.remaining());
-            assertEquals(clientIdLength, serverQuicChannelHandler.remoteAddress().connId.remaining());
+            assertEquals(serverIdLength, serverQuicChannelHandler.localAddress().id().remaining());
+            assertEquals(clientIdLength, serverQuicChannelHandler.remoteAddress().id().remaining());
             serverQuicStreamHandler.assertState();
 
             server.close().sync();
@@ -542,10 +542,6 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
 
             assertEquals(serverQuicChannelHandler.localAddress(), remoteAddress);
             assertEquals(serverQuicChannelHandler.remoteAddress(), localAddress);
-
-            // Check if we also can access these after the channel was closed.
-            assertNotNull(quicChannel.localAddress());
-            assertNotNull(quicChannel.remoteAddress());
         } finally {
             serverLatch.await();
 

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionAddressTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionAddressTest.java
@@ -41,9 +41,9 @@ public class QuicConnectionAddressTest extends AbstractQuicTest {
         byte[] bytes = new byte[8];
         ThreadLocalRandom.current().nextBytes(bytes);
         QuicConnectionAddress address = new QuicConnectionAddress(bytes);
-        assertEquals(ByteBuffer.wrap(bytes), address.connId);
+        assertEquals(ByteBuffer.wrap(bytes), address.id());
         ThreadLocalRandom.current().nextBytes(bytes);
-        assertNotEquals(ByteBuffer.wrap(bytes), address.connId);
+        assertNotEquals(ByteBuffer.wrap(bytes), address.id());
     }
 
     @Test
@@ -52,8 +52,8 @@ public class QuicConnectionAddressTest extends AbstractQuicTest {
         ThreadLocalRandom.current().nextBytes(bytes);
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
         QuicConnectionAddress address = new QuicConnectionAddress(bytes);
-        assertEquals(buffer, address.connId);
+        assertEquals(buffer, address.id());
         buffer.position(1);
-        assertNotEquals(buffer, address.connId);
+        assertNotEquals(buffer, address.id());
     }
 }


### PR DESCRIPTION
… life-time

Motivation:

We should not cache the local and remote address as these might change during the life-time of the connection

Modifications:

- Override methods so we don't cache
- Also duplicate ByteBuffer in the QuicConnectionAddress to make things safer.

Result:

Correctly return ids