### PR TITLE
Fail writes with ChannelOutputShutdownException when STREAM_STOPPED i…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -1063,7 +1063,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                                 int capacity = Quiche.quiche_conn_stream_capacity(connAddr, streamId);
                                 if (capacity < 0) {
                                     // Let's close the channel if quiche_conn_stream_capacity(...) returns an error.
-                                    streamChannel.forceClose();
+                                    streamChannel.forceClose(capacity);
                                 } else if (streamChannel.writable(capacity)) {
                                     mayNeedWrite = true;
                                 }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -410,6 +410,18 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         }
     }
 
+    void forceClose(int error) {
+        if (!queue.isEmpty()) {
+            QuicException err = new QuicException(QuicError.valueOf(error));
+            if (error == QuicError.STREAM_STOPPED.code()) {
+                queue.removeAndFailAll(new ChannelOutputShutdownException("STREAM_STOPPED received", err));
+            } else {
+                queue.removeAndFailAll(err);
+            }
+        }
+        forceClose();
+    }
+
     /**
      * Stream is readable.
      */
@@ -646,7 +658,9 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                         if (e instanceof QuicException && (
                                 (QuicException) e).error() == QuicError.STREAM_STOPPED) {
                             // Once its signaled that the stream is stopped we can just fail everything.
-                            queue.removeAndFailAll(e);
+                            // We can also force the close as quiche will generate a RESET_STREAM frame.
+                            queue.removeAndFailAll(
+                                    new ChannelOutputShutdownException("STREAM_STOPPED received", e));
                             forceClose();
                             break;
                         }


### PR DESCRIPTION
…s received

Motivation:

If STREAM_STOPPED is received we should fail all writes with ChannelOutputShutdownException before tearing down the channel

Modifications:

Explicit handle STREAM_STOPPED

Result:

Better signaling of received STREAM_STOPPED