### PR TITLE
Support cancellation of various outbound operations

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -1478,6 +1478,9 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
         void connectStream(QuicStreamType type, @Nullable ChannelHandler handler,
                            Promise<QuicStreamChannel> promise) {
+            if (!promise.setUncancellable()) {
+                return;
+            }
             long streamId = idGenerator.nextStreamId(type == QuicStreamType.BIDIRECTIONAL);
 
             try {
@@ -1511,6 +1514,9 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         @Override
         public void connect(SocketAddress remote, SocketAddress local, ChannelPromise channelPromise) {
             assert eventLoop().inEventLoop();
+            if (!channelPromise.setUncancellable()) {
+                return;
+            }
             if (server) {
                 channelPromise.setFailure(new UnsupportedOperationException());
                 return;


### PR DESCRIPTION
Motivation:

In netty we usually support cancellation of outbound operations but failed to also do so in our quic implementations. This can lead to exceptions when trying to notify promises later and is also inconsistent

Modifications:

- Correctly handle cancellation

Result:

Fixes https://github.com/netty/netty-incubator-codec-quic/issues/777