### PR TITLE
Allow to configure used named groups via -Djdk.tls.namedGroup

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/GroupsConverter.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/GroupsConverter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Convert java naming to BoringSSL naming if possible and if not return the original name.
+ */
+final class GroupsConverter {
+
+    private static final Map<String, String> mappings;
+
+    static {
+        // See https://tools.ietf.org/search/rfc4492#appendix-A and https://www.java.com/en/configure_crypto.html
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("secp224r1", "P-224");
+        map.put("prime256v1", "P-256");
+        map.put("secp256r1", "P-256");
+        map.put("secp384r1", "P-384");
+        map.put("secp521r1", "P-521");
+        map.put("x25519", "X25519");
+        mappings = Collections.unmodifiableMap(map);
+    }
+
+    static String toBoringSSL(String key) {
+        String mapping = mappings.get(key);
+        if (mapping == null) {
+            return key;
+        }
+        return mapping;
+    }
+
+    private GroupsConverter() { }
+}

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
@@ -22,6 +22,10 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.Mapping;
 import io.netty.util.ReferenceCounted;
+import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.jetbrains.annotations.Nullable;
 
 import javax.crypto.NoSuchPaddingException;
@@ -46,8 +50,11 @@ import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 import java.util.function.LongFunction;
@@ -55,6 +62,78 @@ import java.util.function.LongFunction;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 final class QuicheQuicSslContext extends QuicSslContext {
+
+    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(QuicheQuicSslContext.class);
+
+    // Use default that is supported in java 11 and earlier and also in OpenSSL / BoringSSL.
+    // See https://github.com/netty/netty-tcnative/issues/567
+    // See https://www.java.com/en/configure_crypto.html for ordering
+    private static final String[] DEFAULT_NAMED_GROUPS = { "x25519", "secp256r1", "secp384r1", "secp521r1" };
+    private static final String[] NAMED_GROUPS;
+
+    static {
+        String[] namedGroups = DEFAULT_NAMED_GROUPS;
+        Set<String> defaultConvertedNamedGroups = new LinkedHashSet<>(namedGroups.length);
+        for (int i = 0; i < namedGroups.length; i++) {
+            defaultConvertedNamedGroups.add(GroupsConverter.toBoringSSL(namedGroups[i]));
+        }
+
+        final long sslCtx = BoringSSL.SSLContext_new();
+        try {
+            // Let's filter out any group that is not supported from the default.
+            Iterator<String> defaultGroupsIter = defaultConvertedNamedGroups.iterator();
+            while (defaultGroupsIter.hasNext()) {
+                if (BoringSSL.SSLContext_set1_groups_list(sslCtx, defaultGroupsIter.next()) == 0) {
+                    // Not supported, let's remove it. This could for example be the case if we use
+                    // fips and the configure group is not supported when using FIPS.
+                    // See https://github.com/netty/netty-tcnative/issues/883
+                    defaultGroupsIter.remove();
+                }
+            }
+
+            String groups = SystemPropertyUtil.get("jdk.tls.namedGroups", null);
+            if (groups != null) {
+                String[] nGroups = groups.split(",");
+                Set<String> supportedNamedGroups = new LinkedHashSet<>(nGroups.length);
+                Set<String> supportedConvertedNamedGroups = new LinkedHashSet<>(nGroups.length);
+
+                Set<String> unsupportedNamedGroups = new LinkedHashSet<>();
+                for (String namedGroup : nGroups) {
+                    String converted = GroupsConverter.toBoringSSL(namedGroup);
+                    if (BoringSSL.SSLContext_set1_groups_list(sslCtx, converted) == 0) {
+                        supportedConvertedNamedGroups.add(converted);
+                        supportedNamedGroups.add(namedGroup);
+                    } else {
+                        unsupportedNamedGroups.add(namedGroup);
+                    }
+                }
+
+                if (supportedNamedGroups.isEmpty()) {
+                    namedGroups = defaultConvertedNamedGroups.toArray(EmptyArrays.EMPTY_STRINGS);
+                    LOGGER.info("All configured namedGroups are not supported: {}. Use default: {}.",
+                            Arrays.toString(unsupportedNamedGroups.toArray(EmptyArrays.EMPTY_STRINGS)),
+                            Arrays.toString(DEFAULT_NAMED_GROUPS));
+                } else {
+                    String[] groupArray = supportedNamedGroups.toArray(EmptyArrays.EMPTY_STRINGS);
+                    if (unsupportedNamedGroups.isEmpty()) {
+                        LOGGER.info("Using configured namedGroups -D 'jdk.tls.namedGroup': {} ",
+                                Arrays.toString(groupArray));
+                    } else {
+                        LOGGER.info("Using supported configured namedGroups: {}. Unsupported namedGroups: {}. ",
+                                Arrays.toString(groupArray),
+                                Arrays.toString(unsupportedNamedGroups.toArray(EmptyArrays.EMPTY_STRINGS)));
+                    }
+                    namedGroups =  supportedConvertedNamedGroups.toArray(EmptyArrays.EMPTY_STRINGS);
+                }
+            } else {
+                namedGroups = defaultConvertedNamedGroups.toArray(EmptyArrays.EMPTY_STRINGS);
+            }
+        } finally {
+            BoringSSL.SSLContext_free(sslCtx);
+        }
+        NAMED_GROUPS = namedGroups;
+    }
+
     final ClientAuth clientAuth;
     private final boolean server;
     @SuppressWarnings("deprecation")
@@ -118,25 +197,43 @@ final class QuicheQuicSslContext extends QuicSslContext {
                 server ? null : new BoringSSLSessionCallback(engineMap, sessionCache), privateKeyMethod,
                 sessionTicketCallback, verifyMode,
                 BoringSSL.subjectNames(trustManager.getAcceptedIssuers())));
