### PR TITLE
Don't close staging repository automatically

### DIFF
--- a/scripts/finish_release.sh
+++ b/scripts/finish_release.sh
@@ -32,5 +32,4 @@ export JAVA_HOME="$JAVA8_HOME"
 
 ./mvnw -Psonatype-oss-release,"$CROSS_COMPILE_PROFILE" clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
 ./mvnw -Psonatype-oss-release clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true -DstagingProgressTimeoutMinutes=10
-./mvnw -Psonatype-oss-release org.sonatype.plugins:nexus-staging-maven-plugin:rc-close  org.sonatype.plugins:nexus-staging-maven-plugin:rc-release -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true -DstagingProgressTimeoutMinutes=10
 git checkout "$BRANCH"


### PR DESCRIPTION
Motivation:

Let's not close the staging repository automatically so we can still inspect it before we do a release

Modifications:

Don't close

Result:

Be able to still inspect staging repository before do the actual release