### PR TITLE
initial congestion window configuration

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicCodecBuilder.java
@@ -48,6 +48,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     private Boolean disableActiveMigration;
     private Boolean enableHystart;
     private QuicCongestionControlAlgorithm congestionControlAlgorithm;
+    private Integer initialCongestionWindowPackets;
     private int localConnIdLength;
     private Function<QuicChannel, ? extends QuicSslEngine> sslEngineProvider;
     private FlushStrategy flushStrategy = FlushStrategy.DEFAULT;
@@ -86,6 +87,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
         this.disableActiveMigration = builder.disableActiveMigration;
         this.enableHystart = builder.enableHystart;
         this.congestionControlAlgorithm = builder.congestionControlAlgorithm;
+        this.initialCongestionWindowPackets = builder.initialCongestionWindowPackets;
         this.localConnIdLength = builder.localConnIdLength;
         this.sslEngineProvider = builder.sslEngineProvider;
         this.flushStrategy = builder.flushStrategy;
@@ -129,6 +131,19 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
      */
     public final B congestionControlAlgorithm(QuicCongestionControlAlgorithm congestionControlAlgorithm) {
         this.congestionControlAlgorithm = congestionControlAlgorithm;
+        return self();
+    }
+
+    /**
+     * Sets initial congestion window size in terms of packet count.
+     *
+     * The default value is 10.
+     *
+     * @param numPackets number of packets for the initial congestion window
+     * @return
+     */
+    public final B initialCongestionWindowPackets(int numPackets) {
+        this.initialCongestionWindowPackets = numPackets;
         return self();
     }
 
@@ -455,7 +470,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
                 initialMaxStreamDataBidiLocal, initialMaxStreamDataBidiRemote,
                 initialMaxStreamDataUni, initialMaxStreamsBidi, initialMaxStreamsUni,
                 ackDelayExponent, maxAckDelay, disableActiveMigration, enableHystart,
-                congestionControlAlgorithm, recvQueueLen, sendQueueLen, activeConnectionIdLimit, statelessResetToken);
+                congestionControlAlgorithm, initialCongestionWindowPackets, recvQueueLen, sendQueueLen, activeConnectionIdLimit, statelessResetToken);
     }
 
     /**

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -690,6 +690,14 @@ final class Quiche {
 
     /**
      * See
+     * <a href="https://github.com/cloudflare/quiche/blob/0.21.0/quiche/include/quiche.h#L222">
+     *     quiche_config_set_initial_congestion_window_packets</a>
+     *
+     */
+    static native void quiche_config_set_initial_congestion_window_packets(long configAddr, int numPackets);
+
+    /**
+     * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#184">
      *     quiche_config_enable_hystart</a>.
      */

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheConfig.java
@@ -26,7 +26,7 @@ final class QuicheConfig {
                  @Nullable Long initialMaxStreamDataBidiLocal, @Nullable Long initialMaxStreamDataBidiRemote,
                  @Nullable Long initialMaxStreamDataUni, @Nullable Long initialMaxStreamsBidi, @Nullable Long initialMaxStreamsUni,
                  @Nullable Long ackDelayExponent, @Nullable Long maxAckDelay, @Nullable Boolean disableActiveMigration, @Nullable Boolean enableHystart,
-                 @Nullable QuicCongestionControlAlgorithm congestionControlAlgorithm,
+                 @Nullable QuicCongestionControlAlgorithm congestionControlAlgorithm, @Nullable Integer initialCongestionWindowPackets,
                  @Nullable Integer recvQueueLen, @Nullable Integer sendQueueLen,
                  @Nullable Long activeConnectionIdLimit, byte @Nullable [] statelessResetToken) {
         long config = Quiche.quiche_config_new(version);
@@ -88,6 +88,9 @@ final class QuicheConfig {
                         throw new IllegalArgumentException(
                                 "Unknown congestionControlAlgorithm: " + congestionControlAlgorithm);
                 }
+            }
+            if (initialCongestionWindowPackets != null) {
+                Quiche.quiche_config_set_initial_congestion_window_packets(config, initialCongestionWindowPackets);
             }
             if (recvQueueLen != null && sendQueueLen != null) {
                 isDatagramSupported = true;

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -1010,7 +1010,6 @@ static void netty_quiche_config_set_initial_congestion_window_packets(JNIEnv* en
     quiche_config_set_initial_congestion_window_packets((quiche_config*) config, (size_t) value);
 }
 
-
 static void netty_quiche_config_enable_hystart(JNIEnv* env, jclass clazz, jlong config, jboolean value) {
     quiche_config_enable_hystart((quiche_config*) config, value == JNI_TRUE ? true : false);
 }

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -1006,6 +1006,11 @@ static void netty_quiche_config_set_cc_algorithm(JNIEnv* env, jclass clazz, jlon
     quiche_config_set_cc_algorithm((quiche_config*) config, (enum quiche_cc_algorithm) algo);
 }
 
+static void netty_quiche_config_set_initial_congestion_window_packets(JNIEnv* env, jclass clazz, jlong config, jint value) {
+    quiche_config_set_initial_congestion_window_packets((quiche_config*) config, (size_t) value);
+}
+
+
 static void netty_quiche_config_enable_hystart(JNIEnv* env, jclass clazz, jlong config, jboolean value) {
     quiche_config_enable_hystart((quiche_config*) config, value == JNI_TRUE ? true : false);
 }
@@ -1227,6 +1232,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_config_set_max_ack_delay", "(JJ)V", (void *) netty_quiche_config_set_max_ack_delay },
   { "quiche_config_set_disable_active_migration", "(JZ)V", (void *) netty_quiche_config_set_disable_active_migration },
   { "quiche_config_set_cc_algorithm", "(JI)V", (void *) netty_quiche_config_set_cc_algorithm },
+  { "quiche_config_set_initial_congestion_window_packets", "(JI)V", (void *) netty_quiche_config_set_initial_congestion_window_packets },
   { "quiche_config_enable_hystart", "(JZ)V", (void *) netty_quiche_config_enable_hystart },
   { "quiche_config_set_active_connection_id_limit", "(JJ)V", (void *) netty_quiche_config_set_active_connection_id_limit },
   { "quiche_config_set_stateless_reset_token", "(J[B)V", (void *) netty_quiche_config_set_stateless_reset_token },


### PR DESCRIPTION
Motivation:

Some environments, with a high bandwidth, may require an increased congestion window upon start

Modifications:

Quiche config method for setting initial congestion window is exposed

Result:

Initial congestion window may be increased optionally