### PR TITLE
Cleanup code to make stacktrace less confusing

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -1087,10 +1087,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                             QuicheQuicStreamChannel streamChannel = streams.get(streamId);
                             if (streamChannel != null) {
                                 int capacity = Quiche.quiche_conn_stream_capacity(connAddr, streamId);
-                                if (capacity < 0) {
-                                    // Let's close the channel if quiche_conn_stream_capacity(...) returns an error.
-                                    streamChannel.forceClose(capacity);
-                                } else if (streamChannel.writable(capacity)) {
+                                if (streamChannel.writable(capacity)) {
                                     mayNeedWrite = true;
                                 }
                             }


### PR DESCRIPTION
Motivation:

5dade1f2b87504f8e4e2b385f62d63f537aac244 introduced a change that did prevent the Channel to be closed if a STREAM_STOPPED frame was received but did not change the name of the method from forceClose(...) to something else. This makes the stacktrace quite confusing as while the method is called forceClose(...) it actually might not close the channel.

Modifications:

- Move all the logic into the writable(...) method and so make things less confusing

Result:

Less confusing stacktrace for failed writes