### PR TITLE
Correctly translate quiche error to QuicException that have no transp…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicException.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicException.java
@@ -15,12 +15,19 @@
  */
 package io.netty.incubator.codec.quic;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Exception produced while processing {@code QUIC}.
  */
 public final class QuicException extends Exception {
 
     private final QuicTransportError error;
+
+    QuicException(String message) {
+        super(message);
+        this.error = null;
+    }
 
     public QuicException(QuicTransportError error) {
         super(error.name());
@@ -42,12 +49,13 @@ public final class QuicException extends Exception {
         this.error = error;
     }
 
-
     /**
      * Returns the {@link QuicTransportError} which was the cause of the {@link QuicException}.
      *
-     * @return  the {@link QuicTransportError} that caused this {@link QuicException}.
+     * @return  the {@link QuicTransportError} that caused this {@link QuicException} or {@code null} if
+     *          it was caused by something different.
      */
+    @Nullable
     public QuicTransportError error() {
         return error;
     }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -889,7 +889,10 @@ final class Quiche {
 
     static Exception convertToException(int result) {
         QuicTransportErrorHolder holder = ERROR_MAPPINGS.get(result);
-        assert holder != null;
+        if (holder == null) {
+            // There is no mapping to a transport error, it's something internal so throw it directly.
+            return new QuicException(QuicheError.valueOf(result).message());
+        }
         Exception exception = new QuicException(holder.error + ": " + holder.quicheErrorName, holder.error);
         if (result == QUICHE_ERR_TLS_FAIL) {
             String lastSslError = BoringSSL.ERR_last_error();

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheError.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheError.java
@@ -79,6 +79,4 @@ enum QuicheError {
         }
         return errorCode;
     }
-
-
 }


### PR DESCRIPTION
…ort error mappings

Motivation:

There are a few errors that just dont have a transport error mapping, we need to special handle these

Modifications:

Correctly handle errors that have no mapping

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/735