### PR TITLE
Update to latest boringssl sha

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -47,7 +47,7 @@
     <boringsslRepository>https://boringssl.googlesource.com/boringssl</boringsslRepository>
     <!-- Lets use what we use in netty-tcnative-boringssl-static -->
     <boringsslBranch>main</boringsslBranch>
-    <boringsslCommitSha>b8c97f5b4bc5d4758612a0430e5c2792d0f9ca7f</boringsslCommitSha>
+    <boringsslCommitSha>cccf8525db8a57153d3cb3e22efed2db4b71a8ab</boringsslCommitSha>
 
     <quicheSourceDir>${project.build.directory}/quiche-source</quicheSourceDir>
     <quicheBuildDir>${quicheSourceDir}/target/release</quicheBuildDir>
@@ -733,8 +733,8 @@
 
                     <!-- Only copy the libs and header files we need -->
                     <mkdir dir="${boringsslHomeBuildDir}" />
-                    <copy file="${boringsslBuildDir}/ssl/${libssl}" todir="${boringsslHomeBuildDir}" verbose="true" />
-                    <copy file="${boringsslBuildDir}/crypto/${libcrypto}" todir="${boringsslHomeBuildDir}" verbose="true" />
+                    <copy file="${boringsslBuildDir}/${libssl}" todir="${boringsslHomeBuildDir}" verbose="true" />
+                    <copy file="${boringsslBuildDir}/${libcrypto}" todir="${boringsslHomeBuildDir}" verbose="true" />
                     <copy todir="${boringsslHomeIncludeDir}" verbose="true">
                       <fileset dir="${boringsslSourceDir}/include" />
                     </copy>

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -68,10 +68,6 @@
     <extraLdflags />
     <extraConfigureArg />
     <extraConfigureArg2 />
-    <!-- We need 10.12 as minimum to compile quiche and use it.
-         Anything below will fail when trying to load quiche with:
-         Symbol not found: ___isPlatformVersionAtLeast
-    -->
     <macosxDeploymentTarget />
     <bundleNativeCode />
     <crossCompile />
@@ -107,11 +103,8 @@
         </os>
       </activation>
       <properties>
-        <!--  We need 10.12 as minimum to compile quiche and use it.
-              Anything below will fail when trying to load quiche with:
-              Symbol not found: ___isPlatformVersionAtLeast
-        -->
-        <macosxDeploymentTarget>10.12</macosxDeploymentTarget>
+        <!--  We need 10.13 as minimum to compile quiche and boringssl  -->
+        <macosxDeploymentTarget>10.13</macosxDeploymentTarget>
         <!-- On *nix, add ASM flags to disable executable stack -->
         <cmakeAsmFlags>-Wa,--noexecstack -mmacosx-version-min=${macosxDeploymentTarget}</cmakeAsmFlags>
         <extraCflags>-mmacosx-version-min=${macosxDeploymentTarget}</extraCflags>
@@ -162,11 +155,11 @@
         <jniLibName>netty_quiche_osx_x86_64</jniLibName>
         <jni.classifier>osx-x86_64</jni.classifier>
         <javaModuleNameClassifier>osx.x86_64</javaModuleNameClassifier>
-        <macosxDeploymentTarget>10.12</macosxDeploymentTarget>
-        <extraCflags>-target x86_64-apple-macos10.12 -mmacosx-version-min=${macosxDeploymentTarget}</extraCflags>
-        <extraCxxflags>-target x86_64-apple-macos10.12</extraCxxflags>
+        <macosxDeploymentTarget>10.13</macosxDeploymentTarget>
+        <extraCflags>-target x86_64-apple-macos10.13 -mmacosx-version-min=${macosxDeploymentTarget}</extraCflags>
+        <extraCxxflags>-target x86_64-apple-macos10.13</extraCxxflags>
         <!-- On *nix, add ASM flags to disable executable stack -->
-        <cmakeAsmFlags>-Wa,--noexecstack -target x86_64-apple-macos10.12 -mmacosx-version-min=${macosxDeploymentTarget}</cmakeAsmFlags>
+        <cmakeAsmFlags>-Wa,--noexecstack -target x86_64-apple-macos10.13 -mmacosx-version-min=${macosxDeploymentTarget}</cmakeAsmFlags>
         <extraCmakeFlags>-DCMAKE_SYSTEM_PROCESSOR=x86_64 -DCMAKE_OSX_ARCHITECTURES=x86_64</extraCmakeFlags>
         <cmakeCFlags>${extraCflags} -O3 -fno-omit-frame-pointer</cmakeCFlags>
         <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->


### PR DESCRIPTION
Motivation:

BoringSSL had an important fix that we want to consume https://boringssl.googlesource.com/boringssl/+/cccf8525db8a57153d3cb3e22efed2db4b71a8ab

Modifications:

Update to latest sha

Result:

Use latest boringssl code