### PR TITLE
Propagate exception to all listeners before force close

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -1539,6 +1539,8 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                             ChannelPromise connectPromise = QuicheQuicChannel.this.connectPromise;
                             if (connectPromise != null && !f.isSuccess()) {
                                 connectPromise.tryFailure(f.cause());
+                                // close everything after notify about failure.
+                                unsafe().closeForcibly();
                             }
                         });
                 return;

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicClientCodec.java
@@ -68,8 +68,8 @@ final class QuicheQuicClientCodec extends QuicheQuicCodec {
                     senderSockaddrMemory.internalNioBuffer(0, senderSockaddrMemory.capacity()),
                     recipientSockaddrMemory.internalNioBuffer(0, recipientSockaddrMemory.capacity()));
         } catch (Throwable cause) {
+            // Only fail the original promise. Cleanup will be done as part of the listener attached to it.
             promise.setFailure(cause);
-            channel.unsafe().closeForcibly();
             return;
         }
 


### PR DESCRIPTION
Motivation:

We should ensure we had a chance to propagate the exception to the listeners before force close the channel, as otherwise we might loose the exception details

Modifications:

Force close after notify

Result:

Correctly preserve exception in all cases during connect failure