### PR TITLE
Correctly detect supported namedGroups during initialization

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicSslContext.java
@@ -105,11 +105,12 @@ final class QuicheQuicSslContext extends QuicSslContext {
                     Set<String> unsupportedNamedGroups = new LinkedHashSet<>();
                     for (String namedGroup : nGroups) {
                         String converted = GroupsConverter.toBoringSSL(namedGroup);
+                        // Will return 0 on failure.
                         if (BoringSSL.SSLContext_set1_groups_list(sslCtx, converted) == 0) {
+                            unsupportedNamedGroups.add(namedGroup);
+                        } else {
                             supportedConvertedNamedGroups.add(converted);
                             supportedNamedGroups.add(namedGroup);
-                        } else {
-                            unsupportedNamedGroups.add(namedGroup);
                         }
                     }
 


### PR DESCRIPTION
Motivation:

When init our quic implementation we also try to respect jdk.tls.namedGroups. While doing so we try to detect which group is supported by the underlying BoringSSL version. Unfortunally we did miss-interpret the return value of BoringSSL.SSLContext_set1_groups_list(...) and so assumed a group is not supported even if it is.

Modifications:

Correctly handle return value of BoringSSL.SSLContext_set1_groups_list(...)

Result:

Be able to configure a supported named group via -Djdk.tls.namedGroups=