### PR TITLE
Explicit specify the platform for Docker files

### DIFF
--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM --platform=linux/amd64 centos:7
 
 ENV SOURCE_DIR /root/source
 ENV LIBS_DIR /root/libs

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -1,4 +1,4 @@
-FROM centos:7.6.1810
+FROM --platform=linux/amd64 centos:7.6.1810
 
 ARG GCC_VERSION=10.2-2020.11
 ENV MAVEN_VERSION 3.9.1


### PR DESCRIPTION
Motivation:

We should explicit specify the platform we use for docker to ensure our build produce the correct artifacts

Modifications:

Add --platform=linux/amd64 to docker files

Result:

Ensure build produces correct artifacts