### PR TITLE
Apply Nullable annotations to arrays

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSL.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSL.java
@@ -54,7 +54,7 @@ final class BoringSSL {
                 keylogCallback, sessionCallback, privateKeyMethod, sessionTicketCallback, verifyMode, subjectNames);
     }
 
-    private static byte[] toWireFormat(String[] applicationProtocols) {
+    private static byte @Nullable [] toWireFormat(String @Nullable [] applicationProtocols) {
         if (applicationProtocols == null) {
             return null;
         }
@@ -71,7 +71,7 @@ final class BoringSSL {
     }
 
     private static native long SSLContext_new0(boolean server,
-                                               byte[] applicationProtocols, Object handshakeCompleteCallback,
+                                               byte @Nullable [] applicationProtocols, Object handshakeCompleteCallback,
                                                Object certificateCallback, Object verifyCallback,
                                                @Nullable Object servernameCallback, @Nullable Object keylogCallback,
                                                @Nullable Object sessionCallback,

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallback.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateCallback.java
@@ -98,7 +98,7 @@ final class BoringSSLCertificateCallback {
     }
 
     @SuppressWarnings("unused")
-    long[] handle(long ssl, byte[] keyTypeBytes, byte[][] asn1DerEncodedPrincipals, String[] authMethods) {
+    long @Nullable [] handle(long ssl, byte[] keyTypeBytes, byte @Nullable [][] asn1DerEncodedPrincipals, String[] authMethods) {
         QuicheQuicSslEngine engine = engineMap.get(ssl);
         if (engine == null) {
             return null;
@@ -138,14 +138,14 @@ final class BoringSSLCertificateCallback {
         }
     }
 
-    private long[] removeMappingIfNeeded(long ssl, long[] result) {
+    private long @Nullable [] removeMappingIfNeeded(long ssl, long @Nullable [] result) {
         if (result == null) {
             engineMap.remove(ssl);
         }
         return result;
     }
 
-    private long[] selectKeyMaterialServerSide(long ssl, QuicheQuicSslEngine engine, String[] authMethods)
+    private long @Nullable [] selectKeyMaterialServerSide(long ssl, QuicheQuicSslEngine engine, String[] authMethods)
             throws SSLException {
         if (authMethods.length == 0) {
             throw new SSLHandshakeException("Unable to find key material");
@@ -168,8 +168,8 @@ final class BoringSSLCertificateCallback {
                 + Arrays.toString(authMethods));
     }
 
-    private long[] selectKeyMaterialClientSide(long ssl, QuicheQuicSslEngine engine, String[] keyTypes,
-                                               X500Principal[] issuer) {
+    private long @Nullable [] selectKeyMaterialClientSide(long ssl, QuicheQuicSslEngine engine, String[] keyTypes,
+                                               X500Principal @Nullable [] issuer) {
         String alias = chooseClientAlias(engine, keyTypes, issuer);
         // Only try to set the keymaterial if we have a match. This is also consistent with what OpenJDK does:
         // https://hg.openjdk.java.net/jdk/jdk11/file/76072a077ee1/
@@ -180,7 +180,7 @@ final class BoringSSLCertificateCallback {
         return NO_KEY_MATERIAL_CLIENT_SIDE;
     }
 
-    private long[] selectMaterial(long ssl, QuicheQuicSslEngine engine, String alias)  {
+    private long @Nullable [] selectMaterial(long ssl, QuicheQuicSslEngine engine, String alias)  {
         X509Certificate[] certificates = keyManager.getCertificateChain(alias);
         if (certificates == null || certificates.length == 0) {
             return null;
@@ -213,7 +213,7 @@ final class BoringSSLCertificateCallback {
         return new long[] { key,  chain };
     }
 
-    private static byte[] toPemEncoded(PrivateKey key) {
+    private static byte @Nullable [] toPemEncoded(PrivateKey key) {
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             out.write(BEGIN_PRIVATE_KEY);
             out.write(Base64.getEncoder().encode(key.getEncoded()));
@@ -226,7 +226,7 @@ final class BoringSSLCertificateCallback {
 
     @Nullable
     private String chooseClientAlias(QuicheQuicSslEngine engine,
-                                     String[] keyTypes, X500Principal[] issuer) {
+                                     String[] keyTypes, X500Principal @Nullable [] issuer) {
         return keyManager.chooseEngineClientAlias(keyTypes, issuer, engine);
     }
 
@@ -243,7 +243,7 @@ final class BoringSSLCertificateCallback {
      * @return supported key types that can be used in {@code X509KeyManager.chooseClientAlias} and
      *         {@code X509ExtendedKeyManager.chooseEngineClientAlias}.
      */
-    private static Set<String> supportedClientKeyTypes(byte[] clientCertificateTypes) {
+    private static Set<String> supportedClientKeyTypes(byte @Nullable[] clientCertificateTypes) {
         if (clientCertificateTypes == null) {
             // Try all of the supported key types.
             return SUPPORTED_KEY_TYPES;

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateVerifyCallback.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLCertificateVerifyCallback.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.handler.ssl.OpenSslCertificateException;
+import org.jetbrains.annotations.Nullable;
 
 import javax.net.ssl.X509ExtendedTrustManager;
 import javax.net.ssl.X509TrustManager;
@@ -42,7 +43,7 @@ final class BoringSSLCertificateVerifyCallback {
     private final QuicheQuicSslEngineMap engineMap;
     private final X509TrustManager manager;
 
-    BoringSSLCertificateVerifyCallback(QuicheQuicSslEngineMap engineMap, X509TrustManager manager) {
+    BoringSSLCertificateVerifyCallback(QuicheQuicSslEngineMap engineMap, @Nullable X509TrustManager manager) {
         this.engineMap = engineMap;
         this.manager = manager;
     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLKeylessManagerFactory.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLKeylessManagerFactory.java
@@ -159,7 +159,7 @@ public final class BoringSSLKeylessManagerFactory extends KeyManagerFactory {
                 }
 
                 @Override
-                public Certificate[] engineGetCertificateChain(String alias) {
+                public Certificate @Nullable [] engineGetCertificateChain(String alias) {
                     return engineContainsAlias(alias)? certificateChain.clone() : null;
                 }
 
@@ -240,7 +240,7 @@ public final class BoringSSLKeylessManagerFactory extends KeyManagerFactory {
                 }
 
                 @Override
-                public void engineLoad(@Nullable InputStream stream, char[] password) {
+                public void engineLoad(@Nullable InputStream stream, char @Nullable [] password) {
                     if (stream != null && password != null) {
                         throw new UnsupportedOperationException();
                     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLSessionCallback.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLSessionCallback.java
@@ -37,7 +37,7 @@ final class BoringSSLSessionCallback {
     }
 
     @SuppressWarnings("unused")
-    void newSession(long ssl, long creationTime, long timeout, byte[] session, boolean isSingleUse, byte[] peerParams) {
+    void newSession(long ssl, long creationTime, long timeout, byte[] session, boolean isSingleUse, byte @Nullable [] peerParams) {
         if (sessionCache == null) {
             return;
         }
@@ -66,7 +66,7 @@ final class BoringSSLSessionCallback {
     }
 
     // Mimic the encoding of quiche: https://github.com/cloudflare/quiche/blob/0.10.0/src/lib.rs#L1668
-    private static byte[] toQuicheQuicSession(byte[] sslSession, byte[] peerParams) {
+    private static byte @Nullable [] toQuicheQuicSession(byte @Nullable [] sslSession, byte @Nullable [] peerParams) {
         if (sslSession != null && peerParams != null) {
             try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
                  DataOutputStream dos = new DataOutputStream(bos)) {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLSessionTicketCallback.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLSessionTicketCallback.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.util.internal.PlatformDependent;
+import org.jetbrains.annotations.Nullable;
 
 final class BoringSSLSessionTicketCallback {
 
@@ -23,7 +24,7 @@ final class BoringSSLSessionTicketCallback {
     private volatile byte[][] sessionKeys;
 
     // Accessed via JNI.
-    byte[] findSessionTicket(byte[] keyname) {
+    byte @Nullable [] findSessionTicket(byte @Nullable [] keyname) {
         byte[][] keys = this.sessionKeys;
         if (keys == null || keys.length == 0) {
             return null;
@@ -41,7 +42,7 @@ final class BoringSSLSessionTicketCallback {
         return null;
     }
 
-    void setSessionTicketKeys(SslSessionTicketKey[] keys) {
+    void setSessionTicketKeys(SslSessionTicketKey @Nullable [] keys) {
         if (keys != null && keys.length != 0) {
             byte[][] sessionKeys = new byte[keys.length][];
             for(int i = 0; i < keys.length; ++i) {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicClientSessionCache.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicClientSessionCache.java
@@ -83,7 +83,7 @@ final class QuicClientSessionCache {
         return false;
     }
 
-    byte[] getSession(@Nullable String host, int port) {
+    byte @Nullable [] getSession(@Nullable String host, int port) {
         HostPort hostPort = keyFor(host, port);
         if (hostPort != null) {
             SessionHolder sessionHolder;
@@ -214,7 +214,7 @@ final class QuicClientSessionCache {
         private final String host;
         private final int port;
 
-        HostPort(String host, int port) {
+        HostPort(@Nullable String host, int port) {
             this.host = host;
             this.port = port;
             // Calculate a hashCode that does ignore case.

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicSslContextBuilder.java
@@ -229,7 +229,7 @@ public final class QuicSslContextBuilder {
      * see <a href="https://www.oracle.com/java/technologies/javase/8u261-relnotes.html">
      *     JDK 8u261 Update Release Notes</a>
      */
-    public QuicSslContextBuilder trustManager(X509Certificate... trustCertCollection) {
+    public QuicSslContextBuilder trustManager(X509Certificate @Nullable ... trustCertCollection) {
         try {
             return trustManager(QuicheQuicSslContext.buildTrustManagerFactory0(trustCertCollection));
         } catch (Exception e) {
@@ -293,7 +293,7 @@ public final class QuicSslContextBuilder {
      *     password-protected
      * @param certChain an X.509 certificate chain
      */
-    public QuicSslContextBuilder keyManager(@Nullable PrivateKey key, @Nullable String keyPassword, X509Certificate... certChain) {
+    public QuicSslContextBuilder keyManager(@Nullable PrivateKey key, @Nullable String keyPassword, X509Certificate @Nullable ... certChain) {
         try {
             java.security.KeyStore ks = java.security.KeyStore.getInstance(KeyStore.getDefaultType());
             ks.load(null);
@@ -332,7 +332,7 @@ public final class QuicSslContextBuilder {
     /**
      * Application protocol negotiation configuration. {@code null} disables support.
      */
-    public QuicSslContextBuilder applicationProtocols(String... applicationProtocols) {
+    public QuicSslContextBuilder applicationProtocols(String @Nullable ... applicationProtocols) {
         this.applicationProtocols = applicationProtocols;
         return this;
     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicSslSessionContext.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicSslSessionContext.java
@@ -15,6 +15,8 @@
  */
 package io.netty.incubator.codec.quic;
 
+import org.jetbrains.annotations.Nullable;
+
 import javax.net.ssl.SSLSessionContext;
 
 /**
@@ -30,5 +32,5 @@ public interface QuicSslSessionContext extends SSLSessionContext {
      *
      * @param keys the tickets to use.
      */
-    void setTicketKeys(SslSessionTicketKey... keys);
+    void setTicketKeys(SslSessionTicketKey @Nullable ... keys);
 }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -304,6 +304,7 @@ final class Quiche {
     /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L105">quiche_version</a>.
      */
+    @Nullable
     static native String quiche_version();
 
     /**
@@ -368,7 +369,7 @@ final class Quiche {
         return new QuicConnectionCloseEvent((Boolean) error[0], (Integer) error[1], (byte[]) error[2]);
     }
 
-    private static native Object[] quiche_conn_peer_error0(long connAddr);
+    private static native Object @Nullable [] quiche_conn_peer_error0(long connAddr);
 
     /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.7.0/include/quiche.h#L330">
@@ -394,7 +395,7 @@ final class Quiche {
     /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.7.0/include/quiche.h#L309">quiche_conn_trace_id</a>.
      */
-    static native byte[] quiche_conn_trace_id(long connAddr);
+    static native byte @Nullable [] quiche_conn_trace_id(long connAddr);
 
     static native byte[] quiche_conn_source_id(long connAddr);
 
@@ -466,14 +467,14 @@ final class Quiche {
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L340">quiche_stats</a> being numerical.
      * The assumption made allows passing primitive array rather than dealing with objects.
      */
-    static native long[] quiche_conn_stats(long connAddr);
+    static native long @Nullable [] quiche_conn_stats(long connAddr);
 
     /**
      * See
      * <a href="https://github.com/cloudflare/quiche/blob/master/quiche/include/quiche.h#L567C65-L567C88">
      *     quiche_conn_stats</a>.
      */
-    static native long[] quiche_conn_peer_transport_params(long connAddr);
+    static native long @Nullable [] quiche_conn_peer_transport_params(long connAddr);
 
     /**
      * See
@@ -521,7 +522,7 @@ final class Quiche {
      * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.20.0/quiche/include/quiche.h#L672">quiche_conn_path_stats</a>.
      */
-    static native Object[] quiche_conn_path_stats(long connAddr, long streamIdx);
+    static native Object @Nullable [] quiche_conn_path_stats(long connAddr, long streamIdx);
 
     /**
      * See
@@ -570,7 +571,7 @@ final class Quiche {
 
     static native long quiche_conn_new_scid(long connAddr, long scidAddr, int scidLen, byte[] resetToken, boolean retire_if_needed, long seq);
 
-    static native byte[] quiche_conn_retired_scid_next(long connAddr);
+    static native byte @Nullable [] quiche_conn_retired_scid_next(long connAddr);
 
     static native long quiche_conn_path_event_next(long connAddr);
     static native int quiche_path_event_type(long pathEvent);

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -2049,6 +2049,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         collectStats0(connection, promise);
     }
 
+    @Nullable
     private QuicConnectionStats collectStats0(QuicheQuicConnection connection, Promise<QuicConnectionStats> promise) {
         final long[] stats = Quiche.quiche_conn_stats(connection.address());
         if (stats == null) {
@@ -2083,6 +2084,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         collectPathStats0(conn, pathIdx, promise);
     }
 
+    @Nullable
     private QuicConnectionPathStats collectPathStats0(QuicheQuicConnection connection, int pathIdx, Promise<QuicConnectionPathStats> promise) {
         final Object[] stats = Quiche.quiche_conn_path_stats(connection.address(), pathIdx);
         if (stats == null) {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
@@ -157,7 +157,7 @@ final class QuicheQuicSslContext extends QuicSslContext {
         throw new IllegalArgumentException("No X509TrustManager included");
     }
 
-     static X509Certificate[] toX509Certificates0(@Nullable File file) throws CertificateException {
+     static X509Certificate @Nullable [] toX509Certificates0(@Nullable File file) throws CertificateException {
         return toX509Certificates(file);
     }
 
@@ -169,7 +169,7 @@ final class QuicheQuicSslContext extends QuicSslContext {
     }
 
     static TrustManagerFactory buildTrustManagerFactory0(
-            X509Certificate[] certCollection)
+            X509Certificate @Nullable [] certCollection)
             throws NoSuchAlgorithmException, CertificateException, KeyStoreException, IOException {
         return buildTrustManagerFactory(certCollection, null, null);
     }
@@ -344,7 +344,7 @@ final class QuicheQuicSslContext extends QuicSslContext {
         }
     }
 
-    void setSessionTicketKeys(SslSessionTicketKey[] ticketKeys) {
+    void setSessionTicketKeys(SslSessionTicketKey @Nullable [] ticketKeys) {
         sessionTicketCallback.setSessionTicketKeys(ticketKeys);
         BoringSSL.SSLContext_setSessionTicketKeys(
                 nativeSslContext.address(), ticketKeys != null && ticketKeys.length != 0);
@@ -354,7 +354,7 @@ final class QuicheQuicSslContext extends QuicSslContext {
     private static final class QuicheQuicApplicationProtocolNegotiator implements ApplicationProtocolNegotiator {
         private final List<String> protocols;
 
-        QuicheQuicApplicationProtocolNegotiator(String... protocols) {
+        QuicheQuicApplicationProtocolNegotiator(String @Nullable ... protocols) {
             if (protocols == null) {
                 this.protocols = Collections.emptyList();
             } else {
@@ -417,7 +417,7 @@ final class QuicheQuicSslContext extends QuicSslContext {
         }
 
         @Override
-        public void setTicketKeys(SslSessionTicketKey... keys) {
+        public void setTicketKeys(SslSessionTicketKey @Nullable ... keys) {
             context.setSessionTicketKeys(keys);
         }
     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslEngine.java
@@ -263,7 +263,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
     synchronized void handshakeFinished(byte[] id, String cipher, String protocol, byte[] peerCertificate,
                                         byte[][] peerCertificateChain,
                                         long creationTime, long timeout,
-                                        byte[] applicationProtocol, boolean sessionReused) {
+                                        byte @Nullable [] applicationProtocol, boolean sessionReused) {
         if (applicationProtocol == null) {
             this.applicationProtocol = null;
         } else {
@@ -296,10 +296,10 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
         // lazy init for memory reasons
         private Map<String, Object> values;
 
-        private boolean isEmpty(Object[] arr) {
+        private boolean isEmpty(Object @Nullable [] arr) {
             return arr == null || arr.length == 0;
         }
-        private boolean isEmpty(byte[] arr) {
+        private boolean isEmpty(byte @Nullable [] arr) {
             return arr == null || arr.length == 0;
         }
 
@@ -507,7 +507,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
         }
 
         @Override
-        public Certificate[] getLocalCertificates() {
+        public Certificate @Nullable [] getLocalCertificates() {
             Certificate[] localCerts = localCertificateChain;
             if (localCerts == null) {
                 return null;

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SslSessionTicketKey.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SslSessionTicketKey.java
@@ -16,6 +16,8 @@
 
 package io.netty.incubator.codec.quic;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Arrays;
 
 /**
@@ -50,7 +52,7 @@ public final class SslSessionTicketKey {
      * @param hmacKey the HMAC key of the session ticket key
      * @param aesKey the AES key of the session ticket key
      */
-    public SslSessionTicketKey(byte[] name, byte[] hmacKey, byte[] aesKey) {
+    public SslSessionTicketKey(byte @Nullable [] name, byte @Nullable [] hmacKey, byte @Nullable [] aesKey) {
         if (name == null || name.length != NAME_SIZE) {
             throw new IllegalArgumentException("Length of name must be " + NAME_SIZE);
         }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SslSessionTicketKey.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SslSessionTicketKey.java
@@ -52,7 +52,7 @@ public final class SslSessionTicketKey {
      * @param hmacKey the HMAC key of the session ticket key
      * @param aesKey the AES key of the session ticket key
      */
-    public SslSessionTicketKey(byte @Nullable [] name, byte @Nullable [] hmacKey, byte @Nullable [] aesKey) {
+    public SslSessionTicketKey(byte[] name, byte[] hmacKey, byte[] aesKey) {
         if (name == null || name.length != NAME_SIZE) {
             throw new IllegalArgumentException("Length of name must be " + NAME_SIZE);
         }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SslSessionTicketKey.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/SslSessionTicketKey.java
@@ -16,8 +16,6 @@
 
 package io.netty.incubator.codec.quic;
 
-import org.jetbrains.annotations.Nullable;
-
 import java.util.Arrays;
 
 /**


### PR DESCRIPTION
Motivation:
`Nullable` annotations give an idea of what to expect from the API. Plus, they provide better IDE integration.

Modification:
`Nullable` annotations are applied to arrays where necessary.

Result:
The change extends the API with nullability expectations.