### PR TITLE
Enable linker `build-id` for android builds.

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -293,7 +293,7 @@
         <ldflags>-L${quicheHomeBuildDir} -lquiche -L${boringsslHomeBuildDir} -lssl -lcrypto</ldflags>
         <bundleNativeCode>META-INF/native/${jniLibName}.dll;osname=android;processor=${androidAbi}</bundleNativeCode>
         <ndkToolchain>${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64</ndkToolchain>
-        <extraLdflags>-Wl,-soname=${jniLibName}.so -Wl,--strip-debug -Wl,--exclude-libs,ALL -lm</extraLdflags>
+        <extraLdflags>-Wl,-soname=${jniLibName}.so -Wl,--build-id=sha1 -Wl,--strip-debug -Wl,--exclude-libs,ALL -lm</extraLdflags>
 
         <extraConfigureArg>--host=${androidTriple}</extraConfigureArg>
 


### PR DESCRIPTION
Linker `build-id` is [mandatory](https://firebase.google.com/docs/crashlytics/ndk-reports) to make Firebase crashlytics recognise libraries which encounters crashes. So since Firebase is ubiquitous to monitor app crash performance it make sense to enable it for android builds. It only slightly increases binary size (20 bytes) but make Firebase crash symbolication work. Here I assume that debugging symbols are currently presented/published, if not the case it will be handled in subsequent PRs.
<img width="958" alt="image" src="https://github.com/user-attachments/assets/59bfb873-9f43-4558-88f3-1e3e0e63af72">
