### PR TITLE
Add QuicTimeoutClosedChannelException which will be used to fail writ…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicTimeoutClosedChannelException.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicTimeoutClosedChannelException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import java.nio.channels.ClosedChannelException;
+
+/**
+ * Special {@link ClosedChannelException} that is used in case of closure caused by the idle timeout.
+ */
+public final class QuicTimeoutClosedChannelException extends ClosedChannelException {
+
+    QuicTimeoutClosedChannelException() { }
+}

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -791,10 +791,20 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     private void closeStreams() {
+        if (streams.isEmpty()) {
+            return;
+        }
+        final ClosedChannelException closedChannelException;
+        if (isTimedOut()) {
+            // Close the streams because of a timeout.
+            closedChannelException = new QuicTimeoutClosedChannelException();
+        } else {
+            closedChannelException = new ClosedChannelException();
+        }
         // Make a copy to ensure we not run into a situation when we change the underlying iterator from
         // another method and so run in an assert error.
         for (QuicheQuicStreamChannel stream: streams.values().toArray(new QuicheQuicStreamChannel[0])) {
-            stream.unsafe().close(voidPromise());
+            stream.unsafe().close(closedChannelException, voidPromise());
         }
         streams.clear();
     }


### PR DESCRIPTION
…es for streams when the Channel was closed because of a idle timeout

Motivation:

To make it easier to debug we should fail queued writes on the streams with a special ClosedChannelException in case of a timeout.

Modifications:

- Use QuicTimeoutClosedChannelException if writes are failed because the connection is timed out
- Add unit test for timeout

Result:

Easier to debug connection close causes