### PR TITLE
Remove dependency on hamcrest

### DIFF
--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/InsecureQuicTokenHandlerTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/InsecureQuicTokenHandlerTest.java
@@ -25,9 +25,7 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -69,7 +67,7 @@ public class InsecureQuicTokenHandlerTest extends AbstractQuicTest {
             }
 
             InsecureQuicTokenHandler.INSTANCE.writeToken(out, dcid, validAddress);
-            assertThat(out.readableBytes(), lessThanOrEqualTo(InsecureQuicTokenHandler.INSTANCE.maxTokenLength()));
+            assertThat(out.readableBytes()).isLessThanOrEqualTo(InsecureQuicTokenHandler.INSTANCE.maxTokenLength());
             assertNotEquals(-1, InsecureQuicTokenHandler.INSTANCE.validateToken(out, validAddress));
 
             // Use another address and check that the validate fails.

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicChannelConnectTest.java
@@ -37,8 +37,6 @@ import io.netty.util.DomainWildcardMappingBuilder;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -86,7 +84,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -254,7 +252,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                     .connectionAddress(QuicConnectionAddress.random(20))
                     .connect();
             Throwable cause = future.await().cause();
-            assertThat(cause, CoreMatchers.instanceOf(IllegalArgumentException.class));
+            assertInstanceOf(IllegalArgumentException.class, cause);
             verifyHandler.assertState();
         } finally {
             socket.close();
@@ -519,7 +517,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                     .remoteAddress(socket.getLocalSocketAddress())
                     .connect();
             Throwable cause = future.await().cause();
-            assertThat(cause, CoreMatchers.instanceOf(ConnectTimeoutException.class));
+            assertInstanceOf(ConnectTimeoutException.class, cause);
             verifyHandler.assertState();
         } finally {
             socket.close();
@@ -584,7 +582,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             // Try to connect again
             ChannelFuture connectFuture = quicChannel.connect(QuicConnectionAddress.random());
             Throwable cause = connectFuture.await().cause();
-            assertThat(cause, CoreMatchers.instanceOf(AlreadyConnectedException.class));
+            assertInstanceOf(AlreadyConnectedException.class, cause);
             assertTrue(quicChannel.close().await().isSuccess());
             ChannelFuture closeFuture = quicChannel.closeFuture().await();
             assertTrue(closeFuture.isSuccess());
@@ -1117,7 +1115,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                     .remoteAddress(address)
                     .connect()
                     .await().cause();
-            assertThat(cause, Matchers.instanceOf(SSLException.class));
+            assertInstanceOf(SSLException.class, cause);
         } finally {
             server.close().sync();
             // Close the parent Datagram channel as well.
@@ -1181,7 +1179,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                     .remoteAddress(address)
                     .connect()
                     .await().cause();
-            assertThat(cause, Matchers.instanceOf(ClosedChannelException.class));
+            assertInstanceOf(ClosedChannelException.class, cause);
             latch.await();
             eventLatch.await();
             QuicConnectionCloseEvent closeEvent = closeEventRef.get();
@@ -1395,7 +1393,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                     .get();
             latch.await();
 
-            assertThat(causeRef.get(), Matchers.instanceOf(SSLHandshakeException.class));
+            assertInstanceOf(SSLHandshakeException.class, causeRef.get());
         } finally {
             server.close().sync();
 
@@ -1624,8 +1622,8 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                     .remoteAddress(address)
                     .connect().await();
             if (fail) {
-                assertThat(connectFuture.cause(), Matchers.instanceOf(ClosedChannelException.class));
-                assertThat(causeRef.get(), Matchers.instanceOf(SSLHandshakeException.class));
+                assertInstanceOf(ClosedChannelException.class, connectFuture.cause());
+                assertInstanceOf(SSLHandshakeException.class, causeRef.get());
             } else {
                 QuicChannel quicChannel = connectFuture.get();
                 assertTrue(quicChannel.close().await().isSuccess());

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionIdGeneratorTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionIdGeneratorTest.java
@@ -20,8 +20,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -33,8 +32,8 @@ public class QuicConnectionIdGeneratorTest extends AbstractQuicTest {
         QuicConnectionIdGenerator idGenerator = QuicConnectionIdGenerator.randomGenerator();
         ByteBuffer id = idGenerator.newId(Quiche.QUICHE_MAX_CONN_ID_LEN);
         ByteBuffer id2 = idGenerator.newId(Quiche.QUICHE_MAX_CONN_ID_LEN);
-        assertThat(id.remaining(), greaterThan(0));
-        assertThat(id2.remaining(), greaterThan(0));
+        assertThat(id.remaining()).isGreaterThan(0);
+        assertThat(id2.remaining()).isGreaterThan(0);
         assertNotEquals(id, id2);
 
         id = idGenerator.newId(10);

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionPathStatsTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionPathStatsTest.java
@@ -29,9 +29,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -125,11 +123,11 @@ public class QuicConnectionPathStatsTest extends AbstractQuicTest {
 
     private static void assertStats(QuicConnectionPathStats stats) {
         assertNotNull(stats);
-        assertThat(stats.lost(), greaterThanOrEqualTo(0L));
-        assertThat(stats.recv(), greaterThan(0L));
-        assertThat(stats.sent(), greaterThan(0L));
-        assertThat(stats.sentBytes(), greaterThan(0L));
-        assertThat(stats.recvBytes(), greaterThan(0L));
-        assertThat(stats.rtt(), greaterThan(0L));
+        assertThat(stats.lost()).isGreaterThanOrEqualTo(0L);
+        assertThat(stats.recv()).isGreaterThan(0L);
+        assertThat(stats.sent()).isGreaterThan(0L);
+        assertThat(stats.sentBytes()).isGreaterThan(0L);
+        assertThat(stats.recvBytes()).isGreaterThan(0L);
+        assertThat(stats.rtt()).isGreaterThan(0L);
     }
 }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicConnectionStatsTest.java
@@ -29,11 +29,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class QuicConnectionStatsTest extends AbstractQuicTest {
 
@@ -134,10 +132,10 @@ public class QuicConnectionStatsTest extends AbstractQuicTest {
 
     private static void assertStats(QuicConnectionStats stats) {
         assertNotNull(stats);
-        assertThat(stats.lost(), greaterThanOrEqualTo(0L));
-        assertThat(stats.recv(), greaterThan(0L));
-        assertThat(stats.sent(), greaterThan(0L));
-        assertThat(stats.sentBytes(), greaterThan(0L));
-        assertThat(stats.recvBytes(), greaterThan(0L));
+        assertThat(stats.lost()).isGreaterThanOrEqualTo(0L);
+        assertThat(stats.recv()).isGreaterThan(0L);
+        assertThat(stats.sent()).isGreaterThan(0L);
+        assertThat(stats.sentBytes()).isGreaterThan(0L);
+        assertThat(stats.recvBytes()).isGreaterThan(0L);
     }
 }

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamLimitTest.java
@@ -22,17 +22,15 @@ import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class QuicStreamLimitTest extends AbstractQuicTest {
 
@@ -102,7 +100,7 @@ public class QuicStreamLimitTest extends AbstractQuicTest {
             // Second stream creation should fail.
             Throwable cause = quicChannel.createStream(
                     type, new ChannelInboundHandlerAdapter()).await().cause();
-            assertThat(cause, CoreMatchers.instanceOf(QuicException.class));
+            assertInstanceOf(QuicException.class, cause);
             stream.close().sync();
             latch2.await();
 
@@ -178,7 +176,7 @@ public class QuicStreamLimitTest extends AbstractQuicTest {
                     .connect().get();
             streamPromise.sync();
             // Second stream creation should fail.
-            assertThat(stream2Promise.get(), CoreMatchers.instanceOf(QuicException.class));
+            assertInstanceOf(QuicException.class, stream2Promise.get());
             quicChannel.close().sync();
 
             serverHandler.assertState();

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicStreamTypeTest.java
@@ -28,10 +28,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.concurrent.Executor;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -79,7 +78,7 @@ public class QuicStreamTypeTest extends AbstractQuicTest {
             // Close stream and quic channel
             streamChannel.close().sync();
             quicChannel.close().sync();
-            assertThat(serverWritePromise.get(), instanceOf(UnsupportedOperationException.class));
+            assertInstanceOf(UnsupportedOperationException.class, serverWritePromise.get());
 
             serverHandler.assertState();
             clientHandler.assertState();
@@ -146,7 +145,7 @@ public class QuicStreamTypeTest extends AbstractQuicTest {
 
             quicChannel.closeFuture().sync();
             assertTrue(serverWritePromise.await().isSuccess());
-            assertThat(clientWritePromise.get(), instanceOf(UnsupportedOperationException.class));
+            assertInstanceOf(UnsupportedOperationException.class, clientWritePromise.get());
 
             serverHandler.assertState();
             clientHandler.assertState();

--- a/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTransportParametersTest.java
+++ b/codec-native-quic/src/test/java/io/netty/incubator/codec/quic/QuicTransportParametersTest.java
@@ -26,8 +26,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.concurrent.Executor;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -78,18 +77,18 @@ public class QuicTransportParametersTest extends AbstractQuicTest {
 
     private static void assertTransportParameters(@Nullable QuicTransportParameters parameters) {
         assertNotNull(parameters);
-        assertThat(parameters.maxIdleTimeout(), greaterThanOrEqualTo(1L));
-        assertThat(parameters.maxUdpPayloadSize(), greaterThanOrEqualTo(1L));
-        assertThat(parameters.initialMaxData(), greaterThanOrEqualTo(1L));
-        assertThat(parameters.initialMaxStreamDataBidiLocal(), greaterThanOrEqualTo(1L));
-        assertThat(parameters.initialMaxStreamDataBidiRemote(), greaterThanOrEqualTo(1L));
-        assertThat(parameters.initialMaxStreamDataUni(), greaterThanOrEqualTo(1L));
-        assertThat(parameters.initialMaxStreamsBidi(), greaterThanOrEqualTo(1L));
-        assertThat(parameters.initialMaxStreamsUni(), greaterThanOrEqualTo(1L));
-        assertThat(parameters.ackDelayExponent(), greaterThanOrEqualTo(1L));
-        assertThat(parameters.maxAckDelay(), greaterThanOrEqualTo(1L));
+        assertThat(parameters.maxIdleTimeout()).isGreaterThanOrEqualTo(1L);
+        assertThat(parameters.maxUdpPayloadSize()).isGreaterThanOrEqualTo(1L);
+        assertThat(parameters.initialMaxData()).isGreaterThanOrEqualTo(1L);
+        assertThat(parameters.initialMaxStreamDataBidiLocal()).isGreaterThanOrEqualTo(1L);
+        assertThat(parameters.initialMaxStreamDataBidiRemote()).isGreaterThanOrEqualTo(1L);
+        assertThat(parameters.initialMaxStreamDataUni()).isGreaterThanOrEqualTo(1L);
+        assertThat(parameters.initialMaxStreamsBidi()).isGreaterThanOrEqualTo(1L);
+        assertThat(parameters.initialMaxStreamsUni()).isGreaterThanOrEqualTo(1L);
+        assertThat(parameters.ackDelayExponent()).isGreaterThanOrEqualTo(1L);
+        assertThat(parameters.maxAckDelay()).isGreaterThanOrEqualTo(1L);
         assertFalse(parameters.disableActiveMigration());
-        assertThat(parameters.activeConnIdLimit(), greaterThanOrEqualTo(1L));
-        assertThat(parameters.maxDatagramFrameSize(), greaterThanOrEqualTo(0L));
+        assertThat(parameters.activeConnIdLimit()).isGreaterThanOrEqualTo(1L);
+        assertThat(parameters.maxDatagramFrameSize()).isGreaterThanOrEqualTo(0L);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -439,12 +439,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-library</artifactId>
-        <version>1.3</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-build-common</artifactId>
         <version>${netty.build.version}</version>


### PR DESCRIPTION
Motivation:

We already have a dependency on junit and assert4j. There is no need to also depend on hamcrest

Modifications:

Remove dependency on hamcrest and replace its usage by either junit or assert4j

Result:

Cleanup