### PR TITLE
QuicTokenHandler: expose max connection id length, fix endianness

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/InsecureQuicTokenHandler.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/InsecureQuicTokenHandler.java
@@ -36,7 +36,7 @@ public final class InsecureQuicTokenHandler implements QuicTokenHandler {
             Unpooled.wrappedBuffer(SERVER_NAME_BYTES)).asReadOnly();
 
     // Just package-private for unit tests
-    static final int MAX_TOKEN_LEN = QuicTokenHandler.maxConnectionIdLength() +
+    static final int MAX_TOKEN_LEN = Quic.MAX_CONN_ID_LEN +
             NetUtil.LOCALHOST6.getAddress().length + SERVER_NAME_BYTES.length;
 
     private InsecureQuicTokenHandler() {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/InsecureQuicTokenHandler.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/InsecureQuicTokenHandler.java
@@ -36,7 +36,7 @@ public final class InsecureQuicTokenHandler implements QuicTokenHandler {
             Unpooled.wrappedBuffer(SERVER_NAME_BYTES)).asReadOnly();
 
     // Just package-private for unit tests
-    static final int MAX_TOKEN_LEN = Quiche.QUICHE_MAX_CONN_ID_LEN +
+    static final int MAX_TOKEN_LEN = QuicTokenHandler.maxConnectionIdLength() +
             NetUtil.LOCALHOST6.getAddress().length + SERVER_NAME_BYTES.length;
 
     private InsecureQuicTokenHandler() {

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quic.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quic.java
@@ -53,6 +53,12 @@ public final class Quic {
     }
 
     /**
+     * The maximum length of the <a href="https://www.rfc-editor.org/rfc/rfc9000.html#section-17.2">connection id</a>.
+     *
+     */
+    public static final int MAX_CONN_ID_LEN = 20;
+
+    /**
      * Return if the given QUIC version is supported.
      *
      * @param version   the version.

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicHeaderParser.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicHeaderParser.java
@@ -34,8 +34,7 @@ import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 public final class QuicHeaderParser implements AutoCloseable {
     // See https://datatracker.ietf.org/doc/rfc7714/
     private static final int AES_128_GCM_TAG_LENGTH = 16;
-    // https://www.rfc-editor.org/rfc/rfc9000.html#section-17.2
-    private static final int MAX_CONN_ID_LEN = 20;
+
     private final int localConnectionIdLength;
     private boolean closed;
 
@@ -146,8 +145,8 @@ public final class QuicHeaderParser implements AutoCloseable {
     // Check if the connection id is not longer then 20. This is what is the maximum for QUIC version 1.
     // See https://www.rfc-editor.org/rfc/rfc9000.html#section-17.2
     private void checkCidLength(int length) throws QuicException{
-        if (length > MAX_CONN_ID_LEN) {
-            throw new QuicException("connection id to large: "  + length + " > " + MAX_CONN_ID_LEN,
+        if (length > Quic.MAX_CONN_ID_LEN) {
+            throw new QuicException("connection id to large: "  + length + " > " + Quic.MAX_CONN_ID_LEN,
                     QuicTransportError.PROTOCOL_VIOLATION);
         }
     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicTokenHandler.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicTokenHandler.java
@@ -51,4 +51,9 @@ public interface QuicTokenHandler {
      * @return the maximal supported token length.
      */
     int maxTokenLength();
+
+    /** @return Maximum possible length of the {@code dcid} buffer passed to {@link #writeToken} method */
+    static int maxConnectionIdLength() {
+        return Quiche.QUICHE_MAX_CONN_ID_LEN;
+    }
 }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicTokenHandler.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicTokenHandler.java
@@ -30,7 +30,8 @@ public interface QuicTokenHandler {
      * {@code false}.
      *
      * @param out       {@link ByteBuf} into which the token will be written.
-     * @param dcid      the destination connection id.
+     * @param dcid      the destination connection id. The {@link ByteBuf#readableBytes()} will be at most
+     *                  {@link Quic#MAX_CONN_ID_LEN}.
      * @param address   the {@link InetSocketAddress} of the sender.
      * @return          {@code true} if a token was written and so validation should happen, {@code false} otherwise.
      */
@@ -51,9 +52,4 @@ public interface QuicTokenHandler {
      * @return the maximal supported token length.
      */
     int maxTokenLength();
-
-    /** @return Maximum possible length of the {@code dcid} buffer passed to {@link #writeToken} method */
-    static int maxConnectionIdLength() {
-        return Quiche.QUICHE_MAX_CONN_ID_LEN;
-    }
 }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -16,6 +16,7 @@
 package io.netty.incubator.codec.quic;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
@@ -87,7 +88,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
     @Override
     protected void handlerAdded(ChannelHandlerContext ctx, int localConnIdLength) {
         connIdBuffer = Quiche.allocateNativeOrder(localConnIdLength);
-        mintTokenBuffer = allocateNativeOrder(tokenHandler.maxTokenLength());
+        mintTokenBuffer = Unpooled.directBuffer(tokenHandler.maxTokenLength());
     }
 
     @Override

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -276,7 +276,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         ChannelStateVerifyHandler serverQuicStreamHandler = new ChannelStateVerifyHandler();
         Channel server = QuicTestUtils.newServer(QuicTestUtils.newQuicServerBuilder(executor)
                         .localConnectionIdLength(serverIdLength),
-                InsecureQuicTokenHandler.INSTANCE, serverQuicChannelHandler, serverQuicStreamHandler);
+                TestQuicTokenHandler.INSTANCE, serverQuicChannelHandler, serverQuicStreamHandler);
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
         Channel channel = QuicTestUtils.newClient(QuicTestUtils.newQuicClientBuilder(executor)
                 .localConnectionIdLength(clientIdLength));
@@ -662,7 +662,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                                 .applicationProtocols(QuicTestUtils.PROTOS)
                                 .earlyData(true)
                                 .build()),
-                InsecureQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter() {
+                TestQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter() {
                     @Override
                     public boolean isSharable() {
                         return true;
@@ -938,7 +938,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                                 QuicTestUtils.SELF_SIGNED_CERTIFICATE.privateKey(), null,
                                         QuicTestUtils.SELF_SIGNED_CERTIFICATE.certificate())
                                 .applicationProtocols("my-protocol").build()),
-                InsecureQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter() {
+                TestQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter() {
 
                     @Override
                     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
@@ -1008,7 +1008,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                                 QuicTestUtils.SELF_SIGNED_CERTIFICATE.privateKey(), null,
                                         QuicTestUtils.SELF_SIGNED_CERTIFICATE.certificate())
                                 .applicationProtocols(QuicTestUtils.PROTOS).clientAuth(ClientAuth.NONE).build()),
-                InsecureQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter(),
+                TestQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter(),
                 new ChannelInboundHandlerAdapter());
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
 
@@ -1070,7 +1070,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                                 .applicationProtocols(QuicTestUtils.PROTOS)
                                 .clientAuth(mode == MutalAuthTestMode.REQUIRED ?
                                         ClientAuth.REQUIRE : ClientAuth.OPTIONAL).build()),
-                InsecureQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter(),
+                TestQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter(),
                 new ChannelInboundHandlerAdapter());
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
 
