### PR TITLE
Fix incorrect handling of stream capacity greater than 2^32

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/Quiche.java
@@ -416,7 +416,7 @@ final class Quiche {
      * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L274">quiche_conn_stream_capacity</a>.
      */
-    static native int quiche_conn_stream_capacity(long connAddr, long streamId);
+    static native long quiche_conn_stream_capacity(long connAddr, long streamId);
 
     /**
      * See

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicChannel.java
@@ -1055,7 +1055,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         freeIfClosed();
     }
 
-    int streamCapacity(long streamId) {
+    long streamCapacity(long streamId) {
         QuicheQuicConnection conn = connection;
         if (conn.isClosed()) {
             return 0;
@@ -1086,7 +1086,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                             long streamId = writableStreams[i];
                             QuicheQuicStreamChannel streamChannel = streams.get(streamId);
                             if (streamChannel != null) {
-                                int capacity = Quiche.quiche_conn_stream_capacity(connAddr, streamId);
+                                long capacity = Quiche.quiche_conn_stream_capacity(connAddr, streamId);
                                 if (streamChannel.writable(capacity)) {
                                     mayNeedWrite = true;
                                 }

--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicheQuicStreamChannel.java
@@ -75,7 +75,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     private volatile boolean inputShutdown;
     private volatile boolean outputShutdown;
     private volatile QuicStreamPriority priority;
-    private volatile int capacity;
+    private volatile long capacity;
 
     QuicheQuicStreamChannel(QuicheQuicChannel parent, long streamId) {
         this.parent = parent;
@@ -412,7 +412,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     /**
      * Stream writability changed.
      */
-    boolean writable(int capacity) {
+    boolean writable(long capacity) {
         assert eventLoop().inEventLoop();
         if (capacity < 0) {
             // If the value is negative its a quiche error.
@@ -423,7 +423,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                         // If STOP_SENDING is received we should not close the channel but just fail all queued writes.
                         return false;
                     } else {
-                        queue.removeAndFailAll(Quiche.convertToException(capacity));
+                        queue.removeAndFailAll(Quiche.convertToException((int) capacity));
                     }
                 } else if (capacity == Quiche.QUICHE_ERR_STREAM_STOPPED) {
                     // If STOP_SENDING is received we should not close the channel
@@ -858,7 +858,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                     int res = parent().streamSend(streamId(), buffer, fin);
 
                     // Update the capacity as well.
-                    int cap = parent.streamCapacity(streamId());
+                    long cap = parent.streamCapacity(streamId());
                     if (cap >= 0) {
                         capacity = cap;
                     }

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -501,8 +501,8 @@ static jint netty_quiche_conn_stream_shutdown(JNIEnv* env, jclass clazz, jlong c
     return (jint) quiche_conn_stream_shutdown((quiche_conn *) conn, (uint64_t) stream_id,  (enum quiche_shutdown) direction, (uint64_t) err);
 }
 
-static jint netty_quiche_conn_stream_capacity(JNIEnv* env, jclass clazz, jlong conn, jlong stream_id) {
-    return (jint) quiche_conn_stream_capacity((quiche_conn *) conn, (uint64_t) stream_id);
+static jlong netty_quiche_conn_stream_capacity(JNIEnv* env, jclass clazz, jlong conn, jlong stream_id) {
+    return (jlong) quiche_conn_stream_capacity((quiche_conn *) conn, (uint64_t) stream_id);
 }
 
 static jboolean netty_quiche_conn_stream_finished(JNIEnv* env, jclass clazz, jlong conn, jlong stream_id) {
@@ -1181,7 +1181,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_stream_recv", "(JJJIJ)I", (void *) netty_quiche_conn_stream_recv },
   { "quiche_conn_stream_send", "(JJJIZ)I", (void *) netty_quiche_conn_stream_send },
   { "quiche_conn_stream_shutdown", "(JJIJ)I", (void *) netty_quiche_conn_stream_shutdown },
-  { "quiche_conn_stream_capacity", "(JJ)I", (void *) netty_quiche_conn_stream_capacity },
+  { "quiche_conn_stream_capacity", "(JJ)J", (void *) netty_quiche_conn_stream_capacity },
   { "quiche_conn_stream_finished", "(JJ)Z", (void *) netty_quiche_conn_stream_finished },
   { "quiche_conn_close", "(JZJJI)I", (void *) netty_quiche_conn_close },
   { "quiche_conn_is_established", "(J)Z", (void *) netty_quiche_conn_is_established },


### PR DESCRIPTION
Motivation:

We did cast the stream capacity to an jint while it should be jlong. This could cause an erroneous closure of the stream in QuicheQuicChannel.java:handleWritableStreams().

Modifications:

Correctly cast to jlong

Result:

No more erroneous closure caused by incorrect casting. Fixes https://github.com/netty/netty-incubator-codec-quic/issues/805