### PR TITLE
Enforce QuicheQuicCodec sub-types to be non-sharable

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicCodec.java
@@ -73,6 +73,11 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
         this.flushStrategy = flushStrategy;
     }
 
+    @Override
+    public final boolean isSharable() {
+        return false;
+    }
+
     @Nullable
     protected final QuicheQuicChannel getChannel(ByteBuffer key) {
         return connectionIdToChannel.get(key);


### PR DESCRIPTION
Motivation:

QuicheQuicCodec keeps state and so can not be sharable, let's enforce this.

Modifications:

- Override isSharable() and return false

Result:

Ensure sub-types can not be sharable