### PR TITLE
Update to quiche 0.23.4

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -56,7 +56,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>4ff56ec2566622980bbb0e0d7b9217254d97c4ba</quicheCommitSha>
+    <quicheCommitSha>68c296009f87a10e1cb935c5879e53bcc412d00c</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -39,7 +39,7 @@ RUN yum install -y centos-release-scl
 RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^# baseurl=http:\/\/mirror.centos.org\/centos\/7\/sclo\/$basearch\/sclo\//baseurl=https:\/\/vault.centos.org\/centos\/7\/sclo\/$basearch\/sclo\//g' /etc/yum.repos.d/CentOS-SCLo-scl.repo
 RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/7\/sclo\/$basearch\/rh\//baseurl=https:\/\/vault.centos.org\/centos\/7\/sclo\/$basearch\/rh\//g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
 
-RUN yum -y install devtoolset-11-gcc devtoolset-11-gcc-c++ clang-devel clang
+RUN yum -y install devtoolset-11-gcc devtoolset-11-gcc-c++
 RUN echo 'source /opt/rh/devtoolset-11/enable' >> ~/.bashrc
 
 RUN wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip && unzip ninja-linux.zip && mkdir -p /opt/ninja-$NINJA_VERSION/bin && mv ninja /opt/ninja-$NINJA_VERSION/bin && echo 'PATH=/opt/ninja-$NINJA_VERSION/bin:$PATH' >> ~/.bashrc

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -39,7 +39,7 @@ RUN yum install -y centos-release-scl
 RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^# baseurl=http:\/\/mirror.centos.org\/centos\/7\/sclo\/$basearch\/sclo\//baseurl=https:\/\/vault.centos.org\/centos\/7\/sclo\/$basearch\/sclo\//g' /etc/yum.repos.d/CentOS-SCLo-scl.repo
 RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/7\/sclo\/$basearch\/rh\//baseurl=https:\/\/vault.centos.org\/centos\/7\/sclo\/$basearch\/rh\//g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
 
-RUN yum -y install devtoolset-11-gcc devtoolset-11-gcc-c++
+RUN yum -y install devtoolset-11-gcc devtoolset-11-gcc-c++ clang-devel clang
 RUN echo 'source /opt/rh/devtoolset-11/enable' >> ~/.bashrc
 
 RUN wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip && unzip ninja-linux.zip && mkdir -p /opt/ninja-$NINJA_VERSION/bin && mv ninja /opt/ninja-$NINJA_VERSION/bin && echo 'PATH=/opt/ninja-$NINJA_VERSION/bin:$PATH' >> ~/.bashrc


### PR DESCRIPTION
Motivation:

We should link against the latest quiche release

Modifications:

Update to 0.23.4

Result:

Use sha that matches latest quiche release