@@ -1166,7 +1166,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                                         QuicTestUtils.SELF_SIGNED_CERTIFICATE.certificate())
                                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                                 .applicationProtocols(QuicTestUtils.PROTOS).clientAuth(ClientAuth.REQUIRE).build()),
-                InsecureQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter() {
+                TestQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter() {
                     @Override
                     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                         causeRef.compareAndSet(null, cause);
@@ -1230,7 +1230,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                                 .add(hostname, sniServerSslContext).build());
 
         Channel server = QuicTestUtils.newServer(QuicTestUtils.newQuicServerBuilder(executor, serverSslContext),
-                InsecureQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter() {
+                TestQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter() {
                     @Override
                     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt instanceof SniCompletionEvent) {
@@ -1306,7 +1306,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                         .add("quic.netty.io", sniServerSslContext).build());
 
         Channel server = QuicTestUtils.newServer(QuicTestUtils.newQuicServerBuilder(executor, serverSslContext),
-                InsecureQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter(),
+                TestQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter(),
                 new ChannelInboundHandlerAdapter());
 
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
@@ -1403,7 +1403,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         Channel server = QuicTestUtils.newServer(QuicTestUtils.newQuicServerBuilder(executor,
                         QuicSslContextBuilder.forServer(factory, null)
                                 .applicationProtocols(QuicTestUtils.PROTOS).clientAuth(ClientAuth.NONE).build()),
-                InsecureQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter() {
+                TestQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter() {
                     @Override
                     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                         causeRef.set(cause);
@@ -1475,7 +1475,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         }
         CountDownLatch serverSslCompletionEventLatch = new CountDownLatch(2);
         Channel server = QuicTestUtils.newServer(QuicTestUtils.newQuicServerBuilder(executor, sslServerCtx),
-                InsecureQuicTokenHandler.INSTANCE,
+                TestQuicTokenHandler.INSTANCE,
                 new ChannelInboundHandlerAdapter() {
                     @Override
                     public boolean isSharable() {

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/TestQuicTokenHandler.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/TestQuicTokenHandler.java
@@ -1,25 +1,41 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.incubator.codec.quic;
 
 import io.netty.buffer.ByteBuf;
-import org.junit.jupiter.api.Assertions;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteOrder;
 
-public class TestQuicTokenHandler implements QuicTokenHandler {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class TestQuicTokenHandler implements QuicTokenHandler {
     public static final QuicTokenHandler INSTANCE = new TestQuicTokenHandler();
 
     @Override
     @SuppressWarnings("deprecation")
     public boolean writeToken(ByteBuf out, ByteBuf dcid, InetSocketAddress address) {
-        Assertions.assertEquals(ByteOrder.BIG_ENDIAN, out.order());
+        assertEquals(ByteOrder.BIG_ENDIAN, out.order());
         return InsecureQuicTokenHandler.INSTANCE.writeToken(out, dcid, address);
     }
 
     @Override
     @SuppressWarnings("deprecation")
     public int validateToken(ByteBuf token, InetSocketAddress address) {
-        Assertions.assertEquals(ByteOrder.BIG_ENDIAN, token.order());
+        assertEquals(ByteOrder.BIG_ENDIAN, token.order());
         return InsecureQuicTokenHandler.INSTANCE.validateToken(token, address);
     }
 
@@ -27,4 +43,6 @@ public class TestQuicTokenHandler implements QuicTokenHandler {
     public int maxTokenLength() {
         return InsecureQuicTokenHandler.INSTANCE.maxTokenLength();
     }
+
+    private TestQuicTokenHandler() { }
 }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/TestQuicTokenHandler.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/TestQuicTokenHandler.java
@@ -1,0 +1,30 @@
+package io.netty.incubator.codec.quic;
+
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.Assertions;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteOrder;
+
+public class TestQuicTokenHandler implements QuicTokenHandler {
+    public static final QuicTokenHandler INSTANCE = new TestQuicTokenHandler();
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean writeToken(ByteBuf out, ByteBuf dcid, InetSocketAddress address) {
+        Assertions.assertEquals(ByteOrder.BIG_ENDIAN, out.order());
+        return InsecureQuicTokenHandler.INSTANCE.writeToken(out, dcid, address);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public int validateToken(ByteBuf token, InetSocketAddress address) {
+        Assertions.assertEquals(ByteOrder.BIG_ENDIAN, token.order());
+        return InsecureQuicTokenHandler.INSTANCE.validateToken(token, address);
+    }
+
+    @Override
+    public int maxTokenLength() {
+        return InsecureQuicTokenHandler.INSTANCE.maxTokenLength();
+    }
+}


### PR DESCRIPTION
Fixes #731.

* Ensures that all buffers passed to the `QuicTokenHandler` are now big endian
* `Quiche.MAX_TOKEN_LEN` is exposed to the outside world via `QuicTokenHandler.maxConnectionIdLength()`