### PR TITLE
Skip androids build for now

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -174,6 +174,8 @@ jobs:
   build-android:
     runs-on: ubuntu-latest
     name: android
+    # Skip the build for now as cargo ndk segfaults and we need to figure out why.
+    if: false
     env:
       SDK_VER: "android-21"
       NDK_VER: "25.2.9519653"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -235,6 +235,8 @@ jobs:
   build-pr-android:
     runs-on: ubuntu-latest
     name: android
+    # Skip the build for now as cargo ndk segfaults and we need to figure out why.
+    if: false
     env:
       SDK_VER: "android-21"
       NDK_VER: "25.2.9519653"


### PR DESCRIPTION
Motivation:

The android builds fail atm as cargo ndk segfaults. We need to figure out why but until then let's disable the builds as otherwise PR verification will fail

Modifications:

Skip android builds

Result:

PR verification works again