### PR TITLE
Add ReferenceCountUtil.touch(...) calls before we store messages into…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -679,6 +679,9 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         }
 
         private void queueAndFailAll(Object msg, ChannelPromise promise, Throwable cause) {
+            // Touch the message to make things easier in terms of debugging buffer leaks.
+            ReferenceCountUtil.touch(msg);
+
             queue.add(msg, promise);
             queue.removeAndFailAll(cause);
         }
@@ -716,6 +719,8 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                     promise.setSuccess();
                     mayNeedWritabilityUpdate = capacity == 0;
                 } else {
+                    // Touch the message to make things easier in terms of debugging buffer leaks.
+                    ReferenceCountUtil.touch(msg);
                     queue.add(msg, promise);
                     mayNeedWritabilityUpdate = true;
                 }


### PR DESCRIPTION
… a queue to make debugging leaks easier

Motivation:

We should touch our messages when we take over ownership, this allows easier debugging of buffer leaks.

Modifications:

Let's add touch call before enqueue into internal datastructure

Result:

Easier to debug buffer leaks