### PR TITLE
Use latest run-on-arch-action

### DIFF
--- a/.github/workflows/ci-verify-load.yml
+++ b/.github/workflows/ci-verify-load.yml
@@ -70,7 +70,7 @@ jobs:
           name:  maven-repository
           path: /home/runner/jars
 
-      - uses: uraimo/run-on-arch-action@v2.5.1
+      - uses: uraimo/run-on-arch-action@v2
         name: Check native loading
         id: runcmd
         with:


### PR DESCRIPTION
Motivation:

We should use the latest v2 version of the run-on-arch-action

Modifications:

Just use @v2 to ensure we use the latest release

Result:

Use latest action