-        apn = new QuicheQuicApplicationProtocolNegotiator(applicationProtocols);
-        if (this.sessionCache != null) {
-            // Cache is handled via our own implementation.
-            this.sessionCache.setSessionCacheSize((int) sessionCacheSize);
-            this.sessionCache.setSessionTimeout((int) sessionTimeout);
-        } else {
-            // Cache is handled by BoringSSL internally
-            BoringSSL.SSLContext_setSessionCacheSize(
-                    nativeSslContext.address(), sessionCacheSize);
-            this.sessionCacheSize = sessionCacheSize;
+        boolean success = false;
+        try {
+            if (NAMED_GROUPS.length > 0 && BoringSSL.SSLContext_set1_groups_list(nativeSslContext.ctx, NAMED_GROUPS) == 0) {
+                String msg = "failed to set curves / groups list: " + Arrays.toString(NAMED_GROUPS);
+                String lastError = BoringSSL.ERR_last_error();
+                if (lastError != null) {
+                    // We have some more details about why the operations failed, include these into the message.
+                    msg += ". " + lastError;
+                }
+                throw new IllegalStateException(msg);
+            }
 
-            BoringSSL.SSLContext_setSessionCacheTimeout(
-                    nativeSslContext.address(), sessionTimeout);
-            this.sessionTimeout = sessionTimeout;
+            apn = new QuicheQuicApplicationProtocolNegotiator(applicationProtocols);
+            if (this.sessionCache != null) {
+                // Cache is handled via our own implementation.
+                this.sessionCache.setSessionCacheSize((int) sessionCacheSize);
+                this.sessionCache.setSessionTimeout((int) sessionTimeout);
+            } else {
+                // Cache is handled by BoringSSL internally
+                BoringSSL.SSLContext_setSessionCacheSize(
+                        nativeSslContext.address(), sessionCacheSize);
+                this.sessionCacheSize = sessionCacheSize;
+
+                BoringSSL.SSLContext_setSessionCacheTimeout(
+                        nativeSslContext.address(), sessionTimeout);
+                this.sessionTimeout = sessionTimeout;
+            }
+            if (earlyData != null) {
+                BoringSSL.SSLContext_set_early_data_enabled(nativeSslContext.address(), earlyData);
+            }
+            sessionCtx = new QuicheQuicSslSessionContext(this);
+            success = true;
+        } finally {
+            if (!success) {
+                nativeSslContext.release();
+            }
         }
-        if (earlyData != null) {
-            BoringSSL.SSLContext_set_early_data_enabled(nativeSslContext.address(), earlyData);
-        }
-        sessionCtx = new QuicheQuicSslSessionContext(this);
     }
 
     private X509ExtendedKeyManager chooseKeyManager(KeyManagerFactory keyManagerFactory) {

--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -993,6 +993,11 @@ int new_session_callback(SSL *ssl, SSL_SESSION *session) {
     return 0;
 }
 
+static jlong netty_boringssl_SSLContext_new(JNIEnv* env, jclass clazz) {
+    SSL_CTX *ctx = SSL_CTX_new(TLS_with_buffers_method());
+    return (jlong) ctx;
+}
+
 static jlong netty_boringssl_SSLContext_new0(JNIEnv* env, jclass clazz, jboolean server, jbyteArray alpn_protos, jobject handshakeCompleteCallback, jobject certificateCallback, jobject verifyCallback, jobject servernameCallback, jobject keylogCallback, jobject sessionCallback, jobject privateKeyMethod, jobject sessionTicketCallback, jint verifyMode, jobjectArray subjectNames) {
     jobject handshakeCompleteCallbackRef = NULL;
     jobject certificateCallbackRef = NULL;
@@ -1415,6 +1420,13 @@ void netty_boringssl_SSLContext_setSessionTicketKeys(JNIEnv* env, jclass clazz, 
     }
 }
 
+jint netty_boringssl_SSLContext_set1_groups_list(JNIEnv* env, jclass clazz, jlong ctx, jstring groups) {
+    const char *nativeString = (*env)->GetStringUTFChars(env, groups, 0);
+    int ret = SSL_CTX_set1_groups_list((SSL_CTX *) ctx, nativeString);
+    (*env)->ReleaseStringUTFChars(env, groups, nativeString);
+    return (jint) ret;
+}
+
 // JNI Registered Methods End
 
 // JNI Method Registration Table Begin
@@ -1444,12 +1456,14 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
 
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 static const JNINativeMethod fixed_method_table[] = {
+  { "SSLContext_new", "()J", (void *) netty_boringssl_SSLContext_new },
   { "SSLContext_new0", "(Z[BLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;I[[B)J", (void *) netty_boringssl_SSLContext_new0 },
   { "SSLContext_free", "(J)V", (void *) netty_boringssl_SSLContext_free },
   { "SSLContext_setSessionCacheTimeout", "(JJ)J", (void *) netty_boringssl_SSLContext_setSessionCacheTimeout },
   { "SSLContext_setSessionCacheSize", "(JJ)J", (void *) netty_boringssl_SSLContext_setSessionCacheSize },
   { "SSLContext_set_early_data_enabled", "(JZ)V", (void *) netty_boringssl_SSLContext_set_early_data_enabled },
   { "SSLContext_setSessionTicketKeys", "(JZ)V", (void *) netty_boringssl_SSLContext_setSessionTicketKeys },
+  { "SSLContext_set1_groups_list", "(JLjava/lang/String;)I", (void *) netty_boringssl_SSLContext_set1_groups_list },
   { "SSL_new0", "(JZLjava/lang/String;)J", (void *) netty_boringssl_SSL_new0 },
   { "SSL_free", "(J)V", (void *) netty_boringssl_SSL_free },
   { "SSL_getTask", "(J)Ljava/lang/Runnable;", (void *) netty_boringssl_SSL_getTask },


### PR DESCRIPTION
Motivation:

We should allow to configure named groups via the known system property jdk.tls.namedGroup

Modifications:

Add code that allows to configure named groups

Result:

Be able to configure named groups via system property