### PR TITLE
Remove usage of QuicheError in public API as its an implementation de…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicChannel.java
@@ -160,7 +160,7 @@ public interface QuicChannel extends Channel {
 
     /**
      * Returns the number of streams that can be created before stream creation will fail
-     * with {@link QuicError#STREAM_LIMIT} error.
+     * with {@link QuicTransportError#STREAM_LIMIT_ERROR} error.
      *
      * @param type the stream type.
      * @return the number of streams left.

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicException.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicException.java
@@ -15,26 +15,29 @@
  */
 package io.netty.incubator.codec.quic;
 
-import java.io.IOException;
-
 /**
  * Exception produced while processing {@code QUIC}.
  */
-public final class QuicException extends IOException {
+public final class QuicException extends Exception {
 
-    private final QuicError error;
+    private final QuicTransportError error;
 
-    QuicException(QuicError error) {
-        super(error.message());
+    public QuicException(QuicTransportError error) {
+        super(error.name());
+        this.error = error;
+    }
+
+    public QuicException(String message, QuicTransportError error) {
+        super(message);
         this.error = error;
     }
 
     /**
-     * Returns the {@link QuicError} which was the cause of the {@link QuicException}.
+     * Returns the {@link QuicTransportError} which was the cause of the {@link QuicException}.
      *
-     * @return  the {@link QuicError} that caused this {@link QuicException}.
+     * @return  the {@link QuicTransportError} that caused this {@link QuicException}.
      */
-    public QuicError error() {
+    public QuicTransportError error() {
         return error;
     }
 }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicHeaderParser.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicHeaderParser.java
@@ -20,6 +20,7 @@ import io.netty.buffer.Unpooled;
 
 import java.net.InetSocketAddress;
 
+import static io.netty.incubator.codec.quic.Quiche.QUICHE_ERR_DONE;
 import static io.netty.incubator.codec.quic.Quiche.allocateNativeOrder;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
@@ -131,8 +132,8 @@ public final class QuicHeaderParser implements AutoCloseable {
                     scidBuffer.setIndex(0, scidLen),
                     dcidBuffer.setIndex(0, dcidLen),
                     tokenBuffer.setIndex(0, tokenLen));
-        } else {
-            throw Quiche.newException(res);
+        } else if (res != QUICHE_ERR_DONE) {
+            throw Quiche.convertToException(res);
         }
     }
 

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicTransportError.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicTransportError.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * <a href="https://www.rfc-editor.org/rfc/rfc9000.html#name-transport-error-codes">
+ *     RFC9000 20.1. Transport Error Codes</a>
+ */
+public final class QuicTransportError {
+
+    /**
+     * An endpoint uses this with CONNECTION_CLOSE to signal that the connection is being closed abruptly in the
+     * absence of any error.
+     */
+    public static final QuicTransportError NO_ERROR =
+            new QuicTransportError(0x0, "NO_ERROR");
+
+    /**
+     * The endpoint encountered an internal error and cannot continue with the connection.
+     */
+    public static final QuicTransportError INTERNAL_ERROR =
+            new QuicTransportError(0x1, "INTERNAL_ERROR");
+
+    /**
+     * The server refused to accept a new connection.
+     */
+    public static final QuicTransportError CONNECTION_REFUSED =
+            new QuicTransportError(0x2, "CONNECTION_REFUSED");
+
+    /**
+     * An endpoint received more data than it permitted in its advertised data limits.
+     */
+    public static final QuicTransportError FLOW_CONTROL_ERROR =
+            new QuicTransportError(0x3, "FLOW_CONTROL_ERROR");
+
+    /**
+     * An endpoint received a frame for a stream identifier that exceeded its advertised stream limit for the
+     * corresponding stream type.
+     */
+    public static final QuicTransportError STREAM_LIMIT_ERROR =
+            new QuicTransportError(0x4, "STREAM_LIMIT_ERROR");
+
+    /**
+     * An endpoint received a frame for a stream that was not in a state that permitted that frame.
+     */
+    public static final QuicTransportError STREAM_STATE_ERROR =
+            new QuicTransportError(0x5, "STREAM_STATE_ERROR");
+
+    /**
+     * (1) An endpoint received a STREAM frame containing data that exceeded the previously established final size,
+     * (2) an endpoint received a STREAM frame or a RESET_STREAM frame containing a final size that was lower than
+     * the size of stream data that was already received, or (3) an endpoint received a STREAM frame or a RESET_STREAM
+     * frame containing a different final size to the one already established.
+     */
+    public static final QuicTransportError FINAL_SIZE_ERROR =
+            new QuicTransportError(0x6, "FINAL_SIZE_ERROR");
+
+    /**
+     * An endpoint received a frame that was badly formatted -- for instance, a frame of an unknown type or an ACK
+     * frame that has more acknowledgment ranges than the remainder of the packet could carry.
+     */
+    public static final QuicTransportError FRAME_ENCODING_ERROR =
+            new QuicTransportError(0x7, "FRAME_ENCODING_ERROR");
+
+    /**
+     * An endpoint received transport parameters that were badly formatted, included an invalid value, omitted a
+     * mandatory transport parameter, included a forbidden transport parameter, or were otherwise in error.
+     */
+    public static final QuicTransportError TRANSPORT_PARAMETER_ERROR =
+            new QuicTransportError(0x8, "TRANSPORT_PARAMETER_ERROR");
+
+    /**
+     * The number of connection IDs provided by the peer exceeds the advertised active_connection_id_limit.
+     */
+    public static final QuicTransportError CONNECTION_ID_LIMIT_ERROR =
+            new QuicTransportError(0x9, "CONNECTION_ID_LIMIT_ERROR");
+
+    /**
+     * An endpoint detected an error with protocol compliance that was not covered by more specific error codes.
+     */
+    public static final QuicTransportError PROTOCOL_VIOLATION =
+            new QuicTransportError(0xa, "PROTOCOL_VIOLATION");
+
+    /**
+     * A server received a client Initial that contained an invalid Token field.
+     */
+    public static final QuicTransportError INVALID_TOKEN =
+            new QuicTransportError(0xb, "INVALID_TOKEN");
+
+    /**
+     * The application or application protocol caused the connection to be closed.
+     */
+    public static final QuicTransportError APPLICATION_ERROR =
+            new QuicTransportError(0xc, "APPLICATION_ERROR");
+
+    /**
+     * An endpoint has received more data in CRYPTO frames than it can buffer.
+     */
+    public static final QuicTransportError CRYPTO_BUFFER_EXCEEDED =
+            new QuicTransportError(0xd, "CRYPTO_BUFFER_EXCEEDED");
+
+    /**
+     * An endpoint detected errors in performing key updates.
+     */
+    public static final QuicTransportError KEY_UPDATE_ERROR =
+            new QuicTransportError(0xe, "KEY_UPDATE_ERROR");
+
+    /**
+     * An endpoint has reached the confidentiality or integrity limit for the AEAD algorithm used by the given
+     * connection.
+     */
+    public static final QuicTransportError AEAD_LIMIT_REACHED =
+            new QuicTransportError(0xf, "AEAD_LIMIT_REACHED");
+
+    /**
+     * n endpoint has determined that the network path is incapable of supporting QUIC. An endpoint is unlikely to
+     * receive a CONNECTION_CLOSE frame carrying this code except when the path does not support a large enough MTU.
+     */
+    public static final QuicTransportError NO_VIABLE_PATH =
+            new QuicTransportError(0x10, "NO_VIABLE_PATH");
+
+    private static final QuicTransportError[] INT_TO_ENUM_MAP;
+    static {
+        List<QuicTransportError> errorList = new ArrayList<>();
+        errorList.add(NO_ERROR);
+        errorList.add(INTERNAL_ERROR);
+        errorList.add(CONNECTION_REFUSED);
+        errorList.add(FLOW_CONTROL_ERROR);
+        errorList.add(STREAM_LIMIT_ERROR);
+        errorList.add(STREAM_STATE_ERROR);
+        errorList.add(FINAL_SIZE_ERROR);
+        errorList.add(FRAME_ENCODING_ERROR);
+        errorList.add(TRANSPORT_PARAMETER_ERROR);
+        errorList.add(CONNECTION_ID_LIMIT_ERROR);
+        errorList.add(PROTOCOL_VIOLATION);
+        errorList.add(INVALID_TOKEN);
+        errorList.add(APPLICATION_ERROR);
+        errorList.add(CRYPTO_BUFFER_EXCEEDED);
+        errorList.add(KEY_UPDATE_ERROR);
+        errorList.add(AEAD_LIMIT_REACHED);
+        errorList.add(NO_VIABLE_PATH);
+
+        // Crypto errors can have various codes.
+        //
+        // See https://www.rfc-editor.org/rfc/rfc9000.html#name-transport-error-codes:
+        // The cryptographic handshake failed. A range of 256 values is reserved for carrying error codes specific to
+        // the cryptographic handshake that is used. Codes for errors occurring when TLS is used for the cryptographic
+        // handshake are described in Section 4.8 of [QUIC-TLS].
+        for (int i = 0x0100; i <= 0x01ff; i++) {
+            errorList.add(new QuicTransportError(i, "CRYPTO_ERROR"));
+        }
+        INT_TO_ENUM_MAP = errorList.toArray(new QuicTransportError[0]);
+    }
+    private final long code;
+    private final String name;
+
+    private QuicTransportError(long code, String name) {
+        this.code = code;
+        this.name = name;
+    }
+
+    /**
+     * Returns true if this is a {@code CRYPTO_ERROR}.
+     */
+    public boolean isCryptoError() {
+        return code >= 0x0100 && code <= 0x01ff;
+    }
+
+    /**
+     * Returns the name of the error as defined by RFC9000.
+     *
+     * @return name
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns the code for this error used on the wire as defined by RFC9000.
+     */
+    public long code() {
+        return code;
+    }
+
+    public static QuicTransportError valueOf(long value) {
+        if (value > 17) {
+            value -= 0x0100;
+        }
+
+        if (value < 0 || value >= INT_TO_ENUM_MAP.length) {
+            throw new IllegalArgumentException("Unknown error code value: " + value);
+        }
+        return INT_TO_ENUM_MAP[(int) value];
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        QuicTransportError quicError = (QuicTransportError) o;
+        return code == quicError.code;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code);
+    }
+
+    @Override
+    public String toString() {
+        return "QuicTransportError{" +
+                "code=" + code +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheError.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheError.java
@@ -22,7 +22,7 @@ import io.netty.util.collection.IntObjectMap;
  * All QUIC error codes identified by Quiche.
  * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/src/lib.rs#L335-L380">Error</a>
  */
-public enum QuicError {
+enum QuicheError {
     BUFFER_TOO_SHORT(Quiche.QUICHE_ERR_BUFFER_TOO_SHORT, "QUICHE_ERR_BUFFER_TOO_SHORT"),
     UNKNOWN_VERSION(Quiche.QUICHE_ERR_UNKNOWN_VERSION, "QUICHE_ERR_UNKNOWN_VERSION"),
     INVALID_FRAME(Quiche.QUICHE_ERR_INVALID_FRAME, "QUICHE_ERR_INVALID_FRAME"),
@@ -43,10 +43,10 @@ public enum QuicError {
     KEY_UPDATE(Quiche.QUICHE_ERR_KEY_UPDATE, "KEY_UPDATE"),
     CRYPTO_BUFFER_EXCEEDED(Quiche.QUICHE_ERR_CRYPTO_BUFFER_EXCEEDED, "QUICHE_ERR_CRYPTO_BUFFER_EXCEEDED");
 
-    private static final IntObjectMap<QuicError> ERROR_MAP = new IntObjectHashMap<>();
+    private static final IntObjectMap<QuicheError> ERROR_MAP = new IntObjectHashMap<>();
 
     static {
-        for (QuicError errorCode : QuicError.values()) {
+        for (QuicheError errorCode : QuicheError.values()) {
             ERROR_MAP.put(errorCode.code(), errorCode);
         }
     }
@@ -54,7 +54,7 @@ public enum QuicError {
     private final int code;
     private final String message;
 
-    QuicError(int code, String message) {
+    QuicheError(int code, String message) {
         this.code = code;
         this.message = message;
     }
@@ -72,11 +72,13 @@ public enum QuicError {
         return String.format("QuicError{code=%d, message=%s}", code, message);
     }
 
-    static QuicError valueOf(int code) {
-        final QuicError errorCode = ERROR_MAP.get(code);
+    static QuicheError valueOf(int code) {
+        final QuicheError errorCode = ERROR_MAP.get(code);
         if (errorCode == null) {
-            throw new IllegalArgumentException("unknown " + QuicError.class.getSimpleName() + " code: " + code);
+            throw new IllegalArgumentException("unknown " + QuicheError.class.getSimpleName() + " code: " + code);
         }
         return errorCode;
     }
+
+
 }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -144,7 +144,9 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
                     Quiche.writerMemoryAddress(out), out.writableBytes());
             if (res < 0) {
                 out.release();
-                Quiche.throwIfError(res);
+                if (res != Quiche.QUICHE_ERR_DONE) {
+                    throw Quiche.convertToException(res);
+                }
             } else {
                 ctx.writeAndFlush(new DatagramPacket(out.writerIndex(outWriterIndex + res), sender));
             }
@@ -176,7 +178,9 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
 
                 if (written < 0) {
                     out.release();
-                    Quiche.throwIfError(written);
+                    if (written != Quiche.QUICHE_ERR_DONE) {
+                        throw Quiche.convertToException(written);
+                    }
                 } else {
                     ctx.writeAndFlush(new DatagramPacket(out.writerIndex(outWriterIndex + written), sender));
                 }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
@@ -102,7 +102,7 @@ public class QuicStreamLimitTest extends AbstractQuicTest {
             // Second stream creation should fail.
             Throwable cause = quicChannel.createStream(
                     type, new ChannelInboundHandlerAdapter()).await().cause();
-            assertThat(cause, CoreMatchers.instanceOf(IOException.class));
+            assertThat(cause, CoreMatchers.instanceOf(QuicException.class));
             stream.close().sync();
             latch2.await();
 
@@ -178,7 +178,7 @@ public class QuicStreamLimitTest extends AbstractQuicTest {
                     .connect().get();
             streamPromise.sync();
             // Second stream creation should fail.
-            assertThat(stream2Promise.get(), CoreMatchers.instanceOf(IOException.class));
+            assertThat(stream2Promise.get(), CoreMatchers.instanceOf(QuicException.class));
             quicChannel.close().sync();
 
             serverHandler.assertState();

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamShutdownTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamShutdownTest.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.socket.ChannelOutputShutdownException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -46,8 +47,7 @@ public class QuicStreamShutdownTest extends AbstractQuicTest {
                         @Override
                         public void operationComplete(ChannelFuture channelFuture) {
                             Throwable cause = channelFuture.cause();
-                            if (cause instanceof QuicException &&
-                                    ((QuicException) cause).error() == QuicError.STREAM_STOPPED) {
+                            if (cause instanceof ChannelOutputShutdownException) {
                                 latch.countDown();
                             }
                         }


### PR DESCRIPTION
…tail of Quiche

Motivation:

Our usage of quiche is an implementation detail so we should not leak it to the user. We should convert from quiche errors to errors that are defined in the RFC9000.

Modifications:

Remove QuicheError from public API and replace it by QuicTransportError.

Result:

Cleaner API without leaking implementation details