### PR TITLE
Don't generate duplicate streamID's

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicStreamIdGenerator.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicStreamIdGenerator.java
@@ -28,7 +28,7 @@ final class QuicStreamIdGenerator {
         nextUnidirectionalStreamId = server ? 3 : 2;
     }
 
-    long nextStreamId(boolean bidirectional) {
+    synchronized long nextStreamId(boolean bidirectional) {
         if (bidirectional) {
             long stream = nextBidirectionalStreamId;
             nextBidirectionalStreamId += 4;


### PR DESCRIPTION
The package sometimes generates duplicate streamID's if multiple streams are opened at exactly the same time. 

This simple PR makes the QuicStreamIdGenerator synchronized to resolve this.