### PR TITLE
Correctly handle lifetimes and channel state.

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
@@ -87,6 +87,10 @@ final class QuicheQuicConnection {
         free(true);
     }
 
+    boolean isFreed() {
+        return connection == -1;
+    }
+
     private void free(boolean closeLeakTracker) {
         boolean release = false;
         synchronized (this) {


### PR DESCRIPTION
Motivation:

Due how our code was structured it was possible that we not always handle the lifetime of the underlying quiche connection correctly. Beside this it was also possible to convert a CLOSED channel state to an ACTIVE again.

Modifications:

- Rewrite the state machine in QuicheQuicChannel to correctly handle the different states and also make it impossible to change a final state like CLOSED
- Correctly handle removal of the QuicheQuicChannel from the datastructures in QuicheQuicChannel

Result:

Correct handling of lifetime and state.