### PR TITLE
Add ability to get path stats

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -307,6 +307,23 @@ public interface QuicChannel extends Channel {
     Future<QuicConnectionStats> collectStats(Promise<QuicConnectionStats> promise);
 
     /**
+     * Collects statistics about the path of the connection and notifies the {@link Future} once done.
+     *
+     * @return the {@link Future} that is notified once the stats were collected.
+     */
+    default Future<QuicConnectionPathStats> collectPathStats(int pathIdx) {
+        return collectPathStats(pathIdx, eventLoop().newPromise());
+    }
+
+    /**
+     * Collects statistics about the path of the connection and notifies the {@link Promise} once done.
+     *
+     * @param   promise the {@link ChannelPromise} that is notified once the stats were collected.
+     * @return          the {@link Future} that is notified once the stats were collected.
+     */
+    Future<QuicConnectionPathStats> collectPathStats(int pathIdx, Promise<QuicConnectionPathStats> promise);
+
+    /**
      * Creates a new {@link QuicChannelBootstrap} that can be used to create and connect new {@link QuicChannel}s to
      * endpoints using the given {@link Channel} as transport layer.
      *

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionPathStats.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionPathStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Netty Project
+ * Copyright 2024 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionPathStats.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionPathStats.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Statistics about a path of the {@code QUIC} connection. If unknown by the implementation it might return {@code -1} values
+ * for the various methods.
+ */
+public interface QuicConnectionPathStats {
+    /**
+     * @return The local address used by this path.
+     */
+    InetSocketAddress localAddress();
+
+    /**
+     * @return The peer address seen by this path.
+     */
+    InetSocketAddress peerAddress();
+
+    /**
+     * @return The validation state of the path.
+     */
+    long validationState();
+
+    /**
+     * @return Whether this path is active.
+     */
+    boolean active();
+
+    /**
+     * @return The number of QUIC packets received on this path.
+     */
+    long recv();
+
+    /**
+     * @return The number of QUIC packets sent on this path.
+     */
+    long sent();
+
+    /**
+     * @return The number of QUIC packets that were lost on this path.
+     */
+    long lost();
+
+    /**
+     * @return The number of sent QUIC packets with retransmitted data on this path.
+     */
+    long retrans();
+
+    /**
+     * @return The estimated round-trip time of the path (in nanoseconds).
+     */
+    long rtt();
+
+    /**
+     * @return The size of the path's congestion window in bytes.
+     */
+    long cwnd();
+
+    /**
+     * @return The number of sent bytes on this path.
+     */
+    long sentBytes();
+
+    /**
+     * @return The number of received bytes on this path.
+     */
+    long recvBytes();
+
+    /**
+     * @return The number of bytes lost on this path.
+     */
+    long lostBytes();
+
+    /**
+     * @return The number of stream bytes retransmitted on this path.
+     */
+    long streamRetransBytes();
+
+    /**
+     * @return The current PMTU for the path.
+     */
+    long pmtu();
+
+    /**
+     * @return The most recent data delivery rate estimate in bytes/s.
+     */
+    long deliveryRate();
+}

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -514,6 +514,13 @@ final class Quiche {
      */
     static native void quiche_stream_iter_free(long iterAddr);
 
+
+    /**
+     * See
+     * <a href="https://github.com/cloudflare/quiche/blob/0.20.0/quiche/include/quiche.h#L672">quiche_conn_path_stats</a>.
+     */
+    static native Object[] quiche_conn_path_stats(long connAddr, long streamIdx);
+
     /**
      * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L358">

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -2061,7 +2061,14 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     private void collectPathStats0(int pathIdx, Promise<QuicConnectionPathStats> promise) {
-        collectPathStats0(connection, pathIdx, promise);
+        QuicheQuicConnection conn = connection;
+
+        if (conn.isFreed()) {
+            promise.setFailure(new IllegalStateException("Connection is closed"));
+            return;
+        }
+
+        collectPathStats0(conn, pathIdx, promise);
     }
 
     private QuicConnectionPathStats collectPathStats0(QuicheQuicConnection connection, int pathIdx, Promise<QuicConnectionPathStats> promise) {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnectionPathStats.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnectionPathStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Netty Project
+ * Copyright 2024 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnectionPathStats.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicConnectionPathStats.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.util.internal.StringUtil;
+
+import java.net.InetSocketAddress;
+
+final class QuicheQuicConnectionPathStats implements QuicConnectionPathStats {
+
+    private final Object[] values;
+
+    QuicheQuicConnectionPathStats(Object[] values) {
+        this.values = values;
+    }
+
+    @Override
+    public InetSocketAddress localAddress() {
+        return (InetSocketAddress) values[0];
+    }
+
+    @Override
+    public InetSocketAddress peerAddress() {
+        return (InetSocketAddress) values[1];
+    }
+
+    public long validationState() {
+        return (long) values[2];
+    }
+
+    @Override
+    public boolean active() {
+        return (boolean) values[3];
+    }
+
+    @Override
+    public long recv() {
+        return (long) values[4];
+    }
+
+    @Override
+    public long sent() {
+        return (long) values[5];
+    }
+
+    @Override
+    public long lost() {
+        return (long) values[6];
+    }
+
+    @Override
+    public long retrans() {
+        return (long) values[7];
+    }
+
+    @Override
+    public long rtt() {
+        return (long) values[8];
+    }
+
+    @Override
+    public long cwnd() {
+        return (long) values[9];
+    }
+
+    @Override
+    public long sentBytes() {
+        return (long) values[10];
+    }
+
+    @Override
+    public long recvBytes() {
+        return (long) values[11];
+    }
+
+    @Override
+    public long lostBytes() {
+        return (long) values[12];
+    }
+
+    @Override
+    public long streamRetransBytes() {
+        return (long) values[13];
+    }
+
+    @Override
+    public long pmtu() {
+        return (long) values[14];
+    }
+
+    @Override
+    public long deliveryRate() {
+        return (long) values[15];
+    }
+
+    /**
+     * Returns the {@link String} representation of stats.
+     */
+    @Override
+    public String toString() {
+        return StringUtil.simpleClassName(this) + "[" +
+                "local=" + localAddress() +
+                ", peer=" + peerAddress() +
+                ", validationState=" + validationState() +
+                ", active=" + active() +
+                ", recv=" + recv() +
+                ", sent=" + sent() +
+                ", lost=" + lost() +
+                ", retrans=" + retrans() +
+                ", rtt=" + rtt() +
+                ", cwnd=" + cwnd() +
+                ", sentBytes=" + sentBytes() +
+                ", recvBytes=" + recvBytes() +
+                ", lostBytes=" + lostBytes() +
+                ", streamRetransBytes=" + streamRetransBytes() +
+                ", pmtu=" + pmtu() +
+                ", deliveryRate=" + deliveryRate() +
+                ']';
+    }
+
+}

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -719,6 +719,39 @@ static jobject netty_new_socket_address(JNIEnv* env, const struct sockaddr_stora
     return (*env)->NewObject(env, inetsocketaddress_class, inetsocketaddress_class_constructor, address, port);
 }
 
+static jobjectArray netty_quiche_conn_path_stats(JNIEnv* env, jclass clazz, jlong conn, jlong idx) {
+    quiche_path_stats stats = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+    quiche_conn_path_stats((quiche_conn *) conn, idx, &stats);
+
+    jobject localAddr = netty_new_socket_address(env, &stats.local_addr);
+    if (localAddr == NULL) {
+        return NULL;
+    }
+    jobject peerAddr = netty_new_socket_address(env, &stats.peer_addr);
+    if (peerAddr == NULL) {
+        return NULL;
+    }
+
+    jobjectArray array = (*env)->NewObjectArray(env, 16, object_class, NULL);
+    (*env)->SetObjectArrayElement(env, array, 0, localAddr);
+    (*env)->SetObjectArrayElement(env, array, 1, peerAddr);
+    (*env)->SetObjectArrayElement(env, array, 2, (*env)->CallStaticObjectMethod(env, long_class, long_class_valueof, (jlong) stats.validation_state));
+    (*env)->SetObjectArrayElement(env, array, 3, (*env)->CallStaticObjectMethod(env, boolean_class, boolean_class_valueof, stats.active ? JNI_TRUE : JNI_FALSE));
+    (*env)->SetObjectArrayElement(env, array, 4, (*env)->CallStaticObjectMethod(env, long_class, long_class_valueof, (jlong) stats.recv));
+    (*env)->SetObjectArrayElement(env, array, 5, (*env)->CallStaticObjectMethod(env, long_class, long_class_valueof, (jlong) stats.sent));
+    (*env)->SetObjectArrayElement(env, array, 6, (*env)->CallStaticObjectMethod(env, long_class, long_class_valueof, (jlong) stats.lost));
+    (*env)->SetObjectArrayElement(env, array, 7, (*env)->CallStaticObjectMethod(env, long_class, long_class_valueof, (jlong) stats.retrans));
+    (*env)->SetObjectArrayElement(env, array, 8, (*env)->CallStaticObjectMethod(env, long_class, long_class_valueof, (jlong) stats.rtt));
+    (*env)->SetObjectArrayElement(env, array, 9, (*env)->CallStaticObjectMethod(env, long_class, long_class_valueof, (jlong) stats.cwnd));
+    (*env)->SetObjectArrayElement(env, array, 10, (*env)->CallStaticObjectMethod(env, long_class, long_class_valueof, (jlong) stats.sent_bytes));
+    (*env)->SetObjectArrayElement(env, array, 11, (*env)->CallStaticObjectMethod(env, long_class, long_class_valueof, (jlong) stats.recv_bytes));
+    (*env)->SetObjectArrayElement(env, array, 12, (*env)->CallStaticObjectMethod(env, long_class, long_class_valueof, (jlong) stats.lost_bytes));
+    (*env)->SetObjectArrayElement(env, array, 13, (*env)->CallStaticObjectMethod(env, long_class, long_class_valueof, (jlong) stats.stream_retrans_bytes));
+    (*env)->SetObjectArrayElement(env, array, 14, (*env)->CallStaticObjectMethod(env, long_class, long_class_valueof, (jlong) stats.pmtu));
+    (*env)->SetObjectArrayElement(env, array, 15, (*env)->CallStaticObjectMethod(env, long_class, long_class_valueof, (jlong) stats.delivery_rate));
+    return array;
+}
+
 static jobjectArray netty_quiche_path_event_new(JNIEnv* env, jclass clazz, jlong ev) {
     struct sockaddr_storage local;
     socklen_t local_len;
@@ -1168,6 +1201,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "sockaddr_cmp", "(JJ)I", (void *) netty_sockaddr_cmp},
   { "quiche_conn_path_event_next", "(J)J", (void *) netty_quiche_conn_path_event_next },
   { "quiche_path_event_type", "(J)I", (void *) netty_quiche_path_event_type },
+  { "quiche_conn_path_stats", "(JJ)[Ljava/lang/Object;", (void *) netty_quiche_conn_path_stats },
   { "quiche_path_event_new", "(J)[Ljava/lang/Object;", (void *) netty_quiche_path_event_new },
   { "quiche_path_event_validated", "(J)[Ljava/lang/Object;", (void *) netty_quiche_path_event_validated },
   { "quiche_path_event_failed_validation", "(J)[Ljava/lang/Object;", (void *) netty_quiche_path_event_failed_validation },

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -721,7 +721,10 @@ static jobject netty_new_socket_address(JNIEnv* env, const struct sockaddr_stora
 
 static jobjectArray netty_quiche_conn_path_stats(JNIEnv* env, jclass clazz, jlong conn, jlong idx) {
     quiche_path_stats stats = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-    quiche_conn_path_stats((quiche_conn *) conn, idx, &stats);
+    if (quiche_conn_path_stats((quiche_conn *) conn, idx, &stats) != 0) {
+        // The idx is not valid. 
+        return NULL;
+    }
 
     jobject localAddr = netty_new_socket_address(env, &stats.local_addr);
     if (localAddr == NULL) {

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionPathStatsTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionPathStatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Netty Project
+ * Copyright 2024 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionPathStatsTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionPathStatsTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.Promise;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class QuicConnectionPathStatsTest extends AbstractQuicTest {
+
+    @ParameterizedTest
+    @MethodSource("newSslTaskExecutors")
+    public void testPathStatsAreCollected(Executor executor) throws Throwable {
+        Channel server = null;
+        Channel channel = null;
+        AtomicInteger counter = new AtomicInteger();
+
+        Promise<QuicConnectionPathStats> serverActiveStats = ImmediateEventExecutor.INSTANCE.newPromise();
+        QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler() {
+            @Override
+            public void channelActive(ChannelHandlerContext ctx) {
+                super.channelActive(ctx);
+                collectPathStats(ctx, serverActiveStats);
+            }
+
+            private void collectPathStats(ChannelHandlerContext ctx, Promise<QuicConnectionPathStats> promise) {
+                QuicheQuicChannel channel = (QuicheQuicChannel) ctx.channel();
+                channel.collectPathStats(0, promise);
+            }
+        };
+        QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler();
+        try {
+            server = QuicTestUtils.newServer(executor, serverHandler, new ChannelInboundHandlerAdapter() {
+
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) {
+                    counter.incrementAndGet();
+                }
+
+                @Override
+                public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                    // Let's just echo back the message.
+                    ctx.writeAndFlush(msg);
+                }
+
+                @Override
+                public boolean isSharable() {
+                    return true;
+                }
+            });
+            channel = QuicTestUtils.newClient(executor);
+
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
+                    .handler(clientHandler)
+                    .streamHandler(new ChannelInboundHandlerAdapter())
+                    .remoteAddress(server.localAddress())
+                    .connect().get();
+            assertNotNull(quicChannel.collectStats().sync().getNow());
+            quicChannel.createStream(QuicStreamType.BIDIRECTIONAL, new ChannelInboundHandlerAdapter() {
+                private final int bufferSize = 8;
+                private int received;
+
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) {
+                    ctx.writeAndFlush(Unpooled.buffer().writeZero(bufferSize));
+                }
+
+                @Override
+                public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                    ByteBuf buffer = (ByteBuf) msg;
+                    received += buffer.readableBytes();
+                    buffer.release();
+                    if (received == bufferSize) {
+                        ctx.close().addListener((ChannelFuture future) -> {
+                            // Close the underlying QuicChannel as well.
+                            future.channel().parent().close();
+                        });
+                    }
+                }
+            }).sync();
+
+            // Wait until closure
+            quicChannel.closeFuture().sync();
+            assertStats(serverActiveStats.sync().getNow());
+            assertEquals(1, counter.get());
+
+            serverHandler.assertState();
+            clientHandler.assertState();
+        } finally {
+            QuicTestUtils.closeIfNotNull(channel);
+            QuicTestUtils.closeIfNotNull(server);
+
+            shutdown(executor);
+        }
+    }
+
+    private static void assertStats(QuicConnectionPathStats stats) {
+        assertNotNull(stats);
+        assertThat(stats.lost(), greaterThanOrEqualTo(0L));
+        assertThat(stats.recv(), greaterThan(0L));
+        assertThat(stats.sent(), greaterThan(0L));
+        assertThat(stats.sentBytes(), greaterThan(0L));
+        assertThat(stats.recvBytes(), greaterThan(0L));
+        assertThat(stats.rtt(), greaterThan(0L));
+    }
+}


### PR DESCRIPTION
Motivation:
Ability to get the RTT as requested in #678

Modification:
Add ability to get the path stats using quiche_conn_path_stats

Result:
The change adds the API to get the path stats, however I wasn't sure if I should include it in QuicheConnectionStats directly. 