### PR TITLE
Upgrade to netty 4.1.115.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <javaModuleName />
     <skipTests>false</skipTests>
     <packaging.type>jar</packaging.type>
-    <netty.version>4.1.114.Final</netty.version>
+    <netty.version>4.1.115.Final</netty.version>
     <netty.build.version>31</netty.build.version>
     <netty.jni-util.version>0.0.9.Final</netty.jni-util.version>
     <junit.version>5.9.0</junit.version>


### PR DESCRIPTION
Motivation:

A new netty version was released

Modifications:

Update to latest netty version

Result:

Use latest netty version as dependency