### PR TITLE
Remove redundant cast

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -397,7 +397,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     boolean writable(@SuppressWarnings("unused") int capacity) {
         assert eventLoop().inEventLoop();
         this.capacity = capacity;
-        boolean mayNeedWrite = ((QuicStreamChannelUnsafe) unsafe()).writeQueued();
+        boolean mayNeedWrite = unsafe().writeQueued();
         // we need to re-read this.capacity as writeQueued() may update the capacity.
         updateWritabilityIfNeeded(this.capacity > 0);
         return mayNeedWrite;


### PR DESCRIPTION
Motivation:

The cast is not needed anymore as the correct type is returned

Modifications:

Fix redundant cast

Result:

Cleanup