### PR TITLE
Upload jar for inspection

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -225,9 +225,10 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
-          name: build-android-jars
+          name: build-android-jars-aars
           path: |
             **/target/*.jar
+            **/target/*.aar
 
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -53,7 +53,14 @@ jobs:
       - name: Checking for test failures
         run: ./.github/scripts/check_build_result.sh build.output
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: build-linux-x86_64-jars
+          path: |
+            **/target/*.jar
+
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: target
@@ -82,7 +89,14 @@ jobs:
       - name: Build project without leak detection
         run: docker-compose -f docker/docker-compose.centos-7-cross.yaml run cross-compile-aarch64-build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: build-linux-aarch64-jars
+          path: |
+            **/target/*.jar
+
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: target
@@ -135,6 +149,13 @@ jobs:
 
       - name: Build project
         run: ./mvnw.cmd -B -ntp --file pom.xml clean package
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: build-windows-jars
+          path: |
+            **/target/*.jar
 
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
@@ -200,6 +221,13 @@ jobs:
 
       - name: Build project
         run: ./mvnw -B -ntp --file pom.xml clean package -Dandroid
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: build-android-jars
+          path: |
+            **/target/*.jar
 
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -85,9 +85,16 @@ jobs:
           path: '**/target/surefire-reports/TEST-*.xml'
 
       - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: build-pr-${{ matrix.setup }}-jars
+          path: |
+            **/target/*.jar
+
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: build-${{ matrix.setup }}-target
+          name: build-pr-${{ matrix.setup }}-target
           path: |
             **/target/surefire-reports/
             **/hs_err*.log
@@ -146,6 +153,13 @@ jobs:
         with:
           name: test-results-pr-windows-x86_64
           path: '**/target/surefire-reports/TEST-*.xml'
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: pr-windows-jars
+          path: |
+            **/target/*.jar
 
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
@@ -211,6 +225,13 @@ jobs:
 
       - name: Build project
         run: ./mvnw -B -ntp --file pom.xml clean package -Dandroid
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: build-pr-android-jars
+          path: |
+            **/target/*.jar
 
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -229,9 +229,10 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
-          name: build-pr-android-jars
+          name: build-pr-android-jars-aars
           path: |
             **/target/*.jar
+            **/target/*.aar
 
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}


### PR DESCRIPTION
Motivation:

Sometimes it is useful to be able to download the generated jars. For example to inspect these.

Modifications:

Add step that uploads jars.

Result:

Be able to inspect jar after workflow run