### PR TITLE
Fix staging of macos and windows artifacts

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -133,13 +133,13 @@ jobs:
             }]
 
       - name: Stage snapshots to local staging directory
-        run: ./mvnw.cmd -B -ntp --file pom.xml clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true
+        run: ./mvnw.cmd -B -ntp --file pom.xml clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/local-staging -DskipRemoteStaging=true -DskipTests=true
 
       - name: Upload local staging directory
         uses: actions/upload-artifact@v4
         with:
           name: windows-x86_64-local-staging
-          path: local-staging
+          path: /local-staging
           if-no-files-found: error
           include-hidden-files: true
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -239,13 +239,13 @@ jobs:
         working-directory: ${{ github.workspace }}/prepare-release-workspace
         env:
           LOCAL_STAGING_DIR: ${{ github.workspace }}/prepare-release-workspace/local-staging
-        run: ./mvnw.cmd -B -ntp --file pom.xml clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=D:\a\netty-incubator-codec-quic\netty-incubator-codec-quic\prepare-release-workspace\local-staging -DskipRemoteStaging=true -DskipTests=true -D'checkstyle.skip=true'
+        run: ./mvnw.cmd -B -ntp --file pom.xml clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/local-staging -DskipRemoteStaging=true -DskipTests=true -D'checkstyle.skip=true'
 
       - name: Upload local staging directory
         uses: actions/upload-artifact@v4
         with:
           name: windows-x86_64-local-staging
-          path: ${{ github.workspace }}/prepare-release-workspace/local-staging
+          path: /local-staging
           if-no-files-found: error
           include-hidden-files: true
 
@@ -335,7 +335,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.setup }}-local-staging
-          path: /local-staging
+          path: ~/local-staging
           if-no-files-found: error
           include-hidden-files: true
 
@@ -390,7 +390,6 @@ jobs:
           name: macos-x86_64-local-staging
           path: ~/macos-x86_64-local-staging
 
-
       - name: Download macos-aarch64 staging directory
         uses: actions/download-artifact@v4
         with:
@@ -413,7 +412,7 @@ jobs:
       # all together with one maven command.
       - name: Merge staging repositories
         working-directory: ./prepare-release-workspace/
-        run: bash ./.github/scripts/merge_local_staging.sh /home/runner/local-staging/staging ~/windows-x86_64-local-staging/staging ~/macos-x86_64-local-staging/staging ~/macos-aarch64-local-staging/staging ~/linux-aarch64-local-staging/staging ~/linux-x86_64-local-staging/staging
+        run: bash ./.github/scripts/merge_local_staging.sh ~/local-staging/staging ~/windows-x86_64-local-staging/staging ~/macos-x86_64-local-staging/staging ~/macos-aarch64-local-staging/staging ~/linux-aarch64-local-staging/staging ~/linux-x86_64-local-staging/staging
 
       # Caching of maven dependencies
       - uses: actions/cache@v4


### PR DESCRIPTION
Motivation:

We had some typos in our jobs to stage windows and macos artifacts during deploy of snapshots and releases.

Modifications:

- Fix path

Result:

Staging works for snapshots and releases