### PR TITLE
Update to quiche 0.24.4

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -56,7 +56,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>28cb72b7c6a1f134f4d2e2f36ed04a81e113a0a6</quicheCommitSha>
+    <quicheCommitSha>70d6d3e233568e906e66179a56c93cf9b0616899</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />


### PR DESCRIPTION
Motivation:

Quiche released a new version which also contains security fixes

Modifications:

Update to sha of 0.24.4

Result:

Depend on latest quiche version