### PR TITLE
Upgrade Windows GHA images to Windows Server 2022

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -111,7 +111,7 @@ jobs:
             **/hs_err*.log
 
   build-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: windows-x86_64
     env:
       # Let's limit the amount of ram that is used to unpack rustup as we saw

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -87,7 +87,7 @@ jobs:
           include-hidden-files: true
 
   stage-snapshot-windows-x86_64:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: stage-snapshot-windows-x86_64
     env:
       # Let's limit the amount of ram that is used to unpack rustup as we saw

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -111,7 +111,7 @@ jobs:
             **/core.*
 
   build-pr-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: windows-x86_64 build
     env:
       # Let's limit the amount of ram that is used to unpack rustup as we saw

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -169,7 +169,7 @@ jobs:
         run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty-incubator-codec-quic main
 
   stage-release-windows-x86_64:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: stage-release-windows-x86_64
     needs: prepare-release
     env:

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -1066,7 +1066,7 @@
               <customPackageDirectory>${templateDir}</customPackageDirectory>
               <windowsBuildTool>msbuild</windowsBuildTool>
               <windowsCustomProps>true</windowsCustomProps>
-              <windowsPlatformToolset>v142</windowsPlatformToolset>
+              <windowsPlatformToolset>v143</windowsPlatformToolset>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <verbose>true</verbose>
               <configureArgs>


### PR DESCRIPTION
Motivation:
We are currently using the Windows 2019 images, which will reach end-of-life on June 30, 2025.

Modification:
Change the windows images in our GHA workflows from `windows-2019` to `windows-2022`.

Result:
More up to date windows build agents.
