### PR TITLE
Update java versions to latest release

### DIFF
--- a/docker/docker-compose.centos-7.117.yaml
+++ b/docker/docker-compose.centos-7.117.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-quic-centos6:centos-6-1.17
     build:
       args:
-        java_version : "17.0.10-zulu"
+        java_version : "17.0.11-zulu"
 
   build:
     image: netty-codec-quic-centos6:centos-6-1.17

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-quic-centos6:centos-6-1.8
     build:
       args:
-        java_version : "8.0.402-zulu"
+        java_version : "8.0.412-zulu"
 
   build:
     image: netty-codec-quic-centos6:centos-6-1.8

--- a/docker/docker-compose.centos-7.21.yaml
+++ b/docker/docker-compose.centos-7.21.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-quic-centos7:centos-7-21
     build:
       args:
-        java_version : "21.0.2-zulu"
+        java_version : "21.0.3-zulu"
 
   build:
     image: netty-codec-quic-centos7:centos-7-21


### PR DESCRIPTION
Motivation:

The used java versions in our docker-compose file were outdated

Modifications:

Update all versions to latest release

Result:

Use latest versions on CI