### PR TITLE
Apply Nullable/NotNullByDefault annotations

### DIFF
--- a/codec-classes-quic/pom.xml
+++ b/codec-classes-quic/pom.xml
@@ -85,5 +85,13 @@
       <!-- Let's mark as optional as it is not strictly needed -->
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSL.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSL.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.handler.ssl.util.LazyX509Certificate;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -41,10 +42,10 @@ final class BoringSSL {
                                BoringSSLHandshakeCompleteCallback handshakeCompleteCallback,
                                BoringSSLCertificateCallback certificateCallback,
                                BoringSSLCertificateVerifyCallback verifyCallback,
-                               BoringSSLTlsextServernameCallback servernameCallback,
-                               BoringSSLKeylogCallback keylogCallback,
-                               BoringSSLSessionCallback sessionCallback,
-                               BoringSSLPrivateKeyMethod privateKeyMethod,
+                               @Nullable BoringSSLTlsextServernameCallback servernameCallback,
+                               @Nullable BoringSSLKeylogCallback keylogCallback,
+                               @Nullable BoringSSLSessionCallback sessionCallback,
+                               @Nullable BoringSSLPrivateKeyMethod privateKeyMethod,
                                BoringSSLSessionTicketCallback sessionTicketCallback,
                                int verifyMode,
                                byte[][] subjectNames) {
@@ -72,9 +73,9 @@ final class BoringSSL {
     private static native long SSLContext_new0(boolean server,
                                                byte[] applicationProtocols, Object handshakeCompleteCallback,
                                                Object certificateCallback, Object verifyCallback,
-                                               Object servernameCallback, Object keylogCallback,
-                                               Object sessionCallback,
-                                               Object privateKeyMethod,
+                                               @Nullable Object servernameCallback, @Nullable Object keylogCallback,
+                                               @Nullable Object sessionCallback,
+                                               @Nullable Object privateKeyMethod,
                                                Object sessionTicketCallback,
                                                int verifyDepth, byte[][] subjectNames);
     static native void SSLContext_set_early_data_enabled(long context, boolean enabled);
@@ -87,7 +88,7 @@ final class BoringSSL {
     static long SSL_new(long context, boolean server, String hostname) {
         return SSL_new0(context, server, tlsExtHostName(hostname));
     }
-    static native long SSL_new0(long context, boolean server, String hostname);
+    static native long SSL_new0(long context, boolean server, @Nullable String hostname);
     static native void SSL_free(long ssl);
 
     static native Runnable SSL_getTask(long ssl);
@@ -100,9 +101,11 @@ final class BoringSSL {
     static native long CRYPTO_BUFFER_stack_new(long ssl, byte[][] bytes);
     static native void CRYPTO_BUFFER_stack_free(long chain);
 
+    @Nullable
     static native String ERR_last_error();
 
-    private static String tlsExtHostName(String hostname) {
+    @Nullable
+    private static String tlsExtHostName(@Nullable String hostname) {
         if (hostname != null && hostname.endsWith(".")) {
             // Strip trailing dot if included.
             // See https://github.com/netty/netty-tcnative/issues/400

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallback.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallback.java
@@ -17,6 +17,7 @@ package io.netty.incubator.codec.quic;
 
 
 import io.netty.util.CharsetUtil;
+import org.jetbrains.annotations.Nullable;
 
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
@@ -90,7 +91,7 @@ final class BoringSSLCertificateCallback {
     private final X509ExtendedKeyManager keyManager;
     private final String password;
 
-    BoringSSLCertificateCallback(QuicheQuicSslEngineMap engineMap, X509ExtendedKeyManager keyManager, String password) {
+    BoringSSLCertificateCallback(QuicheQuicSslEngineMap engineMap, @Nullable X509ExtendedKeyManager keyManager, String password) {
         this.engineMap = engineMap;
         this.keyManager = keyManager;
         this.password = password;
@@ -222,11 +223,14 @@ final class BoringSSLCertificateCallback {
             return null;
         }
     }
+
+    @Nullable
     private String chooseClientAlias(QuicheQuicSslEngine engine,
                                      String[] keyTypes, X500Principal[] issuer) {
         return keyManager.chooseEngineClientAlias(keyTypes, issuer, engine);
     }
 
+    @Nullable
     private String chooseServerAlias(QuicheQuicSslEngine engine, String type) {
         return keyManager.chooseEngineServerAlias(type, null, engine);
     }
@@ -256,6 +260,7 @@ final class BoringSSLCertificateCallback {
         return result;
     }
 
+    @Nullable
     private static String clientKeyType(byte clientCertificateType) {
         // See also https://www.ietf.org/assignments/tls-parameters/tls-parameters.xml
         switch (clientCertificateType) {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLKeylessManagerFactory.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLKeylessManagerFactory.java
@@ -15,6 +15,8 @@
  */
 package io.netty.incubator.codec.quic;
 
+import org.jetbrains.annotations.Nullable;
+
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.KeyManagerFactorySpi;
@@ -148,6 +150,7 @@ public final class BoringSSLKeylessManagerFactory extends KeyManagerFactory {
                 private final Date creationDate = new Date();
 
                 @Override
+                @Nullable
                 public Key engineGetKey(String alias, char[] password) {
                     if (engineContainsAlias(alias)) {
                         return BoringSSLKeylessPrivateKey.INSTANCE;
@@ -161,11 +164,13 @@ public final class BoringSSLKeylessManagerFactory extends KeyManagerFactory {
                 }
 
                 @Override
+                @Nullable
                 public Certificate engineGetCertificate(String alias) {
                     return engineContainsAlias(alias)? certificateChain[0] : null;
                 }
 
                 @Override
+                @Nullable
                 public Date engineGetCreationDate(String alias) {
                     return engineContainsAlias(alias)? creationDate : null;
                 }
@@ -217,6 +222,7 @@ public final class BoringSSLKeylessManagerFactory extends KeyManagerFactory {
                 }
 
                 @Override
+                @Nullable
                 public String engineGetCertificateAlias(Certificate cert) {
                     if (cert instanceof X509Certificate) {
                         for (X509Certificate x509Certificate : certificateChain) {
@@ -234,7 +240,7 @@ public final class BoringSSLKeylessManagerFactory extends KeyManagerFactory {
                 }
 
                 @Override
-                public void engineLoad(InputStream stream, char[] password) {
+                public void engineLoad(@Nullable InputStream stream, char[] password) {
                     if (stream != null && password != null) {
                         throw new UnsupportedOperationException();
                     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLSessionCallback.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLSessionCallback.java
@@ -18,6 +18,7 @@ package io.netty.incubator.codec.quic;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -30,7 +31,7 @@ final class BoringSSLSessionCallback {
     private final QuicClientSessionCache sessionCache;
     private final QuicheQuicSslEngineMap engineMap;
 
-    BoringSSLSessionCallback(QuicheQuicSslEngineMap engineMap, QuicClientSessionCache sessionCache) {
+    BoringSSLSessionCallback(QuicheQuicSslEngineMap engineMap, @Nullable QuicClientSessionCache sessionCache) {
         this.engineMap = engineMap;
         this.sessionCache = sessionCache;
     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quic.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quic.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.util.AttributeKey;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -87,6 +88,7 @@ public final class Quic {
      *
      * @return the cause if unavailable. {@code null} if available.
      */
+    @Nullable
     public static Throwable unavailabilityCause() {
         return UNAVAILABILITY_CAUSE;
     }
@@ -131,7 +133,7 @@ public final class Quic {
      * Allow to specify a {@link ChannelOption} which is used for the {@link QuicStreamChannel} instances once they got
      * created. Use a value of {@code null} to remove a previous set {@link ChannelOption}.
      */
-    static <T> void updateOptions(Map<ChannelOption<?>, Object> options, ChannelOption<T> option, T value) {
+    static <T> void updateOptions(Map<ChannelOption<?>, Object> options, ChannelOption<T> option, @Nullable T value) {
         ObjectUtil.checkNotNull(option, "option");
         if (value == null) {
             options.remove(option);
@@ -144,7 +146,7 @@ public final class Quic {
      * Allow to specify an initial attribute of the newly created {@link QuicStreamChannel}. If the {@code value} is
      * {@code null}, the attribute of the specified {@code key} is removed.
      */
-    static <T> void updateAttributes(Map<AttributeKey<?>, Object> attributes, AttributeKey<T> key, T value) {
+    static <T> void updateAttributes(Map<AttributeKey<?>, Object> attributes, AttributeKey<T> key, @Nullable T value) {
         ObjectUtil.checkNotNull(key, "key");
         if (value == null) {
             attributes.remove(key);
@@ -154,7 +156,7 @@ public final class Quic {
     }
 
     static void setupChannel(Channel ch, Map.Entry<ChannelOption<?>, Object>[] options,
-                             Map.Entry<AttributeKey<?>, Object>[] attrs, ChannelHandler handler,
+                             Map.Entry<AttributeKey<?>, Object>[] attrs, @Nullable ChannelHandler handler,
                              InternalLogger logger) {
         Quic.setChannelOptions(ch, options, logger);
         Quic.setAttributes(ch, attrs);

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelProgressivePromise;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
+import org.jetbrains.annotations.Nullable;
 
 import javax.net.ssl.SSLEngine;
 import java.net.SocketAddress;
@@ -154,6 +155,7 @@ public interface QuicChannel extends Channel {
      *
      * @return the engine.
      */
+    @Nullable
     SSLEngine sslEngine();
 
     /**
@@ -177,6 +179,7 @@ public interface QuicChannel extends Channel {
      *
      * @return peerTransportParams.
      */
+    @Nullable
     QuicTransportParameters peerTransportParameters();
 
     /**
@@ -189,7 +192,7 @@ public interface QuicChannel extends Channel {
      *                  {@link io.netty.channel.ChannelPipeline} during the stream creation.
      * @return          the {@link Future} that will be notified once the operation completes.
      */
-    default Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler) {
+    default Future<QuicStreamChannel> createStream(QuicStreamType type, @Nullable ChannelHandler handler) {
         return createStream(type, handler, eventLoop().newPromise());
     }
 
@@ -204,7 +207,7 @@ public interface QuicChannel extends Channel {
      * @param promise   the {@link ChannelPromise} that will be notified once the operation completes.
      * @return          the {@link Future} that will be notified once the operation completes.
      */
-    Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler,
+    Future<QuicStreamChannel> createStream(QuicStreamType type, @Nullable ChannelHandler handler,
                                            Promise<QuicStreamChannel> promise);
 
     /**

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
@@ -26,6 +26,7 @@ import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -74,7 +75,7 @@ public final class QuicChannelBootstrap {
      * @param <T>       the type of the value.
      * @return          this instance.
      */
-    public <T> QuicChannelBootstrap option(ChannelOption<T> option, T value) {
+    public <T> QuicChannelBootstrap option(ChannelOption<T> option, @Nullable T value) {
         Quic.updateOptions(options, option, value);
         return this;
     }
@@ -88,7 +89,7 @@ public final class QuicChannelBootstrap {
      * @param <T>       the type of the value.
      * @return          this instance.
      */
-    public <T> QuicChannelBootstrap attr(AttributeKey<T> key, T value) {
+    public <T> QuicChannelBootstrap attr(AttributeKey<T> key, @Nullable T value) {
         Quic.updateAttributes(attrs, key, value);
         return this;
     }
@@ -115,7 +116,7 @@ public final class QuicChannelBootstrap {
      * @param <T>       the type of the value.
      * @return          this instance.
      */
-    public <T> QuicChannelBootstrap streamOption(ChannelOption<T> option, T value) {
+    public <T> QuicChannelBootstrap streamOption(ChannelOption<T> option, @Nullable T value) {
         Quic.updateOptions(streamOptions, option, value);
         return this;
     }
@@ -129,7 +130,7 @@ public final class QuicChannelBootstrap {
      * @param <T>       the type of the value.
      * @return          this instance.
      */
-    public <T> QuicChannelBootstrap streamAttr(AttributeKey<T> key, T value) {
+    public <T> QuicChannelBootstrap streamAttr(AttributeKey<T> key, @Nullable T value) {
         Quic.updateAttributes(streamAttrs, key, value);
         return this;
     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicClientSessionCache.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicClientSessionCache.java
@@ -17,6 +17,7 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.util.AsciiString;
 import io.netty.util.internal.SystemPropertyUtil;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -55,7 +56,7 @@ final class QuicClientSessionCache {
                 }
             };
 
-    void saveSession(String host, int port, long creationTime, long timeout, byte[] session, boolean isSingleUse) {
+    void saveSession(@Nullable String host, int port, long creationTime, long timeout, byte[] session, boolean isSingleUse) {
         HostPort hostPort = keyFor(host, port);
         if (hostPort != null) {
             synchronized (sessions) {
@@ -72,7 +73,7 @@ final class QuicClientSessionCache {
     }
 
     // Only used for testing.
-    boolean hasSession(String host, int port) {
+    boolean hasSession(@Nullable String host, int port) {
         HostPort hostPort = keyFor(host, port);
         if (hostPort != null) {
             synchronized (sessions) {
@@ -82,7 +83,7 @@ final class QuicClientSessionCache {
         return false;
     }
 
-    byte[] getSession(String host, int port) {
+    byte[] getSession(@Nullable String host, int port) {
         HostPort hostPort = keyFor(host, port);
         if (hostPort != null) {
             SessionHolder sessionHolder;
@@ -103,7 +104,7 @@ final class QuicClientSessionCache {
         return null;
     }
 
-    void removeSession(String host, int port) {
+    void removeSession(@Nullable String host, int port) {
         HostPort hostPort = keyFor(host, port);
         if (hostPort != null) {
             synchronized (sessions) {
@@ -167,7 +168,8 @@ final class QuicClientSessionCache {
         }
     }
 
-    private static HostPort keyFor(String host, int port) {
+    @Nullable
+    private static HostPort keyFor(@Nullable String host, int port) {
         if (host == null && port < 1) {
             return null;
         }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicClosedChannelException.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicClosedChannelException.java
@@ -15,6 +15,8 @@
  */
 package io.netty.incubator.codec.quic;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.nio.channels.ClosedChannelException;
 
 /**
@@ -25,7 +27,7 @@ public final class QuicClosedChannelException extends ClosedChannelException {
 
     private final QuicConnectionCloseEvent event;
 
-    QuicClosedChannelException(QuicConnectionCloseEvent event) {
+    QuicClosedChannelException(@Nullable QuicConnectionCloseEvent event) {
         this.event = event;
     }
 
@@ -34,6 +36,7 @@ public final class QuicClosedChannelException extends ClosedChannelException {
      *
      * @return the event.
      */
+    @Nullable
     public QuicConnectionCloseEvent event() {
         return event;
     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicServerCodecBuilder.java
@@ -19,6 +19,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.util.AttributeKey;
 import io.netty.util.internal.ObjectUtil;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -77,7 +78,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
      * @param <T>       the type of the value.
      * @return          this instance.
      */
-    public <T> QuicServerCodecBuilder option(ChannelOption<T> option, T value) {
+    public <T> QuicServerCodecBuilder option(ChannelOption<T> option, @Nullable T value) {
         Quic.updateOptions(options, option, value);
         return self();
     }
@@ -91,7 +92,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
      * @param <T>       the type of the value.
      * @return          this instance.
      */
-    public <T> QuicServerCodecBuilder attr(AttributeKey<T> key, T value) {
+    public <T> QuicServerCodecBuilder attr(AttributeKey<T> key, @Nullable T value) {
         Quic.updateAttributes(attrs, key, value);
         return self();
     }
@@ -118,7 +119,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
      * @param <T>       the type of the value.
      * @return          this instance.
      */
-    public <T> QuicServerCodecBuilder streamOption(ChannelOption<T> option, T value) {
+    public <T> QuicServerCodecBuilder streamOption(ChannelOption<T> option, @Nullable T value) {
         Quic.updateOptions(streamOptions, option, value);
         return self();
     }
@@ -132,7 +133,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
      * @param <T>       the type of the value.
      * @return          this instance.
      */
-    public <T> QuicServerCodecBuilder streamAttr(AttributeKey<T> key, T value) {
+    public <T> QuicServerCodecBuilder streamAttr(AttributeKey<T> key, @Nullable T value) {
         Quic.updateAttributes(streamAttrs, key, value);
         return self();
     }
@@ -169,7 +170,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
      * @param tokenHandler  the {@link QuicTokenHandler} to use.
      * @return              this instance.
      */
-    public QuicServerCodecBuilder tokenHandler(QuicTokenHandler tokenHandler) {
+    public QuicServerCodecBuilder tokenHandler(@Nullable QuicTokenHandler tokenHandler) {
         this.tokenHandler = tokenHandler;
         return self();
     }
@@ -181,7 +182,7 @@ public final class QuicServerCodecBuilder extends QuicCodecBuilder<QuicServerCod
      * @param resetTokenGenerator  the {@link QuicResetTokenGenerator} to use.
      * @return                     this instance.
      */
-    public QuicServerCodecBuilder resetTokenGenerator(QuicResetTokenGenerator resetTokenGenerator) {
+    public QuicServerCodecBuilder resetTokenGenerator(@Nullable QuicResetTokenGenerator resetTokenGenerator) {
         this.resetTokenGenerator = resetTokenGenerator;
         return self();
     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
@@ -20,6 +20,7 @@ import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.util.KeyManagerFactoryWrapper;
 import io.netty.handler.ssl.util.TrustManagerFactoryWrapper;
 import io.netty.util.Mapping;
+import org.jetbrains.annotations.Nullable;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -56,6 +57,7 @@ public final class QuicSslContextBuilder {
         }
 
         @Override
+        @Nullable
         public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
             return null;
         }
@@ -66,6 +68,7 @@ public final class QuicSslContextBuilder {
         }
 
         @Override
+        @Nullable
         public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
             return null;
         }
@@ -76,6 +79,7 @@ public final class QuicSslContextBuilder {
         }
 
         @Override
+        @Nullable
         public PrivateKey getPrivateKey(String alias) {
             return null;
         }
@@ -98,7 +102,7 @@ public final class QuicSslContextBuilder {
      * @see #keyManager(File, String, File)
      */
     public static QuicSslContextBuilder forServer(
-            File keyFile, String keyPassword, File certChainFile) {
+            File keyFile, @Nullable String keyPassword, File certChainFile) {
         return new QuicSslContextBuilder(true).keyManager(keyFile, keyPassword, certChainFile);
     }
 
@@ -112,7 +116,7 @@ public final class QuicSslContextBuilder {
      * @see #keyManager(File, String, File)
      */
     public static QuicSslContextBuilder forServer(
-            PrivateKey key, String keyPassword, X509Certificate... certChain) {
+            PrivateKey key, @Nullable String keyPassword, X509Certificate... certChain) {
         return new QuicSslContextBuilder(true).keyManager(key, keyPassword, certChain);
     }
 
@@ -122,7 +126,7 @@ public final class QuicSslContextBuilder {
      * @param keyManagerFactory non-{@code null} factory for server's private key
      * @see #keyManager(KeyManagerFactory, String)
      */
-    public static QuicSslContextBuilder forServer(KeyManagerFactory keyManagerFactory, String password) {
+    public static QuicSslContextBuilder forServer(KeyManagerFactory keyManagerFactory, @Nullable String password) {
         return new QuicSslContextBuilder(true).keyManager(keyManagerFactory, password);
     }
 
@@ -134,7 +138,7 @@ public final class QuicSslContextBuilder {
      * @param keyPassword the password of the {@code keyFile}, or {@code null} if it's not
      *     password-protected
      */
-    public static QuicSslContextBuilder forServer(KeyManager keyManager, String keyPassword) {
+    public static QuicSslContextBuilder forServer(KeyManager keyManager, @Nullable String keyPassword) {
         return new QuicSslContextBuilder(true).keyManager(keyManager, keyPassword);
     }
 
@@ -198,7 +202,7 @@ public final class QuicSslContextBuilder {
      * <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format">
      *     NSS Key Log Format</a>. This is intended for debugging use with tools like Wireshark.
      */
-    public QuicSslContextBuilder keylog(BoringSSLKeylog keylog) {
+    public QuicSslContextBuilder keylog(@Nullable BoringSSLKeylog keylog) {
         this.keylog = keylog;
         return this;
     }
@@ -210,7 +214,7 @@ public final class QuicSslContextBuilder {
      * see <a href="https://www.oracle.com/java/technologies/javase/8u261-relnotes.html">
      *     JDK 8u261 Update Release Notes</a>
      */
-    public QuicSslContextBuilder trustManager(File trustCertCollectionFile) {
+    public QuicSslContextBuilder trustManager(@Nullable File trustCertCollectionFile) {
         try {
             return trustManager(QuicheQuicSslContext.toX509Certificates0(trustCertCollectionFile));
         } catch (Exception e) {
@@ -239,7 +243,7 @@ public final class QuicSslContextBuilder {
      * see <a href="https://www.oracle.com/java/technologies/javase/8u261-relnotes.html">
      *     JDK 8u261 Update Release Notes</a>
      */
-    public QuicSslContextBuilder trustManager(TrustManagerFactory trustManagerFactory) {
+    public QuicSslContextBuilder trustManager(@Nullable TrustManagerFactory trustManagerFactory) {
         this.trustManagerFactory = trustManagerFactory;
         return this;
     }
@@ -264,7 +268,7 @@ public final class QuicSslContextBuilder {
      *     password-protected
      * @param keyCertChainFile an X.509 certificate chain file in PEM format
      */
-    public QuicSslContextBuilder keyManager(File keyFile, String keyPassword, File keyCertChainFile) {
+    public QuicSslContextBuilder keyManager(@Nullable File keyFile, @Nullable String keyPassword, @Nullable File keyCertChainFile) {
         X509Certificate[] keyCertChain;
         PrivateKey key;
         try {
@@ -289,7 +293,7 @@ public final class QuicSslContextBuilder {
      *     password-protected
      * @param certChain an X.509 certificate chain
      */
-    public QuicSslContextBuilder keyManager(PrivateKey key, String keyPassword, X509Certificate... certChain) {
+    public QuicSslContextBuilder keyManager(@Nullable PrivateKey key, @Nullable String keyPassword, X509Certificate... certChain) {
         try {
             java.security.KeyStore ks = java.security.KeyStore.getInstance(KeyStore.getDefaultType());
             ks.load(null);
@@ -308,7 +312,7 @@ public final class QuicSslContextBuilder {
      * Identifying manager for this host. {@code keyManagerFactory} may be {@code null} for
      * client contexts, which disables mutual authentication.
      */
-    public QuicSslContextBuilder keyManager(KeyManagerFactory keyManagerFactory, String keyPassword) {
+    public QuicSslContextBuilder keyManager(@Nullable KeyManagerFactory keyManagerFactory, @Nullable String keyPassword) {
         this.keyPassword = keyPassword;
         this.keyManagerFactory = keyManagerFactory;
         return this;
@@ -321,7 +325,7 @@ public final class QuicSslContextBuilder {
      * {@link KeyManager} will be created, thus all the requirements specified in
      * {@link #keyManager(KeyManagerFactory, String)} also apply here.
      */
-    public QuicSslContextBuilder keyManager(KeyManager keyManager, String password) {
+    public QuicSslContextBuilder keyManager(KeyManager keyManager, @Nullable String password) {
         return keyManager(new KeyManagerFactoryWrapper(keyManager), password);
     }
 

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannel.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelProgressivePromise;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.socket.DuplexChannel;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.SocketAddress;
 
@@ -262,6 +263,7 @@ public interface QuicStreamChannel extends DuplexChannel {
      *
      * @return the priority if any was set.
      */
+    @Nullable
     QuicStreamPriority priority();
 
     /**

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelBootstrap.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicStreamChannelBootstrap.java
@@ -24,6 +24,7 @@ import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -60,7 +61,7 @@ public final class QuicStreamChannelBootstrap {
      * @param <T>       the type of the value.
      * @return          this instance.
      */
-    public <T> QuicStreamChannelBootstrap option(ChannelOption<T> option, T value) {
+    public <T> QuicStreamChannelBootstrap option(ChannelOption<T> option, @Nullable T value) {
         Quic.updateOptions(options, option, value);
         return this;
     }
@@ -74,7 +75,7 @@ public final class QuicStreamChannelBootstrap {
      * @param <T>       the type of the value.
      * @return          this instance.
      */
-    public <T> QuicStreamChannelBootstrap attr(AttributeKey<T> key, T value) {
+    public <T> QuicStreamChannelBootstrap attr(AttributeKey<T> key, @Nullable T value) {
         Quic.updateAttributes(attrs, key, value);
         return this;
     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -23,6 +23,7 @@ import io.netty.util.internal.NativeLibraryLoader;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.Nullable;
 
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
@@ -356,6 +357,7 @@ final class Quiche {
      */
     static native void quiche_conn_free(long connAddr);
 
+    @Nullable
     static QuicConnectionCloseEvent quiche_conn_peer_error(long connAddr) {
         Object[] error =  quiche_conn_peer_error0(connAddr);
         if (error == null) {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
@@ -15,18 +15,20 @@
  */
 package io.netty.incubator.codec.quic;
 
+import org.jetbrains.annotations.Nullable;
+
 final class QuicheConfig {
     private final boolean isDatagramSupported;
     private long config = -1;
 
-    QuicheConfig(int version, Boolean grease, Long maxIdleTimeout, Long maxSendUdpPayloadSize,
-                        Long maxRecvUdpPayloadSize, Long initialMaxData,
-                        Long initialMaxStreamDataBidiLocal, Long initialMaxStreamDataBidiRemote,
-                        Long initialMaxStreamDataUni, Long initialMaxStreamsBidi, Long initialMaxStreamsUni,
-                        Long ackDelayExponent, Long maxAckDelay, Boolean disableActiveMigration, Boolean enableHystart,
-                        QuicCongestionControlAlgorithm congestionControlAlgorithm,
-                 Integer recvQueueLen, Integer sendQueueLen,
-                 Long activeConnectionIdLimit, byte[] statelessResetToken) {
+    QuicheConfig(int version, @Nullable Boolean grease, @Nullable Long maxIdleTimeout, @Nullable Long maxSendUdpPayloadSize,
+                 @Nullable Long maxRecvUdpPayloadSize, @Nullable Long initialMaxData,
+                 @Nullable Long initialMaxStreamDataBidiLocal, @Nullable Long initialMaxStreamDataBidiRemote,
+                 @Nullable Long initialMaxStreamDataUni, @Nullable Long initialMaxStreamsBidi, @Nullable Long initialMaxStreamsUni,
+                 @Nullable Long ackDelayExponent, @Nullable Long maxAckDelay, @Nullable Boolean disableActiveMigration, @Nullable Boolean enableHystart,
+                 @Nullable QuicCongestionControlAlgorithm congestionControlAlgorithm,
+                 @Nullable Integer recvQueueLen, @Nullable Integer sendQueueLen,
+                 @Nullable Long activeConnectionIdLimit, byte[] statelessResetToken) {
         long config = Quiche.quiche_config_new(version);
         try {
             if (grease != null) {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannelConfig.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannelConfig.java
@@ -22,6 +22,7 @@ import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
@@ -136,6 +137,7 @@ final class QuicheQuicChannelConfig extends DefaultChannelConfig implements Quic
         return this;
     }
 
+    @Nullable
     QLogConfiguration getQLogConfiguration() {
         return qLogConfiguration;
     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
@@ -18,6 +18,7 @@ package io.netty.incubator.codec.quic;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -46,6 +47,7 @@ final class QuicheQuicClientCodec extends QuicheQuicCodec {
     }
 
     @Override
+    @Nullable
     protected QuicheQuicChannel quicPacketRead(
             ChannelHandlerContext ctx, InetSocketAddress sender, InetSocketAddress recipient,
             QuicPacketType type, int version, ByteBuf scid, ByteBuf dcid,

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -23,6 +23,7 @@ import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -72,6 +73,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
         this.flushStrategy = flushStrategy;
     }
 
+    @Nullable
     protected final QuicheQuicChannel getChannel(ByteBuffer key) {
         return connectionIdToChannel.get(key);
     }
@@ -220,6 +222,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
      * @return the {@link QuicheQuicChannel} that is mapped to the id.
      * @throws Exception  thrown if there is an error during processing.
      */
+    @Nullable
     protected abstract QuicheQuicChannel quicPacketRead(ChannelHandlerContext ctx, InetSocketAddress sender,
                                                         InetSocketAddress recipient, QuicPacketType type, int version,
                                                         ByteBuf scid, ByteBuf dcid, ByteBuf token,

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnection.java
@@ -20,6 +20,7 @@ import io.netty.util.ReferenceCounted;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetectorFactory;
 import io.netty.util.ResourceLeakTracker;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -115,6 +116,7 @@ final class QuicheQuicConnection {
         }
     }
 
+    @Nullable
     Runnable sslTask() {
         final Runnable task;
         synchronized (this) {
@@ -137,14 +139,17 @@ final class QuicheQuicConnection {
         };
     }
 
+    @Nullable
     QuicConnectionAddress sourceId() {
         return connectionId(() -> Quiche.quiche_conn_source_id(connection));
     }
 
+    @Nullable
     QuicConnectionAddress destinationId() {
         return connectionId(() -> Quiche.quiche_conn_destination_id(connection));
     }
 
+    @Nullable
     QuicConnectionAddress connectionId(Supplier<byte[]> idSupplier) {
         final byte[] id;
         synchronized (this) {
@@ -156,6 +161,7 @@ final class QuicheQuicConnection {
         return id == null ? QuicConnectionAddress.NULL_LEN : new QuicConnectionAddress(id);
     }
 
+    @Nullable
     QuicheQuicTransportParameters peerParameters() {
         final long[] ret;
         synchronized (this) {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -25,6 +25,7 @@ import io.netty.util.AttributeKey;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -101,6 +102,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
     }
 
     @Override
+    @Nullable
     protected QuicheQuicChannel quicPacketRead(ChannelHandlerContext ctx, InetSocketAddress sender,
                                                InetSocketAddress recipient, QuicPacketType type, int version,
                                                ByteBuf scid, ByteBuf dcid, ByteBuf token,
@@ -122,6 +124,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         return channel;
     }
 
+    @Nullable
     private QuicheQuicChannel handleServer(ChannelHandlerContext ctx, InetSocketAddress sender,
                                            InetSocketAddress recipient,
                                            @SuppressWarnings("unused") QuicPacketType type, int version,

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
@@ -22,6 +22,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.Mapping;
 import io.netty.util.ReferenceCounted;
+import org.jetbrains.annotations.Nullable;
 
 import javax.crypto.NoSuchPaddingException;
 import javax.net.ssl.KeyManager;
@@ -70,10 +71,10 @@ final class QuicheQuicSslContext extends QuicSslContext {
     final NativeSslContext nativeSslContext;
 
     QuicheQuicSslContext(boolean server, long sessionTimeout, long sessionCacheSize,
-                         ClientAuth clientAuth, TrustManagerFactory trustManagerFactory,
-                         KeyManagerFactory keyManagerFactory, String password,
-                         Mapping<? super String, ? extends QuicSslContext> mapping,
-                         Boolean earlyData, BoringSSLKeylog keylog,
+                         ClientAuth clientAuth, @Nullable TrustManagerFactory trustManagerFactory,
+                         @Nullable KeyManagerFactory keyManagerFactory, String password,
+                         @Nullable Mapping<? super String, ? extends QuicSslContext> mapping,
+                         @Nullable Boolean earlyData, @Nullable BoringSSLKeylog keylog,
                          String... applicationProtocols) {
         Quic.ensureAvailability();
         this.server = server;
@@ -157,11 +158,11 @@ final class QuicheQuicSslContext extends QuicSslContext {
         throw new IllegalArgumentException("No X509TrustManager included");
     }
 
-     static X509Certificate[] toX509Certificates0(File file) throws CertificateException {
+     static X509Certificate[] toX509Certificates0(@Nullable File file) throws CertificateException {
         return toX509Certificates(file);
     }
 
-    static PrivateKey toPrivateKey0(File keyFile, String keyPassword) throws NoSuchAlgorithmException,
+    static PrivateKey toPrivateKey0(@Nullable File keyFile, @Nullable String keyPassword) throws NoSuchAlgorithmException,
             NoSuchPaddingException, InvalidKeySpecException,
             InvalidAlgorithmParameterException,
             KeyException, IOException {
@@ -187,6 +188,7 @@ final class QuicheQuicSslContext extends QuicSslContext {
         }
     }
 
+    @Nullable
     QuicheQuicConnection createConnection(LongFunction<Long> connectionCreator, QuicheQuicSslEngine engine) {
         nativeSslContext.retain();
         long ssl = BoringSSL.SSL_new(nativeSslContext.address(), isServer(), engine.tlsHostName);
@@ -227,6 +229,7 @@ final class QuicheQuicSslContext extends QuicSslContext {
         engine.removeSessionFromCacheIfInvalid();
     }
 
+    @Nullable
     QuicClientSessionCache getSessionCache() {
         return sessionCache;
     }
@@ -374,6 +377,7 @@ final class QuicheQuicSslContext extends QuicSslContext {
         }
 
         @Override
+        @Nullable
         public SSLSession getSession(byte[] sessionId) {
             return null;
         }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
@@ -21,6 +21,7 @@ import io.netty.handler.ssl.util.LazyX509Certificate;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.ObjectUtil;
+import org.jetbrains.annotations.Nullable;
 
 import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SNIServerName;
@@ -58,7 +59,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
 
     volatile Consumer<String> sniSelectedCallback;
 
-    QuicheQuicSslEngine(QuicheQuicSslContext ctx, String peerHost, int peerPort) {
+    QuicheQuicSslEngine(QuicheQuicSslContext ctx, @Nullable String peerHost, int peerPort) {
         this.ctx = ctx;
         this.peerHost = peerHost;
         this.peerPort = peerPort;
@@ -84,6 +85,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
         return added;
     }
 
+    @Nullable
     QuicheQuicConnection createConnection(LongFunction<Long> connectionCreator) {
         return ctx.createConnection(connectionCreator, this);
     }
@@ -95,7 +97,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
     /**
      * Validate that the given hostname can be used in SNI extension.
      */
-    static boolean isValidHostNameForSNI(String hostname) {
+    static boolean isValidHostNameForSNI(@Nullable String hostname) {
         return hostname != null &&
                 hostname.indexOf('.') > 0 &&
                 !hostname.endsWith(".") &&
@@ -133,6 +135,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
     }
 
     @Override
+    @Nullable
     public Runnable getDelegatedTask() {
         return null;
     }
@@ -194,6 +197,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
     }
 
     @Override
+    @Nullable
     public SSLSession getHandshakeSession() {
         if (handshakeFinished) {
             return null;
@@ -443,6 +447,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
         }
 
         @Override
+        @Nullable
         public Object getValue(String name) {
             ObjectUtil.checkNotNull(name, "name");
             synchronized (this) {
@@ -484,7 +489,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
             return new SSLSessionBindingEvent(session, name);
         }
 
-        private void notifyUnbound(Object value, String name) {
+        private void notifyUnbound(@Nullable Object value, String name) {
             if (value instanceof SSLSessionBindingListener) {
                 // Use newSSLSessionBindingEvent so we alway use the wrapper if needed.
                 ((SSLSessionBindingListener) value).valueUnbound(newSSLSessionBindingEvent(name));
@@ -529,6 +534,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
         }
 
         @Override
+        @Nullable
         public Principal getLocalPrincipal() {
             Certificate[] local = localCertificateChain;
             if (local == null || local.length == 0) {
@@ -548,6 +554,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
         }
 
         @Override
+        @Nullable
         public String getPeerHost() {
             return peerHost;
         }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngineMap.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngineMap.java
@@ -16,6 +16,8 @@
 package io.netty.incubator.codec.quic;
 
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -23,10 +25,12 @@ final class QuicheQuicSslEngineMap {
 
     private final ConcurrentMap<Long, QuicheQuicSslEngine> engines = new ConcurrentHashMap<>();
 
+    @Nullable
     QuicheQuicSslEngine get(long ssl) {
         return engines.get(ssl);
     }
 
+    @Nullable
     QuicheQuicSslEngine remove(long ssl) {
         return engines.remove(ssl);
     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -40,6 +40,7 @@ import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
@@ -807,6 +808,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         }
 
         @Override
+        @Nullable
         public ChannelOutboundBuffer outboundBuffer() {
             return null;
         }
@@ -833,7 +835,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
             }
         }
 
-        private void handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf, Throwable cause,
+        private void handleReadException(ChannelPipeline pipeline, @Nullable ByteBuf byteBuf, Throwable cause,
                                          @SuppressWarnings("deprecation") RecvByteBufAllocator.Handle allocHandle,
                                          boolean readFrames) {
             if (byteBuf != null) {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheSendInfo.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheSendInfo.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.util.concurrent.FastThreadLocal;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -50,14 +51,17 @@ final class QuicheSendInfo {
      * @param memory the memory of {@code quiche_send_info}.
      * @return the address that was read.
      */
+    @Nullable
     static InetSocketAddress getToAddress(ByteBuffer memory) {
         return getAddress(memory, Quiche.QUICHE_SEND_INFO_OFFSETOF_TO_LEN, Quiche.QUICHE_SEND_INFO_OFFSETOF_TO);
     }
 
+    @Nullable
     static InetSocketAddress getFromAddress(ByteBuffer memory) {
        return getAddress(memory, Quiche.QUICHE_SEND_INFO_OFFSETOF_FROM_LEN, Quiche.QUICHE_SEND_INFO_OFFSETOF_FROM);
     }
 
+    @Nullable
     private static InetSocketAddress getAddress(ByteBuffer memory, int lenOffset, int addressOffset) {
         int position = memory.position();
         try {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SockaddrIn.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SockaddrIn.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.util.internal.PlatformDependent;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -136,6 +137,7 @@ final class SockaddrIn {
         }
     }
 
+    @Nullable
     static InetSocketAddress getIPv4(ByteBuffer memory, byte[] tmpArray) {
         assert tmpArray.length == IPV4_ADDRESS_LENGTH;
         int position = memory.position();
@@ -154,6 +156,7 @@ final class SockaddrIn {
         }
     }
 
+    @Nullable
     static InetSocketAddress getIPv6(ByteBuffer memory, byte[] ipv6Array, byte[] ipv4Array) {
         assert ipv6Array.length == IPV6_ADDRESS_LENGTH;
         assert ipv4Array.length == IPV4_ADDRESS_LENGTH;

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/internal/NotNullByDefault.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/internal/NotNullByDefault.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic.internal;
+
+
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.meta.TypeQualifierDefault;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies that all parameters and return values of methods within a package should be treated as non-null by
+ * default, unless explicitly annotated with a nullness annotation such as {@link org.jetbrains.annotations.Nullable}.
+ * <p>
+ * This annotation is applied at the package level and affects all types within the annotated package.
+ * <p>
+ * Any nullness annotations explicitly applied to a parameter or return value within a package will override
+ * the default nullness behavior specified by {@link NotNullByDefault}.
+ */
+@Documented
+@TypeQualifierDefault({ ElementType.PARAMETER, ElementType.METHOD })
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.PACKAGE)
+@NotNull
+public @interface NotNullByDefault {
+}

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/package-info.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/package-info.java
@@ -16,4 +16,7 @@
 /**
  * QUIC implementation
  */
+@NotNullByDefault
 package io.netty.incubator.codec.quic;
+
+import io.netty.incubator.codec.quic.internal.NotNullByDefault;

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -1235,5 +1235,13 @@
       <version>3.20.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -37,6 +37,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -528,10 +529,12 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             stream.writeAndFlush(Unpooled.directBuffer().writeZero(numBytes)).sync();
             clientLatch.await();
 
+            QuicheQuicSslEngine quicheQuicSslEngine = (QuicheQuicSslEngine) quicChannel.sslEngine();
+            assertNotNull(quicheQuicSslEngine);
             assertEquals(QuicTestUtils.PROTOS[0],
                     // Just do the cast as getApplicationProtocol() only exists in SSLEngine itself since Java9+ and
                     // we may run on an earlier version
-                    ((QuicheQuicSslEngine) quicChannel.sslEngine()).getApplicationProtocol());
+                    quicheQuicSslEngine.getApplicationProtocol());
             stream.close().sync();
             quicChannel.close().sync();
             ChannelFuture closeFuture = quicChannel.closeFuture().await();
@@ -964,6 +967,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                     }
 
                     @Override
+                    @Nullable
                     public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
                         return null;
                     }
@@ -1433,6 +1437,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
 
     private static void assertSessionReused(QuicChannel channel, boolean reused) throws Exception {
         QuicheQuicSslEngine engine =  (QuicheQuicSslEngine) channel.sslEngine();
+        assertNotNull(engine);
         while (engine.getHandshakeStatus() != SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING) {
             // Let's wait a bit and re-check if the handshake is done.
             Thread.sleep(50);

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicSslContextTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicSslContextTest.java
@@ -17,6 +17,7 @@ package io.netty.incubator.codec.quic;
 
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.internal.EmptyArrays;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLException;
@@ -46,6 +47,7 @@ public class QuicSslContextTest {
             }
 
             @Override
+            @Nullable
             public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
                 return null;
             }
@@ -56,6 +58,7 @@ public class QuicSslContextTest {
             }
 
             @Override
+            @Nullable
             public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
                 return null;
             }
@@ -66,6 +69,7 @@ public class QuicSslContextTest {
             }
 
             @Override
+            @Nullable
             public PrivateKey getPrivateKey(String alias) {
                 return null;
             }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamChannelCreationTest.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.util.AttributeKey;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -124,7 +125,7 @@ public class QuicStreamChannelCreationTest extends AbstractQuicTest {
     }
 
     private static void assertQuicStreamChannel(QuicStreamChannel channel, QuicStreamType expectedType,
-                                                Boolean expectedAutoRead, String expectedAttribute) {
+                                                Boolean expectedAutoRead, @Nullable String expectedAttribute) {
         assertEquals(expectedType, channel.type());
         assertEquals(expectedAutoRead, channel.config().getOption(ChannelOption.AUTO_READ));
         assertEquals(expectedAttribute, channel.attr(ATTRIBUTE_KEY).get());

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTestUtils.java
@@ -30,6 +30,7 @@ import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.NetUtil;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.Executor;
@@ -148,7 +149,7 @@ final class QuicTestUtils {
     }
 
     private static Bootstrap newServerBootstrap(QuicServerCodecBuilder serverBuilder,
-                                                QuicTokenHandler tokenHandler, ChannelHandler handler,
+                                                QuicTokenHandler tokenHandler, @Nullable ChannelHandler handler,
                                                 ChannelHandler streamHandler) {
         serverBuilder.tokenHandler(tokenHandler)
                 .streamHandler(streamHandler);
@@ -180,7 +181,7 @@ final class QuicTestUtils {
         return newServer(sslTaskExecutor, InsecureQuicTokenHandler.INSTANCE, handler, streamHandler);
     }
 
-    static void closeIfNotNull(Channel channel) throws Exception {
+    static void closeIfNotNull(@Nullable Channel channel) throws Exception {
         if (channel != null) {
             channel.close().sync();
         }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTransportParametersTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTransportParametersTest.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -75,7 +76,7 @@ public class QuicTransportParametersTest extends AbstractQuicTest {
         }
     }
 
-    private static void assertTransportParameters(QuicTransportParameters parameters) {
+    private static void assertTransportParameters(@Nullable QuicTransportParameters parameters) {
         assertNotNull(parameters);
         assertThat(parameters.maxIdleTimeout(), greaterThanOrEqualTo(1L));
         assertThat(parameters.maxUdpPayloadSize(), greaterThanOrEqualTo(1L));

--- a/pom.xml
+++ b/pom.xml
@@ -450,6 +450,18 @@
         <version>3.20.2</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>24.1.0</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.2</version>
+        <scope>provided</scope>
+      </dependency>
     </dependencies>
 
   </dependencyManagement>


### PR DESCRIPTION
Motivation:
`Nullable`/`NotNullByDefault` annotations give an idea of what to expect from the API. Plus, they provide a better IDE integration. This PR is based on the work done in https://github.com/netty/netty/pull/12878

Modification:
`Nullable`/`NotNullByDefault` annotations are applied where necessary.

Result:
The change extends the API with nullability expectations. Plus, it provides a better IDE integration.