### PR TITLE
Cleanup methods / annotations

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -2074,27 +2074,19 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
     private void collectPathStats0(int pathIdx, Promise<QuicConnectionPathStats> promise) {
         QuicheQuicConnection conn = connection;
-
         if (conn.isFreed()) {
             promise.setFailure(new IllegalStateException("Connection is closed"));
             return;
         }
 
-        collectPathStats0(conn, pathIdx, promise);
-    }
-
-    private QuicConnectionPathStats collectPathStats0(QuicheQuicConnection connection, int pathIdx, Promise<QuicConnectionPathStats> promise) {
         final Object[] stats = Quiche.quiche_conn_path_stats(connection.address(), pathIdx);
         if (stats == null) {
             promise.setFailure(new IllegalStateException("native quiche_conn_path_stats(...) failed"));
-            return null;
+            return;
         }
-
-        final QuicheQuicConnectionPathStats connStats =
-                new QuicheQuicConnectionPathStats(stats);
-        promise.setSuccess(connStats);
-        return connStats;
+        promise.setSuccess(new QuicheQuicConnectionPathStats(stats));
     }
+
 
     @Override
     public QuicTransportParameters peerTransportParameters() {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -394,7 +394,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     /**
      * Stream is writable.
      */
-    boolean writable(@SuppressWarnings("unused") int capacity) {
+    boolean writable(int capacity) {
         assert eventLoop().inEventLoop();
         this.capacity = capacity;
         boolean mayNeedWrite = unsafe().writeQueued();
@@ -442,6 +442,8 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     }
 
     final class QuicStreamChannelUnsafe implements Unsafe {
+
+        @SuppressWarnings("deprecation")
         private RecvByteBufAllocator.Handle recvHandle;
 
         private final ChannelPromise voidPromise = new VoidChannelPromise(
@@ -904,7 +906,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         void recv() {
             assert eventLoop().inEventLoop();
             if (inRecv) {
-                // As the use may call read() we need to guard against re-entrancy here as otherwise it could
+                // As the use may call read() we need to guard against reentrancy here as otherwise it could
                 // be possible that we re-enter this method while still processing it.
                 return;
             }


### PR DESCRIPTION
Motivation:

Just some code cleanup related to unused return values and incorrect usage of annotations

Modifications:

- Simplify method as return value was never used
- Remove incorrect usage of @SupressWarnings

Result:

Cleanup