### PR TITLE
Only build quiche package

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -791,7 +791,7 @@
                       <equals arg1="${platform}" arg2="android" />
                       <then>
                         <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                          <arg line="ndk ${cargoTarget} -p ${androidNdkVersion} -- build --exclude quiche_apps --workspace --features &quot;ffi qlog&quot; --release" />
+                          <arg line="ndk ${cargoTarget} -p ${androidNdkVersion} -- build -p quiche --features &quot;ffi qlog&quot; --release" />
                           <env key="CFLAGS" value="${extraCflags}" />
                           <env key="CXXFLAGS" value="${extraCxxflags}" />
                           <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
@@ -802,7 +802,7 @@
                           <equals arg1="${os.detected.name}" arg2="windows" />
                           <then>
                             <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                              <arg line="build --exclude quiche_apps --workspace --features &quot;ffi qlog&quot; --release" />
+                              <arg line="build -p quiche --features &quot;ffi qlog&quot; --release" />
                               <arg value="${cargoTarget}" />
                               <!-- See https://github.com/cloudflare/quiche/blob/0.7.0/src/build.rs#L73 -->
                               <env key="DEBUG" value="true" />
@@ -814,7 +814,7 @@
                             <equals arg1="${crossCompile}" arg2="linux" />
                             <then>
                               <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                                <arg line="build --exclude quiche_apps --workspace --features &quot;ffi qlog&quot; --release" />
+                                <arg line="build -p quiche --features &quot;ffi qlog&quot; --release" />
                                 <arg value="${cargoTarget}" />
                                 <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
                                 <!-- Lets enable frame-pointers so we can profile better -->
@@ -827,7 +827,7 @@
                             <equals arg1="${crossCompile}" arg2="mac" />
                             <then>
                               <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                                <arg line="build --exclude quiche_apps --workspace --features &quot;ffi qlog&quot; --release" />
+                                <arg line="build -p quiche --features &quot;ffi qlog&quot; --release" />
                                 <env key="CFLAGS" value="${extraCflags}" />
                                 <env key="CXXFLAGS" value="${extraCxxflags}" />
                                 <arg value="${cargoTarget}" />
@@ -840,7 +840,7 @@
                           </elseif>
                           <else>
                             <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                              <arg line="build --exclude quiche_apps --workspace --features &quot;ffi qlog&quot; --release" />
+                              <arg line="build -p quiche --features &quot;ffi qlog&quot; --release" />
                               <env key="CFLAGS" value="${extraCflags}" />
                               <env key="CXXFLAGS" value="${extraCxxflags}" />
                               <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />


### PR DESCRIPTION
Motivation:

We only link against the quiche package so we only need to build it with cargo

Modifications:

Only build quiche package

Result:

Speedup build and cleanup