### PR TITLE
Correctly map GENERIC to UNKNOWN when using BoringSSL

### DIFF
--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -33,7 +33,7 @@
 
 #define STATICALLY_CLASSNAME "io/netty/incubator/codec/quic/BoringSSLNativeStaticallyReferencedJniMethods"
 #define CLASSNAME "io/netty/incubator/codec/quic/BoringSSL"
-
+#define AUTH_UNKNOWN "UNKNOWN"
 #define ERR_LEN 256
 
 // For encoding of keys see BoringSSLSessionTicketCallback.setSessionTicketKeys(...)
@@ -359,11 +359,17 @@ enum ssl_verify_result_t quic_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_aler
     const SSL_CIPHER* cipher = SSL_get_current_cipher(ssl);
     if (cipher == NULL) {
         // No cipher available so return UNKNOWN.
-        authentication_method = "UNKNOWN";
+        authentication_method = AUTH_UNKNOWN;
     } else {
         authentication_method = SSL_CIPHER_get_kx_name(cipher);
         if (authentication_method == NULL) {
-            authentication_method = "UNKNOWN";
+            authentication_method = AUTH_UNKNOWN;
+        } else if (strcmp(authentication_method, "GENERIC") == 0) {
+            // Only TLS 1.3 will report the kx name as generic.
+            // Map this UNKNOWN, which will signal to Java to validate that
+            // the certificate's keyUsage has at least the digitalSignature bit set.
+            // (Per the SunJCE implementation).
+            authentication_method = AUTH_UNKNOWN;
         }
     }
 


### PR DESCRIPTION
Motivation:

BoringSSL returns GENERIC when using TLS1.3 but the JDK TrustManager implementation expect UNKNOWN. We need to map it the expected value as otherwise we will see failures.

Modifications:

Compare and adjust if needed

Result:

Correctly map auth method name