### PR TITLE
Fix javadoc description

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLPrivateKeyMethod.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLPrivateKeyMethod.java
@@ -41,8 +41,7 @@ interface BoringSSLPrivateKeyMethod {
      * @param ssl                   the SSL instance
      * @param signatureAlgorithm    the algorithm to use for signing
      * @param input                 the input itself
-     * @return                      the sign
-     * @throws Exception            thrown if an error accours while signing.
+     * @param callback              the callback provides the signed bytes and an error if such occurs while signing
      */
     void sign(long ssl, int signatureAlgorithm, byte[] input, BiConsumer<byte[], Throwable> callback);
 
@@ -51,8 +50,7 @@ interface BoringSSLPrivateKeyMethod {
      *
      * @param ssl                   the SSL instance
      * @param input                 the input which should be decrypted
-     * @return                      the decrypted data
-     * @throws Exception            thrown if an error accours while decrypting.
+     * @param callback              the callback provides the decrypted bytes and an error if such occurs while decrypting
      */
     void decrypt(long ssl, byte[] input, BiConsumer<byte[], Throwable> callback);
 }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicResetTokenGenerator.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicResetTokenGenerator.java
@@ -26,8 +26,8 @@ public interface QuicResetTokenGenerator {
 
     /**
      * Generate a reset token to use for the given connection id. The returned token MUST be of length 16.
-     * @param cid
-     * @return
+     * @param cid the connection id
+     * @return a newly generated reset token
      */
     ByteBuffer newResetToken(ByteBuffer cid);
 


### PR DESCRIPTION
Motivation:
Javadoc doesn't reflect the API

Modification:
- `BoringSSLPrivateKeyMethod.sign`/`decrypt`: replace return/throws tags with param tag
- `QuicResetTokenGenerator.newResetToken`: add param/return description

Result:
Correct javadoc