### PR TITLE
WritabilityChanged event is triggered with wrong capacity

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -681,7 +681,9 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                         queue.remove().setFailure(e);
                     }
                 }
-                updateWritabilityIfNeeded(true);
+                if (written) {
+                    updateWritabilityIfNeeded(true);
+                }
                 return written;
             } finally {
                 closeIfNeeded(wasFinSent);


### PR DESCRIPTION
Motivation:

There was a regression in `fdb1a7` (00.63.Final) where `writeQueued()` may call `updateWritabilityIfNeeded(true)` at the end of the loop, even when no write operations were completed. As a result, the channel capacity is zero. That has an impact on handlers that intercept the WritabilityChanged events and call `Channel.bytesBeforeUnwritable()`.

Modifications:

Only call `updateWritabilityIfNeeded(true)` if `written` is true.

Result:

Handlers that intercept WritabilityChanged events see the correct capacity.