### PR TITLE
Fix codec-native-quic Bundle-SymbolicNames

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -974,23 +974,10 @@
               </target>
             </configuration>
           </execution>
-          <!-- Copy the manifest file that we populated so far so we can use it as a starting point when generating the jars and adding more things to it. -->
-          <execution>
-            <id>copy-manifest</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <copy file="${project.build.outputDirectory}/META-INF/MANIFEST.MF" tofile="${project.build.directory}/manifests/MANIFEST-native.MF" />
-                <copy file="${project.build.outputDirectory}/META-INF/MANIFEST.MF" tofile="${project.build.directory}/manifests/MANIFEST.MF" />
-              </target>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
-      <!-- always produce osgi bundles -->
+
+      <!-- always produce osgi bundles: the first execution is for main artifact, the second for native library -->
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -1013,6 +1000,29 @@
                 <Quiche-Revision>${quicheCommitSha}</Quiche-Revision>
                 <Quiche-Branch>${quicheBranch}</Quiche-Branch>
               </instructions>
+            </configuration>
+          </execution>
+          <execution>
+            <id>native-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <supportedProjectTypes>
+                <supportedProjectType>jar</supportedProjectType>
+                <supportedProjectType>bundle</supportedProjectType>
+              </supportedProjectTypes>
+              <instructions>
+                <Fragment-Host>${fragmentHost}</Fragment-Host>
+                <Bundle-NativeCode>${bundleNativeCode}</Bundle-NativeCode>
+                <Bundle-SymbolicName>${maven-symbolicname}.${jni.classifier}</Bundle-SymbolicName>
+                <BoringSSL-Revision>${boringsslCommitSha}</BoringSSL-Revision>
+                <BoringSSL-Branch>${boringsslBranch}</BoringSSL-Branch>
+                <Quiche-Revision>${quicheCommitSha}</Quiche-Revision>
+                <Quiche-Branch>${quicheBranch}</Quiche-Branch>
+              </instructions>
+              <manifestLocation>${project.build.directory}/${jni.classifier}</manifestLocation>
             </configuration>
           </execution>
         </executions>
@@ -1105,7 +1115,7 @@
                   <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
                 </manifestEntries>
                 <index>true</index>
-                <manifestFile>${project.build.directory}/manifests/MANIFEST.MF</manifestFile>
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
               </archive>
             </configuration>
           </execution>
@@ -1123,11 +1133,9 @@
                 </manifest>
                 <manifestEntries>
                   <Automatic-Module-Name>${javaModuleNameWithClassifier}</Automatic-Module-Name>
-                  <Fragment-Host>${fragmentHost}</Fragment-Host>
-                  <Bundle-NativeCode>${bundleNativeCode}</Bundle-NativeCode>
                 </manifestEntries>
                 <index>true</index>
-                <manifestFile>${project.build.directory}/manifests/MANIFEST-native.MF</manifestFile>
+                <manifestFile>${project.build.directory}/${jni.classifier}/MANIFEST.MF</manifestFile>
               </archive>
               <classifier>${jni.classifier}</classifier>
             </configuration>


### PR DESCRIPTION
Motivation:

OSGi expects the combination of 'Bundle-SymblicName' and
'Bundle-Version' to be unique to a particular bundle, but we generate a
bundle for each jni.classifier.

Modification:

Run two generate-manifest executions, one for the main artifact and one
for native code. The second one overrides the usual Bundle-SymbolicName
by appending the jni.classifier (and includes the native-specific
headers).

Result:

Multiple CPU architectures can be supported by a single Apache Karaf
feature.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
