### PR TITLE
Obtain correct cipher to generate the authentication method

### DIFF
--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -356,12 +356,12 @@ enum ssl_verify_result_t quic_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_aler
     }
 
     const char* authentication_method = NULL;
-    STACK_OF(SSL_CIPHER) *ciphers = SSL_get_ciphers(ssl);
-    if (ciphers == NULL || sk_SSL_CIPHER_num(ciphers) <= 0) {
+    const SSL_CIPHER* cipher = SSL_get_current_cipher(ssl);
+    if (cipher == NULL) {
         // No cipher available so return UNKNOWN.
         authentication_method = "UNKNOWN";
     } else {
-        authentication_method = SSL_CIPHER_get_kx_name(sk_SSL_CIPHER_value(ciphers, 0));
+        authentication_method = SSL_CIPHER_get_kx_name(cipher);
         if (authentication_method == NULL) {
             authentication_method = "UNKNOWN";
         }


### PR DESCRIPTION
Motivation:

This function returns the first cipher from the preference order, but is not necessarily the actual cipher that was negotiated.

Modifications:

Use SSL_get_current_cipher to obtain current cipher

Result:

Always use the current cipher and not just the prefered cipher when generate the authentication method