### PR TITLE
Slice token before pass it to QuicTokenHandler

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -184,7 +184,10 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
             offset = 0;
             noToken = true;
         } else {
-            offset = tokenHandler.validateToken(token, sender);
+            // Slice the token before pass it ot the QuicTokenHandler as the implementation might modify
+            // the readerIndex.
+            // See https://github.com/netty/netty-incubator-codec-quic/issues/742
+            offset = tokenHandler.validateToken(token.slice(), sender);
             if (offset == -1) {
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("invalid token: {}", token.toString(CharsetUtil.US_ASCII));


### PR DESCRIPTION
Motivation:

As the QuicTokenHandler implementation might modify the readerIndex of the token we need to ensure we slice it before pass it to to the handler. Otherwise we will run into issues that might fail the connection establishment

Modifications:

- Slice token before pass it to the QuicTokenHandler
- Add unit test

Result:

No more connection issues due of token readerIndex adjustments. Fixes https://github.com/netty/netty-incubator-codec-quic/issues/742