### PR TITLE
Compatibility with Android

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
+++ b/codec-classes-quic/src/main/java/io/netty/incubator/codec/quic/QuicChannelBootstrap.java
@@ -60,8 +60,10 @@ public final class QuicChannelBootstrap {
      * pipeline.
      *
      * @param parent    the {@link Channel} that is used as the transport layer.
+     * @deprecated Use QuicChannel.newBootstrap() instead.
      */
-    QuicChannelBootstrap(Channel parent) {
+    @Deprecated
+    public QuicChannelBootstrap(Channel parent) {
         Quic.ensureAvailability();
         this.parent = ObjectUtil.checkNotNull(parent, "parent");
     }

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -285,7 +285,7 @@
         <ldflags>-L${quicheHomeBuildDir} -lquiche -L${boringsslHomeBuildDir} -lssl -lcrypto</ldflags>
         <bundleNativeCode>META-INF/native/${jniLibName}.dll;osname=android;processor=${androidAbi}</bundleNativeCode>
         <ndkToolchain>${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64</ndkToolchain>
-        <extraLdflags>-Wl,-soname=${jniLibName}.so -Wl,--build-id=sha1 -Wl,--strip-debug -Wl,--exclude-libs,ALL -lm</extraLdflags>
+        <extraLdflags>-Wl,-soname=${jniLibName}.so -Wl,--build-id=sha1 -Wl,--strip-debug -Wl,--exclude-libs,ALL -lm -lc++_shared</extraLdflags>
 
         <extraConfigureArg>--host=${androidTriple}</extraConfigureArg>
 


### PR DESCRIPTION
fix android c++_shared not visible, because not linked
Made QuicChannelBootstrap constructor public for compatibility with Android API <= 24