### PR TITLE
Hide implementation details

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/NotNullByDefault.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/NotNullByDefault.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.incubator.codec.quic.internal;
+package io.netty.incubator.codec.quic;
 
 
 import org.jetbrains.annotations.NotNull;
@@ -39,5 +39,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.PACKAGE)
 @NotNull
-public @interface NotNullByDefault {
+@interface NotNullByDefault {
 }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/package-info.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/package-info.java
@@ -19,4 +19,3 @@
 @NotNullByDefault
 package io.netty.incubator.codec.quic;
 
-import io.netty.incubator.codec.quic.internal.NotNullByDefault;


### PR DESCRIPTION
Motivation:

We should hide the annotation so someone will not import it by mistake

Modifications:

Move annotation to same package as the rest of the code and mark it as package-private

Result:

Don't expose implementation details