### PR TITLE
Run tests on macos as well during PR build

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -215,7 +215,7 @@ jobs:
         run: brew bundle
 
       - name: Build project
-        run: ./mvnw -B -ntp --file pom.xml clean package -DskipTests=true
+        run: ./mvnw -B -ntp --file pom.xml clean package
 
       - name: Upload Test Results
         if: always()


### PR DESCRIPTION
Motivation:

We should run the tests on macos as well when validating PRs

Modifications:

Remove '-DskipTests=true'

Result:

Tests are executed on macos as well