### PR TITLE
Allow the QuicConnectionIdGenerator also take the source connection i…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicCodecDispatcher.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicCodecDispatcher.java
@@ -281,6 +281,14 @@ public abstract class QuicCodecDispatcher extends ChannelInboundHandlerAdapter {
         }
 
         @Override
+        public ByteBuffer newId(ByteBuffer scid, ByteBuffer dcid, int length) {
+            if (length > Short.BYTES) {
+                return encodeIdx(idGenerator.newId(scid, dcid, length - Short.BYTES), idx);
+            }
+            return idGenerator.newId(scid, dcid, length);
+        }
+
+        @Override
         public int maxConnectionIdLength() {
             return idGenerator.maxConnectionIdLength();
         }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionIdGenerator.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicConnectionIdGenerator.java
@@ -43,6 +43,19 @@ public interface QuicConnectionIdGenerator {
     ByteBuffer newId(ByteBuffer input, int length);
 
     /**
+     * Creates a new connection id with the given length. The given source connection id and destionation connection id
+     * may be used to sign or seed the id, or may be ignored (depending on the implementation).
+     *
+     * @param scid      the source connection id which may be used to generate the id.
+     * @param dcid      the destination connection id which may be used to generate the id.
+     * @param length    the length of the id.
+     * @return          the id.
+     */
+    default ByteBuffer newId(ByteBuffer scid, ByteBuffer dcid, int length) {
+        return newId(dcid, length);
+    }
+
+    /**
      * Returns the maximum length of a connection id.
      *
      * @return the maximum length of a connection id that is supported.

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -165,7 +165,9 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
             // The remote peer did not send a token.
             if (tokenHandler.writeToken(mintTokenBuffer, dcid, sender)) {
                 ByteBuffer connId = connectionIdAddressGenerator.newId(
-                        dcid.internalNioBuffer(dcid.readerIndex(), dcid.readableBytes()), localConnIdLength);
+                        scid.internalNioBuffer(scid.readerIndex(), scid.readableBytes()),
+                        dcid.internalNioBuffer(dcid.readerIndex(), dcid.readableBytes()),
+                        localConnIdLength);
                 connIdBuffer.writeBytes(connId);
 
                 ByteBuf out = ctx.alloc().directBuffer(Quic.MAX_DATAGRAM_SIZE);

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicServerCodec.java
@@ -207,7 +207,9 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         if (noToken) {
             connIdBuffer.clear();
             key = connectionIdAddressGenerator.newId(
-                    dcid.internalNioBuffer(dcid.readerIndex(), dcid.readableBytes()), localConnIdLength);
+                    scid.internalNioBuffer(scid.readerIndex(), scid.readableBytes()),
+                    dcid.internalNioBuffer(dcid.readerIndex(), dcid.readableBytes()),
+                    localConnIdLength);
             connIdBuffer.writeBytes(key.duplicate());
             scidAddr = Quiche.readerMemoryAddress(connIdBuffer);
             scidLen = localConnIdLength;


### PR DESCRIPTION
…d into account

Motivation:

Sometimes its useful to use the source and destination connection id to generate a connection id

Modifications:

- Add new default method to QuicConnectionIdGenerator that implementations can implement
- Call new method when it makes sense

Result:

More flexible connection id generation on the server