### PR TITLE
Upgrade java to latest patch releases

### DIFF
--- a/docker/docker-compose.centos-7.117.yaml
+++ b/docker/docker-compose.centos-7.117.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-quic-centos6:centos-6-1.17
     build:
       args:
-        java_version : "17.0.11-zulu"
+        java_version : "17.0.12-zulu"
 
   build:
     image: netty-codec-quic-centos6:centos-6-1.17

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-quic-centos6:centos-6-1.8
     build:
       args:
-        java_version : "8.0.412-zulu"
+        java_version : "8.0.422-zulu"
 
   build:
     image: netty-codec-quic-centos6:centos-6-1.8

--- a/docker/docker-compose.centos-7.21.yaml
+++ b/docker/docker-compose.centos-7.21.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-codec-quic-centos7:centos-7-21
     build:
       args:
-        java_version : "21.0.3-zulu"
+        java_version : "21.0.4-zulu"
 
   build:
     image: netty-codec-quic-centos7:centos-7-21


### PR DESCRIPTION
Motivation:

We are behind on the java patch releases used during build

Modifications:

Bump up java versions in docker-compose files

Result:

Use latest java versions