### PR TITLE
Allow to configure groups via BoringSSLContextOption

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLContextOption.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/BoringSSLContextOption.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.codec.quic;
+
+import io.netty.handler.ssl.SslContextOption;
+
+/**
+ * {@link SslContextOption}s that are specific to BoringSSL.
+ *
+ * @param <T>   the type of the value.
+ */
+public final class BoringSSLContextOption<T> extends SslContextOption<T> {
+    private BoringSSLContextOption(String name) {
+        super(name);
+    }
+
+    /**
+     * Set the groups that should be used. This will override curves set with {@code -Djdk.tls.namedGroups}.
+     * <p>
+     * See <a href="https://github.com/google/boringssl/blob/master/include/openssl/ssl.h#L2632">
+     *     SSL_CTX_set1_groups_list</a>.
+     */
+    public static final BoringSSLContextOption<String[]> GROUPS = new BoringSSLContextOption<>("GROUPS");
+}


### PR DESCRIPTION
Motivation:

At the moment its only possible to specify the used named groups per JVM via system property. We can do better when using our native provider.

Modifications:

Introduce BoringSSLContextOption.GROUPS that can be used to configure the named groups per context

Result:

More flexible way of configure ssl.