### PR TITLE
Update to latest netty-4.2.0 release for PR validation

### DIFF
--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -41,7 +41,7 @@ services:
 
   build-4.2:
     <<: *common
-    command: /bin/bash -cl "./mvnw -B -ntp clean package -Dnetty.version=4.2.0.Beta1"
+    command: /bin/bash -cl "./mvnw -B -ntp clean package -Dnetty.version=4.2.0.RC4"
 
   deploy:
     <<: *common


### PR DESCRIPTION
Motivation:

Let's ensure we can build with latest netty 4.2.0 release

Modifications:

Change version to latest release

Result:

Validate everything works with latest netty 4.2.0 release